### PR TITLE
feat(search): 新增 Serper.dev 与通用自定义搜索 API 提供商

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -38,11 +38,14 @@ SANDBOX_NETWORK=manus-network
 #BROWSER_ENGINE=browser_use
 
 # Search engine configuration
-# Options: baidu, baidu_web, google, bing, bing_web, tavily
-# baidu: uses the Baidu Qianfan AI Search API (requires BAIDU_SEARCH_API_KEY)
+# Options: baidu, baidu_web, google, bing, bing_web, tavily, serper, custom
+# baidu:    uses the Baidu Qianfan AI Search API (requires BAIDU_SEARCH_API_KEY)
 # baidu_web: scrapes Baidu search results with browser impersonation (no API key needed)
-# bing: uses the official Bing Web Search API (requires BING_SEARCH_API_KEY)
+# bing:     uses the official Bing Web Search API (requires BING_SEARCH_API_KEY)
 # bing_web: scrapes Bing search results directly (no API key needed)
+# tavily:   uses the Tavily Search API (requires TAVILY_API_KEY)
+# serper:   uses the Serper.dev Google Search API (requires SERPER_API_KEY)
+# custom:   calls any third-party search REST API via SEARCH_API_URL + SEARCH_API_KEY
 SEARCH_PROVIDER=bing_web
 
 # Baidu search configuration, only used when SEARCH_PROVIDER=baidu
@@ -58,7 +61,54 @@ SEARCH_PROVIDER=bing_web
 #GOOGLE_SEARCH_ENGINE_ID=
 
 # Tavily search configuration, only used when SEARCH_PROVIDER=tavily
+# Get your API key from https://tavily.com
 #TAVILY_API_KEY=
+
+# Serper.dev search configuration, only used when SEARCH_PROVIDER=serper
+# Returns reliable Google results. Get your API key from https://serper.dev
+#SERPER_API_KEY=
+
+# Custom search API configuration, only used when SEARCH_PROVIDER=custom
+# Allows integration with any third-party search REST API.
+#
+# Minimal setup (POST + Bearer token, e.g. a custom internal API):
+#   SEARCH_API_URL=https://your-search-api.example.com/search
+#   SEARCH_API_KEY=your-api-key
+#
+# Serper.dev via custom provider:
+#   SEARCH_API_URL=https://google.serper.dev/search
+#   SEARCH_API_KEY=your-serper-key
+#   SEARCH_API_KEY_HEADER=X-API-KEY
+#   SEARCH_API_KEY_HEADER_PREFIX=
+#   SEARCH_RESULT_FIELD=organic
+#
+# SerpAPI via custom provider:
+#   SEARCH_API_URL=https://serpapi.com/search
+#   SEARCH_API_KEY=your-serpapi-key
+#   SEARCH_API_KEY_PARAM=api_key
+#   SEARCH_API_METHOD=GET
+#   SEARCH_RESULT_FIELD=organic_results
+#
+# Brave Search API via custom provider:
+#   SEARCH_API_URL=https://api.search.brave.com/res/v1/web/search
+#   SEARCH_API_KEY=your-brave-key
+#   SEARCH_API_KEY_HEADER=X-Subscription-Token
+#   SEARCH_API_KEY_HEADER_PREFIX=
+#   SEARCH_API_METHOD=GET
+#   SEARCH_RESULT_FIELD=web.results
+#   SEARCH_SNIPPET_FIELD=description
+#
+#SEARCH_API_URL=
+#SEARCH_API_KEY=
+#SEARCH_API_KEY_HEADER=Authorization
+#SEARCH_API_KEY_HEADER_PREFIX=Bearer
+#SEARCH_API_KEY_PARAM=
+#SEARCH_API_METHOD=POST
+#SEARCH_QUERY_FIELD=q
+#SEARCH_RESULT_FIELD=results
+#SEARCH_TITLE_FIELD=title
+#SEARCH_LINK_FIELD=link
+#SEARCH_SNIPPET_FIELD=snippet
 
 # Google Analytics configuration
 # Set your Google Analytics Measurement ID (e.g. G-XXXXXXXXXX)

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -60,12 +60,26 @@ class Settings(BaseSettings):
     browser_engine: str = "browser_use"  # "playwright" or "browser_use"
     
     # Search engine configuration
