### PR TITLE
feat: 默认关闭 Claw 功能

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -142,7 +142,7 @@ JWT_REFRESH_TOKEN_EXPIRE_DAYS=7
 
 # Claw (OpenClaw) configuration
 # Enable or disable Claw feature (hides sidebar entry when false)
-#CLAW_ENABLED=true
+#CLAW_ENABLED=false
 # Docker image used for Claw containers
 #CLAW_IMAGE=simpleyyt/manus-claw
 # Prefix for Claw container names

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -111,7 +111,7 @@ class Settings(BaseSettings):
     extra_headers: dict | None = None
     
     # Claw (OpenClaw) configuration
-    claw_enabled: bool = True
+    claw_enabled: bool = False
     claw_image: str = "simpleyyt/manus-claw"
     claw_name_prefix: str = "manus-claw"
     claw_ttl_seconds: int = 3600

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -58,7 +58,7 @@
 
 | 配置项 | 默认值 | 是否必需 | 说明 |
 |--------|--------|----------|------|
-| `CLAW_ENABLED` | `true` | 否 | 是否启用 Claw 功能，设为 `false` 关闭左侧面板入口 |
+| `CLAW_ENABLED` | `false` | 否 | 是否启用 Claw 功能，设为 `true` 显示左侧面板入口 |
 | `CLAW_IMAGE` | `simpleyyt/manus-claw` | 否 | Claw Docker 镜像名称 |
 | `CLAW_NAME_PREFIX` | `manus-claw` | 否 | Claw 容器名称前缀 |
 | `CLAW_TTL_SECONDS` | `3600` | 否 | Claw 容器生存时间（秒），设为 `0` 表示不限时 |

--- a/docs/en/configuration.md
+++ b/docs/en/configuration.md
@@ -58,7 +58,7 @@
 
 | Configuration | Default Value | Required | Description |
 |---------------|---------------|----------|-------------|
-| `CLAW_ENABLED` | `true` | No | Enable Claw feature; set to `false` to hide the sidebar entry |
+| `CLAW_ENABLED` | `false` | No | Enable Claw feature; set to `true` to show the sidebar entry |
 | `CLAW_IMAGE` | `simpleyyt/manus-claw` | No | Claw Docker image name |
 | `CLAW_NAME_PREFIX` | `manus-claw` | No | Claw container name prefix |
 | `CLAW_TTL_SECONDS` | `3600` | No | Claw container time-to-live in seconds; set to `0` for unlimited |

--- a/docs/en/quick_start.md
+++ b/docs/en/quick_start.md
@@ -159,11 +159,14 @@ SANDBOX_NETWORK=manus-network
 #BROWSER_ENGINE=browser_use
 
 # Search engine configuration
-# Options: baidu, baidu_web, google, bing, bing_web, tavily
-# baidu: uses the Baidu Qianfan AI Search API (requires BAIDU_SEARCH_API_KEY)
+# Options: baidu, baidu_web, google, bing, bing_web, tavily, serper, custom
+# baidu:    uses the Baidu Qianfan AI Search API (requires BAIDU_SEARCH_API_KEY)
 # baidu_web: scrapes Baidu search results with browser impersonation (no API key needed)
-# bing: uses the official Bing Web Search API (requires BING_SEARCH_API_KEY)
+# bing:     uses the official Bing Web Search API (requires BING_SEARCH_API_KEY)
 # bing_web: scrapes Bing search results directly (no API key needed)
+# tavily:   uses the Tavily Search API (requires TAVILY_API_KEY)
+# serper:   uses the Serper.dev Google Search API (requires SERPER_API_KEY)
+# custom:   calls any third-party search REST API via SEARCH_API_URL + SEARCH_API_KEY
 SEARCH_PROVIDER=bing_web
 
 # Baidu search configuration, only used when SEARCH_PROVIDER=baidu
@@ -179,7 +182,54 @@ SEARCH_PROVIDER=bing_web
 #GOOGLE_SEARCH_ENGINE_ID=
 
 # Tavily search configuration, only used when SEARCH_PROVIDER=tavily
+# Get your API key from https://tavily.com
 #TAVILY_API_KEY=
