### PR TITLE
perf: optimize session list query with MongoDB projection and compound index

### DIFF
--- a/backend/app/application/services/agent_service.py
+++ b/backend/app/application/services/agent_service.py
@@ -1,7 +1,7 @@
 from typing import AsyncGenerator, Optional, List
 import logging
 from datetime import datetime
-from app.domain.models.session import Session
+from app.domain.models.session import Session, SessionSummary
 from app.domain.repositories.session_repository import SessionRepository
 
 from app.interfaces.schemas.session import ShellViewResponse
@@ -103,10 +103,10 @@ class AgentService:
             logger.error(f"Session {session_id} not found for user {user_id}")
         return session
     
-    async def get_all_sessions(self, user_id: str) -> List[Session]:
-        """Get all sessions for a specific user"""
+    async def get_all_sessions(self, user_id: str) -> List[SessionSummary]:
+        """Get all sessions for a specific user (lightweight summaries)"""
         logger.info(f"Getting all sessions for user {user_id}")
-        return await self._session_repository.find_by_user_id(user_id)
+        return await self._session_repository.find_summaries_by_user_id(user_id)
 
     async def delete_session(self, session_id: str, user_id: str) -> None:
         """Delete a session, ensuring it belongs to the user"""

--- a/backend/app/domain/models/session.py
+++ b/backend/app/domain/models/session.py
@@ -16,6 +16,18 @@ class SessionStatus(str, Enum):
     COMPLETED = "completed"
 
 
+class SessionSummary(BaseModel):
+    """Lightweight session model for list views (excludes heavy events/files)"""
+    id: str
+    user_id: str
+    title: Optional[str] = None
+    unread_message_count: int = 0
+    latest_message: Optional[str] = None
+    latest_message_at: Optional[datetime] = None
+    status: SessionStatus = SessionStatus.PENDING
+    is_shared: bool = False
+
+
 class Session(BaseModel):
     """Session model"""
     id: str = Field(default_factory=lambda: uuid.uuid4().hex[:16])

--- a/backend/app/domain/repositories/session_repository.py
+++ b/backend/app/domain/repositories/session_repository.py
@@ -1,6 +1,6 @@
 from typing import Optional, Protocol, List
 from datetime import datetime
-from app.domain.models.session import Session, SessionStatus
+from app.domain.models.session import Session, SessionStatus, SessionSummary
 from app.domain.models.file import FileInfo
 from app.domain.models.event import BaseEvent
 
@@ -17,6 +17,10 @@ class SessionRepository(Protocol):
     
     async def find_by_user_id(self, user_id: str) -> List[Session]:
         """Find all sessions for a specific user"""
+        ...
+    
+    async def find_summaries_by_user_id(self, user_id: str) -> List[SessionSummary]:
+        """Find lightweight session summaries for a user (excludes events/files)"""
         ...
     
     async def find_by_id_and_user_id(self, session_id: str, user_id: str) -> Optional[Session]:

--- a/backend/app/infrastructure/models/documents.py
+++ b/backend/app/infrastructure/models/documents.py
@@ -9,7 +9,7 @@ from app.domain.models.session import Session, SessionStatus
 from app.domain.models.file import FileInfo
 from app.domain.models.user import User, UserRole
 from app.domain.models.claw import Claw, ClawStatus, ClawMessage
-from pymongo import IndexModel, ASCENDING
+from pymongo import IndexModel, ASCENDING, DESCENDING
 
 T = TypeVar('T', bound=BaseModel)
 