-    search_provider: str | None = "bing_web"  # "baidu", "baidu_web", "google", "bing", "bing_web", "tavily"
+    search_provider: str | None = "bing_web"  # "baidu", "baidu_web", "google", "bing", "bing_web", "tavily", "serper", "custom"
     baidu_search_api_key: str | None = None
     bing_search_api_key: str | None = None
     google_search_api_key: str | None = None
     google_search_engine_id: str | None = None
     tavily_api_key: str | None = None
+    # Serper.dev search configuration (SEARCH_PROVIDER=serper)
+    serper_api_key: str | None = None
+    # Custom search API configuration (SEARCH_PROVIDER=custom)
+    search_api_url: str | None = None
+    search_api_key: str | None = None
+    search_api_key_header: str = "Authorization"
+    search_api_key_header_prefix: str = "Bearer "
+    search_api_key_param: str = ""
+    search_api_method: str = "POST"
+    search_query_field: str = "q"
+    search_result_field: str = "results"
+    search_title_field: str = "title"
+    search_link_field: str = "link"
+    search_snippet_field: str = "snippet"
     
     # Google Analytics configuration
     google_analytics_id: str | None = None

--- a/backend/app/infrastructure/external/search/__init__.py
+++ b/backend/app/infrastructure/external/search/__init__.py
@@ -16,7 +16,9 @@ def get_search_engine() -> Optional[SearchEngine]:
     from app.infrastructure.external.search.bing_search import BingSearchEngine
     from app.infrastructure.external.search.bing_web_search import BingWebSearchEngine
     from app.infrastructure.external.search.tavily_search import TavilySearchEngine
-    
+    from app.infrastructure.external.search.serper_search import SerperSearchEngine
+    from app.infrastructure.external.search.custom_search import CustomSearchEngine
+
     settings = get_settings()
     if settings.search_provider == "google":
         if settings.google_search_api_key and settings.google_search_engine_id:
@@ -50,8 +52,32 @@ def get_search_engine() -> Optional[SearchEngine]:
             logger.info("Initializing Tavily Search Engine")
             return TavilySearchEngine(api_key=settings.tavily_api_key)
         else:
-            logger.warning("Tavily Search Engine not initialized: missing API key")
+            logger.warning("Tavily Search Engine not initialized: missing API key (TAVILY_API_KEY)")
+    elif settings.search_provider == "serper":
+        if settings.serper_api_key:
+            logger.info("Initializing Serper Search Engine")
+            return SerperSearchEngine(api_key=settings.serper_api_key)
+        else:
+            logger.warning("Serper Search Engine not initialized: missing API key (SERPER_API_KEY)")
+    elif settings.search_provider == "custom":
+        if settings.search_api_url:
+            logger.info(f"Initializing Custom Search Engine (url={settings.search_api_url})")
+            return CustomSearchEngine(
+                api_url=settings.search_api_url,
+                api_key=settings.search_api_key or "",
+                api_key_header=settings.search_api_key_header,
+                api_key_header_prefix=settings.search_api_key_header_prefix,
+                api_key_param=settings.search_api_key_param,
+                method=settings.search_api_method,
+                query_field=settings.search_query_field,
+                result_field=settings.search_result_field,
+                title_field=settings.search_title_field,
+                link_field=settings.search_link_field,
+                snippet_field=settings.search_snippet_field,
+            )
+        else:
+            logger.warning("Custom Search Engine not initialized: missing SEARCH_API_URL")
     else:
         logger.warning(f"Unknown search provider: {settings.search_provider}")
-    
-    return None 
+
+    return None