+
+# Serper.dev search configuration, only used when SEARCH_PROVIDER=serper
+# Returns reliable Google results. Get your API key from https://serper.dev
+#SERPER_API_KEY=
+
+# Custom search API configuration, only used when SEARCH_PROVIDER=custom
+# Allows integration with any third-party search REST API.
+#
+# Minimal setup (POST + Bearer token, e.g. a custom internal API):
+#   SEARCH_API_URL=https://your-search-api.example.com/search
+#   SEARCH_API_KEY=your-api-key
+#
+# Serper.dev via custom provider:
+#   SEARCH_API_URL=https://google.serper.dev/search
+#   SEARCH_API_KEY=your-serper-key
+#   SEARCH_API_KEY_HEADER=X-API-KEY
+#   SEARCH_API_KEY_HEADER_PREFIX=
+#   SEARCH_RESULT_FIELD=organic
+#
+# SerpAPI via custom provider:
+#   SEARCH_API_URL=https://serpapi.com/search
+#   SEARCH_API_KEY=your-serpapi-key
+#   SEARCH_API_KEY_PARAM=api_key
+#   SEARCH_API_METHOD=GET
+#   SEARCH_RESULT_FIELD=organic_results
+#
+# Brave Search API via custom provider:
+#   SEARCH_API_URL=https://api.search.brave.com/res/v1/web/search
+#   SEARCH_API_KEY=your-brave-key
+#   SEARCH_API_KEY_HEADER=X-Subscription-Token
+#   SEARCH_API_KEY_HEADER_PREFIX=
+#   SEARCH_API_METHOD=GET
+#   SEARCH_RESULT_FIELD=web.results
+#   SEARCH_SNIPPET_FIELD=description
+#
+#SEARCH_API_URL=
+#SEARCH_API_KEY=
+#SEARCH_API_KEY_HEADER=Authorization
+#SEARCH_API_KEY_HEADER_PREFIX=Bearer
+#SEARCH_API_KEY_PARAM=
+#SEARCH_API_METHOD=POST
+#SEARCH_QUERY_FIELD=q
+#SEARCH_RESULT_FIELD=results
+#SEARCH_TITLE_FIELD=title
+#SEARCH_LINK_FIELD=link
+#SEARCH_SNIPPET_FIELD=snippet
 
 # Google Analytics configuration
 # Set your Google Analytics Measurement ID (e.g. G-XXXXXXXXXX)
@@ -213,7 +263,7 @@ JWT_REFRESH_TOKEN_EXPIRE_DAYS=7
 
 # Claw (OpenClaw) configuration
 # Enable or disable Claw feature (hides sidebar entry when false)
-#CLAW_ENABLED=true
+#CLAW_ENABLED=false
 # Docker image used for Claw containers
 #CLAW_IMAGE=simpleyyt/manus-claw
 # Prefix for Claw container names

--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -160,11 +160,14 @@ SANDBOX_NETWORK=manus-network
 #BROWSER_ENGINE=browser_use
 
 # Search engine configuration
-# Options: baidu, baidu_web, google, bing, bing_web, tavily
-# baidu: uses the Baidu Qianfan AI Search API (requires BAIDU_SEARCH_API_KEY)
+# Options: baidu, baidu_web, google, bing, bing_web, tavily, serper, custom
+# baidu:    uses the Baidu Qianfan AI Search API (requires BAIDU_SEARCH_API_KEY)
 # baidu_web: scrapes Baidu search results with browser impersonation (no API key needed)
-# bing: uses the official Bing Web Search API (requires BING_SEARCH_API_KEY)
+# bing:     uses the official Bing Web Search API (requires BING_SEARCH_API_KEY)
 # bing_web: scrapes Bing search results directly (no API key needed)
+# tavily:   uses the Tavily Search API (requires TAVILY_API_KEY)
+# serper:   uses the Serper.dev Google Search API (requires SERPER_API_KEY)
+# custom:   calls any third-party search REST API via SEARCH_API_URL + SEARCH_API_KEY
 SEARCH_PROVIDER=bing_web
 
 # Baidu search configuration, only used when SEARCH_PROVIDER=baidu
@@ -180,7 +183,54 @@ SEARCH_PROVIDER=bing_web
 #GOOGLE_SEARCH_ENGINE_ID=
 
 # Tavily search configuration, only used when SEARCH_PROVIDER=tavily
+# Get your API key from https://tavily.com
 #TAVILY_API_KEY=