@@ -102,7 +102,11 @@ class SessionDocument(BaseDocument[Session], id_field="session_id", domain_model
         name = "sessions"
         indexes = [
             "session_id",
-            "user_id",  # Add index for user_id for efficient queries
+            "user_id",
+            IndexModel(
+                [("user_id", ASCENDING), ("latest_message_at", DESCENDING)],
+                name="user_id_latest_message_at",
+            ),
         ]
 
 

--- a/backend/app/infrastructure/repositories/mongo_session_repository.py
+++ b/backend/app/infrastructure/repositories/mongo_session_repository.py
@@ -55,7 +55,7 @@ class MongoSessionRepository(SessionRepository):
 
     async def find_summaries_by_user_id(self, user_id: str) -> List[SessionSummary]:
         """Find lightweight session summaries for a user (excludes events/files)"""
-        collection = SessionDocument.get_motor_collection()
+        collection = SessionDocument.get_pymongo_collection()
         cursor = collection.find(
             {"user_id": user_id},
             SESSION_LIST_PROJECTION,

--- a/backend/app/infrastructure/repositories/mongo_session_repository.py
+++ b/backend/app/infrastructure/repositories/mongo_session_repository.py
@@ -1,6 +1,6 @@
 from typing import Optional, List
 from datetime import datetime, UTC
-from app.domain.models.session import Session, SessionStatus
+from app.domain.models.session import Session, SessionStatus, SessionSummary
 from app.domain.models.file import FileInfo
 from app.domain.repositories.session_repository import SessionRepository
 from app.domain.models.event import BaseEvent
@@ -8,6 +8,17 @@ from app.infrastructure.models.documents import SessionDocument
 import logging
 
 logger = logging.getLogger(__name__)
+
+SESSION_LIST_PROJECTION = {
+    "session_id": 1,
+    "user_id": 1,
+    "title": 1,
+    "unread_message_count": 1,
+    "latest_message": 1,
+    "latest_message_at": 1,
+    "status": 1,
+    "is_shared": 1,
+}
 
 class MongoSessionRepository(SessionRepository):
     """MongoDB implementation of SessionRepository"""
@@ -41,6 +52,27 @@ class MongoSessionRepository(SessionRepository):
             SessionDocument.user_id == user_id
         ).sort("-latest_message_at").to_list()
         return [mongo_session.to_domain() for mongo_session in mongo_sessions]
+
+    async def find_summaries_by_user_id(self, user_id: str) -> List[SessionSummary]:
+        """Find lightweight session summaries for a user (excludes events/files)"""
+        collection = SessionDocument.get_motor_collection()
+        cursor = collection.find(
+            {"user_id": user_id},
+            SESSION_LIST_PROJECTION,
+        ).sort("latest_message_at", -1)
+        summaries = []
+        async for doc in cursor:
+            summaries.append(SessionSummary(
+                id=doc["session_id"],
+                user_id=doc["user_id"],
+                title=doc.get("title"),
+                unread_message_count=doc.get("unread_message_count", 0),
+                latest_message=doc.get("latest_message"),
+                latest_message_at=doc.get("latest_message_at"),
+                status=doc.get("status", SessionStatus.PENDING),
+                is_shared=doc.get("is_shared", False),
+            ))
+        return summaries
     
     async def find_by_id_and_user_id(self, session_id: str, user_id: str) -> Optional[Session]:
         """Find a session by ID and user ID (for authorization)"""

--- a/backend/app/interfaces/api/session_routes.py
+++ b/backend/app/interfaces/api/session_routes.py
@@ -90,17 +90,17 @@ async def get_all_sessions(
     current_user: User = Depends(get_current_user),
     agent_service: AgentService = Depends(get_agent_service)
 ) -> APIResponse[ListSessionResponse]:
-    sessions = await agent_service.get_all_sessions(current_user.id)
+    summaries = await agent_service.get_all_sessions(current_user.id)
     session_items = [
         ListSessionItem(
-            session_id=session.id,
-            title=session.title,
-            status=session.status,
-            unread_message_count=session.unread_message_count,
-            latest_message=session.latest_message,
-            latest_message_at=int(session.latest_message_at.timestamp()) if session.latest_message_at else None,
-            is_shared=session.is_shared
-        ) for session in sessions
+            session_id=s.id,
+            title=s.title,
+            status=s.status,
+            unread_message_count=s.unread_message_count,
+            latest_message=s.latest_message,
+            latest_message_at=int(s.latest_message_at.timestamp()) if s.latest_message_at else None,
+            is_shared=s.is_shared
+        ) for s in summaries
     ]
     return APIResponse.success(ListSessionResponse(sessions=session_items))
 
@@ -111,17 +111,17 @@ async def stream_sessions(
 ) -> EventSourceResponse:
     async def event_generator() -> AsyncGenerator[ServerSentEvent, None]:
         while True:
-            sessions = await agent_service.get_all_sessions(current_user.id)
+            summaries = await agent_service.get_all_sessions(current_user.id)
             session_items = [
                 ListSessionItem(
-                    session_id=session.id,
-                    title=session.title,
-                    status=session.status,
-                    unread_message_count=session.unread_message_count,
-                    latest_message=session.latest_message,
-                    latest_message_at=int(session.latest_message_at.timestamp()) if session.latest_message_at else None,
-                    is_shared=session.is_shared
-                ) for session in sessions
+                    session_id=s.id,
+                    title=s.title,
+                    status=s.status,
+                    unread_message_count=s.unread_message_count,
+                    latest_message=s.latest_message,
+                    latest_message_at=int(s.latest_message_at.timestamp()) if s.latest_message_at else None,
+                    is_shared=s.is_shared
+                ) for s in summaries
             ]
             yield ServerSentEvent(
                 event="sessions",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

历史会话列表加载缓慢（约 5 秒），原因是 `GET /api/v1/sessions` 和 SSE `POST /api/v1/sessions` 端点从 MongoDB 加载了**完整的 `SessionDocument`**，包括体积庞大的 `events` 和 `files` 数组字段，而列表视图仅需要 8 个轻量级元数据字段。

## Root Cause

`find_by_user_id()` 使用 Beanie 的 `find().to_list()` 获取完整文档再通过 `to_domain()` 转换为 `Session` 对象。每个会话的 `events` 可能包含大量事件记录，`files` 也可能包含大量文件信息，导致：
1. **MongoDB 传输大量不必要数据**到后端
2. **Python 端反序列化**所有事件和文件数据消耗 CPU
3. **缺少复合索引**，排序操作在内存中完成

## Solution

### 1. MongoDB 投影查询（Projection）
使用 Motor 原生 `collection.find()` + 投影，仅获取列表所需的 8 个字段，排除 `events` 和 `files`：

```python
SESSION_LIST_PROJECTION = {
    "session_id": 1, "user_id": 1, "title": 1,
    "unread_message_count": 1, "latest_message": 1,
    "latest_message_at": 1, "status": 1, "is_shared": 1,
}
```

### 2. 轻量级领域模型 `SessionSummary`
新增 `SessionSummary` 模型，不包含 `events` 和 `files`，避免不必要的反序列化开销。

### 3. 复合索引
为 `SessionDocument` 添加 `(user_id, latest_message_at DESC)` 复合索引，使 MongoDB 可以通过索引同时完成过滤和排序，避免内存排序。

## Demo

[session_list_fast_loading_demo.mp4](https://cursor.com/agents/bc-984e811a-ec34-4aff-a941-fedea1c25937/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsession_list_fast_loading_demo.mp4)

会话列表加载即时完成，无可感知延迟。

[Session list loaded quickly](https://cursor.com/agents/bc-984e811a-ec34-4aff-a941-fedea1c25937/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsession_list_loaded.webp)

## Changes

| File | Change |
|------|--------|
| `backend/app/domain/models/session.py` | 新增 `SessionSummary` 轻量模型 |
| `backend/app/domain/repositories/session_repository.py` | 新增 `find_summaries_by_user_id` 协议方法 |
| `backend/app/infrastructure/repositories/mongo_session_repository.py` | 实现投影查询 `find_summaries_by_user_id` |
| `backend/app/infrastructure/models/documents.py` | 添加 `(user_id, latest_message_at)` 复合索引 |
| `backend/app/application/services/agent_service.py` | `get_all_sessions` 返回 `SessionSummary` |
| `backend/app/interfaces/api/session_routes.py` | GET 和 SSE 端点使用新的 summary 查询 |

## Testing

- ✅ 所有 Python 模块导入成功
- ✅ `SessionSummary` 模型验证正确
- ✅ 投影字段与列表 API 所需字段一致
- ✅ 前端 build 通过（API 响应格式不变）
- ✅ API 响应时间 ~9ms（之前约 5 秒）
- ✅ UI 手动测试：会话列表即时加载，导航正常

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-984e811a-ec34-4aff-a941-fedea1c25937"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-984e811a-ec34-4aff-a941-fedea1c25937"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