--- a/backend/app/infrastructure/external/search/custom_search.py
+++ b/backend/app/infrastructure/external/search/custom_search.py
@@ -1,0 +1,246 @@
+"""Generic custom HTTP search provider.
+
+Allows integrating any third-party search API by configuring the endpoint,
+authentication, and field-mapping via environment variables.
+
+Supported request modes
+-----------------------
+- POST (default): sends a JSON body with the query field
+- GET: sends the query as a URL query parameter
+
+Authentication modes
+--------------------
+- Header-based (default): adds ``{SEARCH_API_KEY_HEADER}: {prefix} {key}`` to the
+  request.  Set ``SEARCH_API_KEY_HEADER=X-API-KEY`` and leave the prefix empty for
+  services like Serper.dev / Brave.
+- Query-param: pass the key as a URL parameter by setting
+  ``SEARCH_API_KEY_PARAM=api_key`` (used e.g. by SerpAPI).
+
+Response field mapping
+----------------------
+The provider expects the API to return JSON.  Configure the field names to
+locate the results array and the title/link/snippet inside each item.
+
+Example – Serper.dev (POST)
+    SEARCH_PROVIDER=custom
+    SEARCH_API_URL=https://google.serper.dev/search
+    SEARCH_API_KEY=<your-key>
+    SEARCH_API_KEY_HEADER=X-API-KEY
+    SEARCH_RESULT_FIELD=organic
+
+Example – SerpAPI (GET)
+    SEARCH_PROVIDER=custom
+    SEARCH_API_URL=https://serpapi.com/search
+    SEARCH_API_KEY=<your-key>
+    SEARCH_API_KEY_PARAM=api_key
+    SEARCH_API_METHOD=GET
+    SEARCH_QUERY_FIELD=q
+    SEARCH_RESULT_FIELD=organic_results
+
+Example – Brave Search API (GET)
+    SEARCH_PROVIDER=custom
+    SEARCH_API_URL=https://api.search.brave.com/res/v1/web/search
+    SEARCH_API_KEY=<your-key>
+    SEARCH_API_KEY_HEADER=X-Subscription-Token
+    SEARCH_API_KEY_HEADER_PREFIX=
+    SEARCH_API_METHOD=GET
+    SEARCH_QUERY_FIELD=q
+    SEARCH_RESULT_FIELD=web.results
+    SEARCH_SNIPPET_FIELD=description
+"""
+
+from typing import Optional, Any
+import logging
+
+import httpx
+
+from app.domain.external.search import SearchEngine
+from app.domain.models.search import SearchResultItem, SearchResults
+from app.domain.models.tool_result import ToolResult
+
+logger = logging.getLogger(__name__)
+
+
+def _get_nested(data: dict, path: str) -> Any:
+    """Retrieve a value from a nested dict using dot-separated path notation.
+
+    Example: _get_nested({"web": {"results": [...]}}, "web.results") → [...]
+    """
+    parts = path.split(".")
+    current: Any = data
+    for part in parts:
+        if not isinstance(current, dict):
+            return None
+        current = current.get(part)
+    return current
+
+
+class CustomSearchEngine(SearchEngine):
+    """Generic search engine that calls a user-configured HTTP endpoint.
+
+    All parameters are provided at construction time (sourced from env-vars via
+    the factory function in __init__.py).
+
+    Args:
+        api_url: Full URL of the search endpoint.
+        api_key: API key value.
+        api_key_header: HTTP header name used to pass the key (e.g. ``X-API-KEY``
+            or ``Authorization``).  Set to empty string to skip header auth.
+        api_key_header_prefix: Optional prefix placed before the key value in the
+            header (e.g. ``Bearer ``).  Include trailing space when needed.
+        api_key_param: URL query-parameter name to send the key as (alternative to
+            header auth).  Leave empty to use header auth.
+        method: HTTP method – ``POST`` (default) or ``GET``.
+        query_field: Field name for the search query in the request body / params.
+        result_field: Dot-path to the results array in the JSON response.
+        title_field: Field name for the result title.
+        link_field: Field name for the result URL.
+        snippet_field: Field name for the result snippet / description.
+        extra_params: Additional fixed parameters to include in every request.
+    """
+
+    def __init__(
+        self,
+        api_url: str,
+        api_key: str = "",
+        api_key_header: str = "Authorization",
+        api_key_header_prefix: str = "Bearer ",
+        api_key_param: str = "",
+        method: str = "POST",
+        query_field: str = "q",
+        result_field: str = "results",
+        title_field: str = "title",
+        link_field: str = "link",
+        snippet_field: str = "snippet",
+        extra_params: Optional[dict] = None,
+    ):
+        self.api_url = api_url
+        self.api_key = api_key
+        self.api_key_header = api_key_header
+        self.api_key_header_prefix = api_key_header_prefix
+        self.api_key_param = api_key_param
+        self.method = method.upper()
+        self.query_field = query_field
+        self.result_field = result_field
+        self.title_field = title_field
+        self.link_field = link_field
+        self.snippet_field = snippet_field
+        self.extra_params = extra_params or {}
+
+    def _build_headers(self) -> dict:
+        headers: dict = {"Content-Type": "application/json"}
+        if self.api_key and self.api_key_header:
+            headers[self.api_key_header] = f"{self.api_key_header_prefix}{self.api_key}"
+        return headers
+
+    def _build_params(self, query: str) -> dict:
+        params: dict = {self.query_field: query, **self.extra_params}
+        if self.api_key and self.api_key_param:
+            params[self.api_key_param] = self.api_key
+        return params
+
+    async def search(
+        self,
+        query: str,
+        date_range: Optional[str] = None,
+    ) -> ToolResult[SearchResults]:
+        """Search using the configured custom API endpoint.
+
+        Args:
+            query: Search query
+            date_range: Optional time range (ignored unless the API supports it
+                via extra_params or a subclass overrides this method)
+
+        Returns:
+            Search results
+        """
+        headers = self._build_headers()
+        params = self._build_params(query)
+
+        try:
+            async with httpx.AsyncClient(timeout=30) as client:
+                if self.method == "GET":
+                    response = await client.get(
+                        self.api_url, params=params, headers=headers
+                    )
+                else:
+                    response = await client.post(
+                        self.api_url, json=params, headers=headers
+                    )
+                response.raise_for_status()
+                data = response.json()
+
+            raw_results = _get_nested(data, self.result_field)
+            if not isinstance(raw_results, list):
+                logger.warning(
+                    f"Custom search: expected list at field '{self.result_field}', "
+                    f"got {type(raw_results).__name__}. Response keys: {list(data.keys()) if isinstance(data, dict) else 'N/A'}"
+                )
+                raw_results = []
+
+            search_results: list[SearchResultItem] = []
+            for item in raw_results:
+                if not isinstance(item, dict):
+                    continue
+                title = str(item.get(self.title_field, "")).strip()
+                link = str(item.get(self.link_field, "") or item.get("url", "")).strip()
+                snippet = str(item.get(self.snippet_field, "")).strip()
+                if title and link:
+                    search_results.append(
+                        SearchResultItem(title=title, link=link, snippet=snippet)
+                    )
+
+            results = SearchResults(
+                query=query,
+                date_range=date_range,
+                total_results=len(search_results),
+                results=search_results,
+            )
+            return ToolResult(success=True, data=results)
+
+        except Exception as e:
+            logger.error(f"Custom Search failed (url={self.api_url}): {e}")
+            error_results = SearchResults(
+                query=query,
+                date_range=date_range,
+                total_results=0,
+                results=[],
+            )
+            return ToolResult(
+                success=False,
+                message=f"Custom Search failed: {e}",
+                data=error_results,
+            )
+
+
+if __name__ == "__main__":
+    import asyncio
+    import os
+
+    async def test():
+        engine = CustomSearchEngine(
+            api_url=os.environ.get("SEARCH_API_URL", ""),
+            api_key=os.environ.get("SEARCH_API_KEY", ""),
+            api_key_header=os.environ.get("SEARCH_API_KEY_HEADER", "Authorization"),
+            api_key_header_prefix=os.environ.get("SEARCH_API_KEY_HEADER_PREFIX", "Bearer "),
+            api_key_param=os.environ.get("SEARCH_API_KEY_PARAM", ""),
+            method=os.environ.get("SEARCH_API_METHOD", "POST"),
+            query_field=os.environ.get("SEARCH_QUERY_FIELD", "q"),
+            result_field=os.environ.get("SEARCH_RESULT_FIELD", "results"),
+            title_field=os.environ.get("SEARCH_TITLE_FIELD", "title"),
+            link_field=os.environ.get("SEARCH_LINK_FIELD", "link"),
+            snippet_field=os.environ.get("SEARCH_SNIPPET_FIELD", "snippet"),
+        )
+        result = await engine.search("Python programming")
+
+        if result.success:
+            print(f"Found {len(result.data.results)} results")
+            for i, item in enumerate(result.data.results[:5]):
+                print(f"{i + 1}. {item.title}")
+                print(f"   {item.link}")
+                print(f"   {item.snippet[:100]}")
+                print()
+        else:
+            print(f"Search failed: {result.message}")
+
+    asyncio.run(test())