+
+# Serper.dev search configuration, only used when SEARCH_PROVIDER=serper
+# Returns reliable Google results. Get your API key from https://serper.dev
+#SERPER_API_KEY=
+
+# Custom search API configuration, only used when SEARCH_PROVIDER=custom
+# Allows integration with any third-party search REST API.
+#
+# Minimal setup (POST + Bearer token, e.g. a custom internal API):
+#   SEARCH_API_URL=https://your-search-api.example.com/search
+#   SEARCH_API_KEY=your-api-key
+#
+# Serper.dev via custom provider:
+#   SEARCH_API_URL=https://google.serper.dev/search
+#   SEARCH_API_KEY=your-serper-key
+#   SEARCH_API_KEY_HEADER=X-API-KEY
+#   SEARCH_API_KEY_HEADER_PREFIX=
+#   SEARCH_RESULT_FIELD=organic
+#
+# SerpAPI via custom provider:
+#   SEARCH_API_URL=https://serpapi.com/search
+#   SEARCH_API_KEY=your-serpapi-key
+#   SEARCH_API_KEY_PARAM=api_key
+#   SEARCH_API_METHOD=GET
+#   SEARCH_RESULT_FIELD=organic_results
+#
+# Brave Search API via custom provider:
+#   SEARCH_API_URL=https://api.search.brave.com/res/v1/web/search
+#   SEARCH_API_KEY=your-brave-key
+#   SEARCH_API_KEY_HEADER=X-Subscription-Token
+#   SEARCH_API_KEY_HEADER_PREFIX=
+#   SEARCH_API_METHOD=GET
+#   SEARCH_RESULT_FIELD=web.results
+#   SEARCH_SNIPPET_FIELD=description
+#
+#SEARCH_API_URL=
+#SEARCH_API_KEY=
+#SEARCH_API_KEY_HEADER=Authorization
+#SEARCH_API_KEY_HEADER_PREFIX=Bearer
+#SEARCH_API_KEY_PARAM=
+#SEARCH_API_METHOD=POST
+#SEARCH_QUERY_FIELD=q
+#SEARCH_RESULT_FIELD=results
+#SEARCH_TITLE_FIELD=title
+#SEARCH_LINK_FIELD=link
+#SEARCH_SNIPPET_FIELD=snippet
 
 # Google Analytics configuration
 # Set your Google Analytics Measurement ID (e.g. G-XXXXXXXXXX)
@@ -214,7 +264,7 @@ JWT_REFRESH_TOKEN_EXPIRE_DAYS=7
 
 # Claw (OpenClaw) configuration
 # Enable or disable Claw feature (hides sidebar entry when false)
-#CLAW_ENABLED=true
+#CLAW_ENABLED=false
 # Docker image used for Claw containers
 #CLAW_IMAGE=simpleyyt/manus-claw
 # Prefix for Claw container names


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 改动说明

将 `CLAW_ENABLED` 的默认值从 `true` 改为 `false`，使 Claw 功能默认关闭、左侧边栏不再显示 "Manus Claw" 入口；如需启用请显式设置 `CLAW_ENABLED=true`。

## 修改文件

- `backend/app/core/config.py`：`claw_enabled` 默认值 `True` → `False`
- `.env.example`：示例注释由 `#CLAW_ENABLED=true` → `#CLAW_ENABLED=false`
- `docs/configuration.md`、`docs/en/configuration.md`：表格默认值列与说明文字同步更新
- `docs/quick_start.md`、`docs/en/quick_start.md`：通过 `./update_doc.sh` 重新同步 `.env.example` 片段

## 验证

- ✅ 直接加载 `app/core/config.py`，确认默认 `claw_enabled` 为 `False`，并验证 `CLAW_ENABLED=true` 环境变量仍可正常覆盖：
  ```
  claw_enabled default = False
  with CLAW_ENABLED=true -> True
  ```
- 前端 `LeftPanel.vue` 中已使用 `cfg?.claw_enabled ?? false` 作为兜底，不需额外改动。

## 风险

- 已部署环境若依赖默认开启 Claw，将需要显式在 `.env` 中设置 `CLAW_ENABLED=true`，与文档说明一致。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d1814336-5495-4d2a-b4f1-74df1962f90f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d1814336-5495-4d2a-b4f1-74df1962f90f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