--- a/backend/app/infrastructure/external/search/serper_search.py
+++ b/backend/app/infrastructure/external/search/serper_search.py
@@ -1,0 +1,125 @@
+from typing import Optional
+import logging
+
+import httpx
+
+from app.domain.external.search import SearchEngine
+from app.domain.models.search import SearchResultItem, SearchResults
+from app.domain.models.tool_result import ToolResult
+
+logger = logging.getLogger(__name__)
+
+# Maps generic date_range values to Serper tbs (time-based search) parameters
+_DATE_RANGE_MAP = {
+    "past_hour": "qdr:h",
+    "past_day": "qdr:d",
+    "past_week": "qdr:w",
+    "past_month": "qdr:m",
+    "past_year": "qdr:y",
+}
+
+
+class SerperSearchEngine(SearchEngine):
+    """Search engine implementation using the Serper.dev Google Search API.
+
+    Serper.dev provides reliable Google search results via a simple REST API.
+    Sign up at https://serper.dev to get an API key (free tier available).
+    """
+
+    def __init__(self, api_key: str):
+        self.api_key = api_key
+        self.base_url = "https://google.serper.dev/search"
+
+    async def search(
+        self,
+        query: str,
+        date_range: Optional[str] = None,
+    ) -> ToolResult[SearchResults]:
+        """Search web pages using Serper.dev Google Search API.
+
+        Args:
+            query: Search query
+            date_range: Optional time range filter (past_hour/past_day/past_week/past_month/past_year/all)
+
+        Returns:
+            Search results
+        """
+        payload: dict = {
+            "q": query,
+            "num": 10,
+        }
+
+        if date_range and date_range != "all":
+            tbs = _DATE_RANGE_MAP.get(date_range)
+            if tbs:
+                payload["tbs"] = tbs
+
+        headers = {
+            "X-API-KEY": self.api_key,
+            "Content-Type": "application/json",
+        }
+
+        try:
+            async with httpx.AsyncClient(timeout=30) as client:
+                response = await client.post(
+                    self.base_url,
+                    json=payload,
+                    headers=headers,
+                )
+                response.raise_for_status()
+                data = response.json()
+
+            search_results: list[SearchResultItem] = []
+
+            for item in data.get("organic", []):
+                title = item.get("title", "")
+                link = item.get("link", "")
+                snippet = item.get("snippet", "")
+                if title and link:
+                    search_results.append(
+                        SearchResultItem(title=title, link=link, snippet=snippet)
+                    )
+
+            results = SearchResults(
+                query=query,
+                date_range=date_range,
+                total_results=len(search_results),
+                results=search_results,
+            )
+            return ToolResult(success=True, data=results)
+
+        except Exception as e:
+            logger.error(f"Serper Search failed: {e}")
+            error_results = SearchResults(
+                query=query,
+                date_range=date_range,
+                total_results=0,
+                results=[],
+            )
+            return ToolResult(
+                success=False,
+                message=f"Serper Search failed: {e}",
+                data=error_results,
+            )
+
+
+if __name__ == "__main__":
+    import asyncio
+    import os
+
+    async def test():
+        key = os.environ.get("SERPER_API_KEY", "")
+        engine = SerperSearchEngine(api_key=key)
+        result = await engine.search("Python programming")
+
+        if result.success:
+            print(f"Found {len(result.data.results)} results")
+            for i, item in enumerate(result.data.results[:5]):
+                print(f"{i + 1}. {item.title}")
+                print(f"   {item.link}")
+                print(f"   {item.snippet[:100]}")
+                print()
+        else:
+            print(f"Search failed: {result.message}")
+
+    asyncio.run(test())

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -72,7 +72,7 @@
 
 | 配置项 | 默认值 | 是否必需 | 说明 |
 |--------|--------|----------|------|
-| `SEARCH_PROVIDER` | `bing_web` | 否 | 搜索引擎提供商 (`baidu`、`baidu_web`、`google`、`bing`、`bing_web` 或 `tavily`) |
+| `SEARCH_PROVIDER` | `bing_web` | 否 | 搜索引擎提供商（`baidu`、`baidu_web`、`google`、`bing`、`bing_web`、`tavily`、`serper` 或 `custom`） |
 
 #### 百度搜索配置
 
@@ -109,7 +109,67 @@
 
 | 配置项 | 默认值 | 是否必需 | 说明 |
 |--------|--------|----------|------|
-| `TAVILY_API_KEY` | - | 是 | Tavily 搜索 API 密钥 |
+| `TAVILY_API_KEY` | - | 是 | Tavily 搜索 API 密钥，从 [tavily.com](https://tavily.com) 获取 |
+
+#### Serper.dev 搜索配置
+
+仅当 `SEARCH_PROVIDER=serper` 时使用。Serper.dev 返回可靠的 Google 搜索结果，推荐作为默认搜索提供商：
+
+| 配置项 | 默认值 | 是否必需 | 说明 |
+|--------|--------|----------|------|
+| `SERPER_API_KEY` | - | 是 | Serper.dev API 密钥，从 [serper.dev](https://serper.dev) 获取（提供免费额度） |
+
+#### 自定义搜索 API 配置
+
+仅当 `SEARCH_PROVIDER=custom` 时使用。可对接任意第三方搜索 REST API，只需配置接口地址、密钥和字段映射即可：
+
+| 配置项 | 默认值 | 是否必需 | 说明 |
+|--------|--------|----------|------|
+| `SEARCH_API_URL` | - | 是 | 搜索接口的完整 URL |
+| `SEARCH_API_KEY` | - | 否 | 接口 API 密钥 |
+| `SEARCH_API_KEY_HEADER` | `Authorization` | 否 | 传递密钥的 HTTP Header 名称（如 `X-API-KEY`） |
+| `SEARCH_API_KEY_HEADER_PREFIX` | `Bearer ` | 否 | Header 值的前缀（含空格时请保留，如 `Bearer `；若 Header 直接是 key 则设为空） |
+| `SEARCH_API_KEY_PARAM` | - | 否 | 将密钥作为 URL 查询参数传递时的参数名（设置后优先于 Header 方式） |
+| `SEARCH_API_METHOD` | `POST` | 否 | HTTP 请求方式（`POST` 或 `GET`） |
+| `SEARCH_QUERY_FIELD` | `q` | 否 | 请求体 / 查询参数中搜索词的字段名 |
+| `SEARCH_RESULT_FIELD` | `results` | 否 | 响应 JSON 中结果数组的字段路径（支持点分隔的嵌套路径，如 `web.results`） |
+| `SEARCH_TITLE_FIELD` | `title` | 否 | 每条结果中标题的字段名 |
+| `SEARCH_LINK_FIELD` | `link` | 否 | 每条结果中 URL 的字段名 |
+| `SEARCH_SNIPPET_FIELD` | `snippet` | 否 | 每条结果中摘要的字段名 |
+
+**典型对接示例：**
+
+- **Serper.dev（POST）**
+  ```env
+  SEARCH_PROVIDER=custom
+  SEARCH_API_URL=https://google.serper.dev/search
+  SEARCH_API_KEY=your-serper-key
+  SEARCH_API_KEY_HEADER=X-API-KEY
+  SEARCH_API_KEY_HEADER_PREFIX=
+  SEARCH_RESULT_FIELD=organic
+  ```
+
+- **SerpAPI（GET）**
+  ```env
+  SEARCH_PROVIDER=custom
+  SEARCH_API_URL=https://serpapi.com/search
+  SEARCH_API_KEY=your-serpapi-key
+  SEARCH_API_KEY_PARAM=api_key
+  SEARCH_API_METHOD=GET
+  SEARCH_RESULT_FIELD=organic_results
+  ```
+
+- **Brave Search API（GET）**
+  ```env
+  SEARCH_PROVIDER=custom
+  SEARCH_API_URL=https://api.search.brave.com/res/v1/web/search
+  SEARCH_API_KEY=your-brave-key
+  SEARCH_API_KEY_HEADER=X-Subscription-Token
+  SEARCH_API_KEY_HEADER_PREFIX=
+  SEARCH_API_METHOD=GET
+  SEARCH_RESULT_FIELD=web.results
+  SEARCH_SNIPPET_FIELD=description
+  ```
 
 ### 认证配置
 

--- a/docs/en/configuration.md
+++ b/docs/en/configuration.md
@@ -72,7 +72,7 @@
 
 | Configuration | Default Value | Required | Description |
 |---------------|---------------|----------|-------------|
-| `SEARCH_PROVIDER` | `bing_web` | No | Search engine provider (`baidu`, `baidu_web`, `google`, `bing`, `bing_web`, or `tavily`) |
+| `SEARCH_PROVIDER` | `bing_web` | No | Search engine provider (`baidu`, `baidu_web`, `google`, `bing`, `bing_web`, `tavily`, `serper`, or `custom`) |
 
 #### Baidu Search Configuration
 
@@ -109,7 +109,67 @@ Used only when `SEARCH_PROVIDER=tavily`:
 
 | Configuration | Default Value | Required | Description |
 |---------------|---------------|----------|-------------|
-| `TAVILY_API_KEY` | - | Yes | Tavily Search API key |
+| `TAVILY_API_KEY` | - | Yes | Tavily Search API key, get from [tavily.com](https://tavily.com) |
+
+#### Serper.dev Search Configuration
+
+Used only when `SEARCH_PROVIDER=serper`. Serper.dev delivers reliable Google search results and is recommended as the default provider:
+
+| Configuration | Default Value | Required | Description |
+|---------------|---------------|----------|-------------|
+| `SERPER_API_KEY` | - | Yes | Serper.dev API key, get from [serper.dev](https://serper.dev) (free tier available) |
+
+#### Custom Search API Configuration
+
+Used only when `SEARCH_PROVIDER=custom`. Integrate any third-party search REST API by configuring the endpoint, credentials, and field mapping:
+
+| Configuration | Default Value | Required | Description |
+|---------------|---------------|----------|-------------|
+| `SEARCH_API_URL` | - | Yes | Full URL of the search endpoint |
+| `SEARCH_API_KEY` | - | No | API key for the endpoint |
+| `SEARCH_API_KEY_HEADER` | `Authorization` | No | HTTP header name used to send the key (e.g. `X-API-KEY`) |
+| `SEARCH_API_KEY_HEADER_PREFIX` | `Bearer ` | No | Prefix placed before the key value in the header (include trailing space, e.g. `Bearer `; set empty if the header value is the key itself) |
+| `SEARCH_API_KEY_PARAM` | - | No | URL query parameter name for the key (alternative to header auth) |
+| `SEARCH_API_METHOD` | `POST` | No | HTTP method: `POST` or `GET` |
+| `SEARCH_QUERY_FIELD` | `q` | No | Field name for the search query in the request body / params |
+| `SEARCH_RESULT_FIELD` | `results` | No | Dot-separated path to the results array in the JSON response (e.g. `web.results`) |
+| `SEARCH_TITLE_FIELD` | `title` | No | Field name for the result title |
+| `SEARCH_LINK_FIELD` | `link` | No | Field name for the result URL |
+| `SEARCH_SNIPPET_FIELD` | `snippet` | No | Field name for the result snippet / description |
+
+**Common integration examples:**
+
+- **Serper.dev (POST)**
+  ```env
+  SEARCH_PROVIDER=custom
+  SEARCH_API_URL=https://google.serper.dev/search
+  SEARCH_API_KEY=your-serper-key
+  SEARCH_API_KEY_HEADER=X-API-KEY
+  SEARCH_API_KEY_HEADER_PREFIX=
+  SEARCH_RESULT_FIELD=organic
+  ```
+
+- **SerpAPI (GET)**
+  ```env
+  SEARCH_PROVIDER=custom
+  SEARCH_API_URL=https://serpapi.com/search
+  SEARCH_API_KEY=your-serpapi-key
+  SEARCH_API_KEY_PARAM=api_key
+  SEARCH_API_METHOD=GET
+  SEARCH_RESULT_FIELD=organic_results
+  ```
+
+- **Brave Search API (GET)**
+  ```env
+  SEARCH_PROVIDER=custom
+  SEARCH_API_URL=https://api.search.brave.com/res/v1/web/search
+  SEARCH_API_KEY=your-brave-key
+  SEARCH_API_KEY_HEADER=X-Subscription-Token
+  SEARCH_API_KEY_HEADER_PREFIX=
+  SEARCH_API_METHOD=GET
+  SEARCH_RESULT_FIELD=web.results
+  SEARCH_SNIPPET_FIELD=description
+  ```
 
 ### Authentication Configuration
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "vite-vue-typescript-starter",
+  "name": "manus-frontend",
   "version": "0.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "vite-vue-typescript-starter",
+      "name": "manus-frontend",
       "version": "0.0.0",
       "dependencies": {
         "@microsoft/fetch-event-source": "^2.0.1",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 问题分析

PR 反馈：联网搜索关键词正确，但结果内容文不对题。

**根本原因**：默认提供商 `bing_web` 使用 `curl_cffi` 模拟 Chrome 进行网页抓取。Bing 的反爬虫机制会在检测到非正常流量后返回 CAPTCHA 页面或不相关的区域性结果，导致 HTML 解析失败或搜索结果与查询词不匹配。

## 解决方案

新增两个搜索提供商，彻底解决依赖网页抓取的稳定性问题：

### 1. `serper` — Serper.dev Google 搜索 API

- 返回可靠的 Google 搜索结果，专为 AI Agent 设计
- 配置简单：
  ```env
  SEARCH_PROVIDER=serper
  SERPER_API_KEY=your-key
  ```
- 注册地址：https://serper.dev（提供免费额度）

### 2. `custom` — 通用第三方搜索 REST API

通过环境变量对接任意第三方搜索接口，无需修改代码：

```env
SEARCH_PROVIDER=custom
SEARCH_API_URL=https://your-search-api.com/search
SEARCH_API_KEY=your-key
```

支持完整的请求/响应字段映射配置：

| 变量 | 默认值 | 说明 |
|------|--------|------|
| `SEARCH_API_URL` | — | 搜索接口地址（必填） |
| `SEARCH_API_KEY` | — | API 密钥 |
| `SEARCH_API_KEY_HEADER` | `Authorization` | 传递密钥的 Header 名 |
| `SEARCH_API_KEY_HEADER_PREFIX` | `Bearer ` | Header 值前缀 |
| `SEARCH_API_KEY_PARAM` | — | 以查询参数方式传递密钥的参数名 |
| `SEARCH_API_METHOD` | `POST` | HTTP 方法（`GET`/`POST`） |
| `SEARCH_QUERY_FIELD` | `q` | 请求中搜索词的字段名 |
| `SEARCH_RESULT_FIELD` | `results` | 响应中结果数组的路径（支持 `web.results` 点分隔嵌套） |
| `SEARCH_TITLE_FIELD` | `title` | 结果标题字段 |
| `SEARCH_LINK_FIELD` | `link` | 结果 URL 字段 |
| `SEARCH_SNIPPET_FIELD` | `snippet` | 结果摘要字段 |

**内置示例配置**（见 `.env.example`）：Serper.dev、SerpAPI、Brave Search API

## 变更文件

- `backend/app/infrastructure/external/search/serper_search.py` — 新增 Serper.dev 提供商
- `backend/app/infrastructure/external/search/custom_search.py` — 新增通用自定义 HTTP 提供商
- `backend/app/infrastructure/external/search/__init__.py` — 工厂函数注册两个新提供商
- `backend/app/core/config.py` — 新增 `serper_api_key` 及所有 `search_api_*` 配置字段
- `.env.example` — 完整文档与使用示例
- `docs/configuration.md` — 中文配置文档
- `docs/en/configuration.md` — 英文配置文档

## 向后兼容

- 默认值保持 `SEARCH_PROVIDER=bing_web`，不影响现有部署
- 已有 6 种提供商的逻辑完全不变
- 架构完全遵循现有 `SearchEngine` Protocol 模式，零侵入
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a185868f-6aa4-4cdf-b638-edefcc99a42e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a185868f-6aa4-4cdf-b638-edefcc99a42e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

