### PR TITLE
feat(backend): add OpenAI SDK LLM gateway selectable via LLM_BACKEND

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,11 +12,11 @@ MODEL_NAME=deepseek-chat
 TEMPERATURE=0.7
 MAX_TOKENS=2000
 
-# LLM gateway backend: langchain (default) or openai.
+# LLM gateway provider: langchain (default) or openai.
 # - langchain: uses init_chat_model, supports many providers via MODEL_PROVIDER.
 # - openai:    talks to OpenAI / OpenAI-compatible endpoints (API_BASE) directly
 #              via the official openai Python SDK (MODEL_PROVIDER is ignored).
-#LLM_BACKEND=langchain
+#LLM_PROVIDER=langchain
 
 # MongoDB configuration
 #MONGODB_URI=mongodb://mongodb:27017

--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,12 @@ MODEL_NAME=deepseek-chat
 TEMPERATURE=0.7
 MAX_TOKENS=2000
 
+# LLM gateway backend: langchain (default) or openai.
+# - langchain: uses init_chat_model, supports many providers via MODEL_PROVIDER.
+# - openai:    talks to OpenAI / OpenAI-compatible endpoints (API_BASE) directly
+#              via the official openai Python SDK (MODEL_PROVIDER is ignored).
+#LLM_BACKEND=langchain
+
 # MongoDB configuration
 #MONGODB_URI=mongodb://mongodb:27017
 #MONGODB_DATABASE=manus

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -32,6 +32,11 @@ class Settings(BaseSettings):
     model_provider: str = "openai"
     temperature: float = 0.7
     max_tokens: int = 2000
+
+    # LLM gateway backend: "langchain" (default, supports many providers via
+    # init_chat_model) or "openai" (direct OpenAI Python SDK, for
+    # OpenAI / OpenAI-compatible endpoints).
+    llm_backend: str = "langchain"
     
     # MongoDB configuration
     mongodb_uri: str = "mongodb://mongodb:27017"

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -33,10 +33,10 @@ class Settings(BaseSettings):
     temperature: float = 0.7
     max_tokens: int = 2000
 
-    # LLM gateway backend: "langchain" (default, supports many providers via
+    # LLM gateway provider: "langchain" (default, supports many providers via
     # init_chat_model) or "openai" (direct OpenAI Python SDK, for
     # OpenAI / OpenAI-compatible endpoints).
-    llm_backend: str = "langchain"
+    llm_provider: str = "langchain"
     
     # MongoDB configuration
     mongodb_uri: str = "mongodb://mongodb:27017"

--- a/backend/app/infrastructure/external/llm/__init__.py
+++ b/backend/app/infrastructure/external/llm/__init__.py
@@ -1,7 +1,7 @@
-"""LLM gateway implementations and backend selection.
+"""LLM gateway implementations and provider selection.
 
 The concrete :class:`app.domain.external.llm.LLM` gateway is chosen at runtime
-from the ``LLM_BACKEND`` setting:
+from the ``LLM_PROVIDER`` setting:
 
 * ``langchain`` (default) — :class:`LangchainLLM`, supports many providers via
   ``init_chat_model``.
@@ -22,13 +22,13 @@ logger = logging.getLogger(__name__)
 
 
 def get_llm() -> LLM:
-    """Return the configured LLM gateway singleton (chosen by ``LLM_BACKEND``)."""
-    backend = (get_settings().llm_backend or "langchain").lower()
-    if backend == "openai":
+    """Return the configured LLM gateway singleton (chosen by ``LLM_PROVIDER``)."""
+    provider = (get_settings().llm_provider or "langchain").lower()
+    if provider == "openai":
         return get_openai_llm()
-    if backend != "langchain":
+    if provider != "langchain":
         logger.warning(
-            "Unknown LLM_BACKEND '%s', falling back to 'langchain'", backend
+            "Unknown LLM_PROVIDER '%s', falling back to 'langchain'", provider
         )
     return get_langchain_llm()
 

--- a/backend/app/infrastructure/external/llm/__init__.py
+++ b/backend/app/infrastructure/external/llm/__init__.py
@@ -1,3 +1,43 @@
-from app.infrastructure.external.llm.langchain_llm import LangchainLLM, get_llm
+"""LLM gateway implementations and backend selection.
 
-__all__ = ["LangchainLLM", "get_llm"]
+The concrete :class:`app.domain.external.llm.LLM` gateway is chosen at runtime
+from the ``LLM_BACKEND`` setting:
+
+* ``langchain`` (default) — :class:`LangchainLLM`, supports many providers via
+  ``init_chat_model``.
+* ``openai`` — :class:`OpenAILLM`, talks to OpenAI / OpenAI-compatible endpoints
+  directly through the official ``openai`` Python SDK.
+"""
+import logging
+
+from app.core.config import get_settings
+from app.domain.external.llm import LLM
+from app.infrastructure.external.llm.langchain_llm import (
+    LangchainLLM,
+    get_langchain_llm,
+)
+from app.infrastructure.external.llm.openai_llm import OpenAILLM, get_openai_llm
+
+logger = logging.getLogger(__name__)
+
+
+def get_llm() -> LLM:
+    """Return the configured LLM gateway singleton (chosen by ``LLM_BACKEND``)."""
+    backend = (get_settings().llm_backend or "langchain").lower()
+    if backend == "openai":
+        return get_openai_llm()
+    if backend != "langchain":
+        logger.warning(
+            "Unknown LLM_BACKEND '%s', falling back to 'langchain'", backend
+        )
+    return get_langchain_llm()
+
+
+__all__ = [
+    "LLM",
+    "LangchainLLM",
+    "OpenAILLM",
+    "get_llm",
+    "get_langchain_llm",
+    "get_openai_llm",
+]

--- a/backend/app/infrastructure/external/llm/langchain_llm.py
+++ b/backend/app/infrastructure/external/llm/langchain_llm.py
@@ -160,7 +160,7 @@ class LangchainLLM:
 
 
 @lru_cache()
-def get_llm() -> LangchainLLM:
+def get_langchain_llm() -> LangchainLLM:
     """Return a process-wide singleton LangChain LLM gateway."""
     logger.info("Creating LangchainLLM gateway")
     return LangchainLLM()

--- a/backend/app/infrastructure/external/llm/openai_llm.py
+++ b/backend/app/infrastructure/external/llm/openai_llm.py
@@ -9,7 +9,7 @@ translation, tool binding, JSON repair and model-level retries — inside the
 infrastructure layer, so the domain agents depend only on the
 :class:`app.domain.external.llm.LLM` Protocol and domain message types.
 
-Selected via ``LLM_BACKEND=openai``.
+Selected via ``LLM_PROVIDER=openai``.
 """
 import json
 import logging

--- a/backend/app/infrastructure/external/llm/openai_llm.py
+++ b/backend/app/infrastructure/external/llm/openai_llm.py
@@ -1,0 +1,259 @@
+"""OpenAI SDK implementation of the domain :class:`LLM` gateway.
+
+An alternative to :class:`app.infrastructure.external.llm.langchain_llm.LangchainLLM`
+that talks to OpenAI (or any OpenAI-compatible endpoint) directly through the
+official ``openai`` Python SDK, without going through LangChain.
+
+Like the LangChain gateway it keeps all framework/SDK concerns — message
+translation, tool binding, JSON repair and model-level retries — inside the
+infrastructure layer, so the domain agents depend only on the
+:class:`app.domain.external.llm.LLM` Protocol and domain message types.
+
+Selected via ``LLM_BACKEND=openai``.
+"""
+import json
+import logging
+import re
+from functools import lru_cache
+from typing import Any, Dict, List, Optional
+
+from openai import AsyncOpenAI
+
+from app.core.config import Settings, get_settings
+from app.domain.models.message import LLMMessage, Role, ToolCall
+
+logger = logging.getLogger(__name__)
+
+_CODE_FENCE_RE = re.compile(r"^\s*```(?:json)?\s*|\s*```\s*$", re.IGNORECASE)
+
+_JSON_REPAIR_PROMPT = (
+    "Extract or repair the JSON from the following LLM output. "
+    "Respond with only the JSON object, nothing else.\n\n{text}"
+)
+
+_TOOL_ARGS_RETRY_PROMPT = (
+    "Your previous response contained invalid JSON in the tool call arguments.\n"
+    "Error details:\n{error}\n\n"
+    "Please resend the tool call with correctly formatted JSON arguments."
+)
+
+
+def _strip_code_fence(text: str) -> str:
+    """Remove a surrounding ```json ... ``` markdown fence, if present."""
+    without_open = _CODE_FENCE_RE.sub("", text, count=1)
+    return _CODE_FENCE_RE.sub("", without_open, count=1).strip()
+
+
+def _extract_json_object(text: Optional[str]) -> Optional[Dict[str, Any]]:
+    """Best-effort local extraction of a JSON object from raw model output.
+
+    Tries the raw string, a markdown-fence-stripped variant, and finally the
+    substring between the first ``{`` and last ``}``. Returns ``None`` when no
+    JSON object can be recovered locally (callers then fall back to a model
+    repair round-trip).
+    """
+    if not text:
+        return None
+
+    candidates = [text, text.strip(), _strip_code_fence(text)]
+    for candidate in candidates:
+        if not candidate:
+            continue
+        try:
+            obj = json.loads(candidate)
+        except (json.JSONDecodeError, TypeError):
+            continue
+        if isinstance(obj, dict):
+            return obj
+
+    start = text.find("{")
+    end = text.rfind("}")
+    if start != -1 and end > start:
+        try:
+            obj = json.loads(text[start : end + 1])
+            if isinstance(obj, dict):
+                return obj
+        except json.JSONDecodeError:
+            pass
+    return None
+
+
+class _ToolArgsParseError(Exception):
+    """Raised internally when tool call arguments cannot be parsed as JSON."""
+
+    def __init__(self, errors: List[str]):
+        super().__init__("; ".join(errors))
+        self.errors = errors
+
+
+class OpenAILLM:
+    """Concrete :class:`LLM` gateway backed by the OpenAI Python SDK."""
+
+    def __init__(self, settings: Optional[Settings] = None, max_retries: int = 3):
+        settings = settings or get_settings()
+        self._model = settings.model_name
+        self._temperature = settings.temperature
+        self._max_tokens = settings.max_tokens
+        self._max_retries = max_retries
+        self._client = AsyncOpenAI(
+            api_key=settings.api_key,
+            base_url=settings.api_base,
+            default_headers=settings.extra_headers or None,
+        )
+
+    # ------------------------------------------------------------------
+    # Message translation (domain <-> OpenAI chat completion payloads)
+    # ------------------------------------------------------------------
+
+    def _to_openai(self, messages: List[LLMMessage]) -> List[Dict[str, Any]]:
+        payload: List[Dict[str, Any]] = []
+        for m in messages:
+            if m.role == Role.SYSTEM:
+                payload.append({"role": "system", "content": m.content})
+            elif m.role == Role.USER:
+                payload.append({"role": "user", "content": m.content})
+            elif m.role == Role.ASSISTANT:
+                msg: Dict[str, Any] = {
+                    "role": "assistant",
+                    # OpenAI accepts null content only when tool_calls are present.
+                    "content": m.content or None,
+                }
+                if m.tool_calls:
+                    msg["tool_calls"] = [
+                        {
+                            "id": tc.id,
+                            "type": "function",
+                            "function": {
+                                "name": tc.name,
+                                "arguments": json.dumps(tc.args or {}),
+                            },
+                        }
+                        for tc in m.tool_calls
+                    ]
+                payload.append(msg)
+            elif m.role == Role.TOOL:
+                payload.append(
+                    {
+                        "role": "tool",
+                        "tool_call_id": m.tool_call_id or "",
+                        "content": m.content,
+                    }
+                )
+        return payload
+
+    def _from_openai(self, message: Any) -> LLMMessage:
+        """Convert an OpenAI response message into a domain :class:`LLMMessage`.
+
+        Raises:
+            _ToolArgsParseError: if any tool call's ``arguments`` string cannot
+                be parsed as a JSON object (caller retries the model).
+        """
+        tool_calls: List[ToolCall] = []
+        errors: List[str] = []
+        for tc in getattr(message, "tool_calls", None) or []:
+            name = tc.function.name or ""
+            raw_args = tc.function.arguments
+            if raw_args is None or raw_args.strip() == "":
+                args: Dict[str, Any] = {}
+            else:
+                parsed = _extract_json_object(raw_args)
+                if parsed is None:
+                    errors.append(f"Tool '{name}': invalid JSON arguments: {raw_args}")
+                    continue
+                args = parsed
+            tool_calls.append(ToolCall(id=tc.id or "", name=name, args=args))
+
+        if errors:
+            raise _ToolArgsParseError(errors)
+
+        return LLMMessage.assistant(content=message.content or "", tool_calls=tool_calls)
+
+    # ------------------------------------------------------------------
+    # LLM Protocol
+    # ------------------------------------------------------------------
+
+    async def _create(
+        self,
+        messages: List[Dict[str, Any]],
+        tools: Optional[List[Dict[str, Any]]],
+        response_format: Optional[str],
+        tool_choice: Optional[str],
+    ) -> Any:
+        kwargs: Dict[str, Any] = dict(
+            model=self._model,
+            messages=messages,
+            temperature=self._temperature,
+            max_tokens=self._max_tokens,
+        )
+        if tools:
+            kwargs["tools"] = tools
+            if tool_choice:
+                kwargs["tool_choice"] = tool_choice
+        if response_format:
+            kwargs["response_format"] = {"type": response_format}
+        response = await self._client.chat.completions.create(**kwargs)
+        return response.choices[0].message
+
+    async def ask(
+        self,
+        messages: List[LLMMessage],
+        tools: Optional[List[Dict[str, Any]]] = None,
+        response_format: Optional[str] = None,
+        tool_choice: Optional[str] = None,
+    ) -> LLMMessage:
+        payload = self._to_openai(messages)
+        for attempt in range(self._max_retries):
+            raw = await self._create(payload, tools, response_format, tool_choice)
+            try:
+                message = self._from_openai(raw)
+                logger.debug("Response from model: %s", message)
+                return message
+            except _ToolArgsParseError as e:
+                if attempt == self._max_retries - 1:
+                    raise
+                logger.warning(
+                    "Attempt %d/%d: tool call JSON parse failed, retrying model: %s",
+                    attempt + 1,
+                    self._max_retries,
+                    e,
+                )
+                if attempt > 0:
+                    # Append the failed assistant turn plus corrective feedback.
+                    payload = payload + [
+                        raw.model_dump(exclude_none=True),
+                        {
+                            "role": "user",
+                            "content": _TOOL_ARGS_RETRY_PROMPT.format(
+                                error="\n".join(e.errors)
+                            ),
+                        },
+                    ]
+        # Unreachable: loop either returns or raises.
+        raise _ToolArgsParseError(["exhausted retries"])
+
+    async def parse_json(self, text: str) -> Dict[str, Any]:
+        """Extract/repair a JSON object from raw model output."""
+        local = _extract_json_object(text)
+        if local is not None:
+            return local
+
+        logger.info("Local JSON extraction failed, asking model to repair")
+        response = await self._client.chat.completions.create(
+            model=self._model,
+            messages=[
+                {"role": "user", "content": _JSON_REPAIR_PROMPT.format(text=text)}
+            ],
+            temperature=0,
+            response_format={"type": "json_object"},
+        )
+        repaired = _extract_json_object(response.choices[0].message.content)
+        if repaired is None:
+            raise ValueError(f"Failed to parse JSON from model output: {text!r}")
+        return repaired
+
+
+@lru_cache()
+def get_openai_llm() -> OpenAILLM:
+    """Return a process-wide singleton OpenAI SDK LLM gateway."""
+    logger.info("Creating OpenAILLM gateway")
+    return OpenAILLM()

--- a/backend/tests/test_openai_gateway.py
+++ b/backend/tests/test_openai_gateway.py
@@ -1,0 +1,150 @@
+"""Unit tests for the OpenAI SDK LLM gateway.
+
+Ensures the infrastructure gateway correctly converts between domain
+:class:`LLMMessage` objects and OpenAI chat-completion payloads/responses in
+both directions, plus its local JSON extraction/repair helpers. These tests
+build the client without making any network calls.
+"""
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from app.core.config import Settings
+from app.domain.models.message import LLMMessage, Role, ToolCall
+from app.infrastructure.external.llm.openai_llm import (
+    OpenAILLM,
+    _ToolArgsParseError,
+    _extract_json_object,
+)
+
+
+def _gateway() -> OpenAILLM:
+    # Constructing AsyncOpenAI only builds the client; no network call is made.
+    return OpenAILLM(settings=Settings(api_key="test", api_base=None))
+
+
+def _resp(content=None, tool_calls=None):
+    """Build a fake OpenAI response message object."""
+    tcs = []
+    for i, (name, args) in enumerate(tool_calls or []):
+        tcs.append(
+            SimpleNamespace(
+                id=f"call_{i}",
+                type="function",
+                function=SimpleNamespace(name=name, arguments=args),
+            )
+        )
+    return SimpleNamespace(content=content, tool_calls=tcs or None)
+
+
+class TestToOpenAI:
+    def test_all_roles_converted(self):
+        gw = _gateway()
+        msgs = [
+            LLMMessage.system("sys"),
+            LLMMessage.user("hi"),
+            LLMMessage.assistant(
+                "", tool_calls=[ToolCall(id="c1", name="shell_exec", args={"cmd": "ls"})]
+            ),
+            LLMMessage.tool(tool_call_id="c1", name="shell_exec", content="{}"),
+        ]
+        payload = gw._to_openai(msgs)
+
+        assert payload[0] == {"role": "system", "content": "sys"}
+        assert payload[1] == {"role": "user", "content": "hi"}
+
+        assistant = payload[2]
+        assert assistant["role"] == "assistant"
+        assert assistant["content"] is None  # null content allowed with tool_calls
+        tc = assistant["tool_calls"][0]
+        assert tc["id"] == "c1"
+        assert tc["type"] == "function"
+        assert tc["function"]["name"] == "shell_exec"
+        assert json.loads(tc["function"]["arguments"]) == {"cmd": "ls"}
+
+        tool = payload[3]
+        assert tool == {"role": "tool", "tool_call_id": "c1", "content": "{}"}
+
+
+class TestFromOpenAI:
+    def test_message_with_tool_calls(self):
+        gw = _gateway()
+        m = gw._from_openai(
+            _resp(tool_calls=[("file_read", '{"file": "/a"}')])
+        )
+        assert m.role == Role.ASSISTANT
+        assert m.tool_calls[0].name == "file_read"
+        assert m.tool_calls[0].args == {"file": "/a"}
+        assert m.tool_calls[0].id == "call_0"
+
+    def test_plain_message(self):
+        gw = _gateway()
+        m = gw._from_openai(_resp(content="hello"))
+        assert m.role == Role.ASSISTANT and m.content == "hello" and m.tool_calls == []
+
+    def test_none_content_becomes_empty_string(self):
+        gw = _gateway()
+        m = gw._from_openai(_resp(content=None, tool_calls=[("f", "{}")]))
+        assert m.content == ""
+
+    def test_empty_arguments_become_empty_dict(self):
+        gw = _gateway()
+        m = gw._from_openai(_resp(tool_calls=[("noargs", "")]))
+        assert m.tool_calls[0].args == {}
+
+    def test_markdown_fenced_arguments_repaired(self):
+        gw = _gateway()
+        m = gw._from_openai(
+            _resp(tool_calls=[("f", '```json\n{"x": 1}\n```')])
+        )
+        assert m.tool_calls[0].args == {"x": 1}
+
+    def test_unparseable_arguments_raise(self):
+        gw = _gateway()
+        with pytest.raises(_ToolArgsParseError):
+            gw._from_openai(_resp(tool_calls=[("f", "not json at all")]))
+
+
+class TestRoundTrip:
+    def test_domain_to_openai_to_domain_preserves_tool_calls(self):
+        gw = _gateway()
+        original = LLMMessage.assistant(
+            "text",
+            tool_calls=[ToolCall(id="c3", name="info_search_web", args={"query": "x"})],
+        )
+        payload = gw._to_openai([original])[0]
+        rebuilt = _resp(
+            content=payload["content"],
+            tool_calls=[
+                (tc["function"]["name"], tc["function"]["arguments"])
+                for tc in payload["tool_calls"]
+            ],
+        )
+        back = gw._from_openai(rebuilt)
+        assert back.content == "text"
+        assert back.tool_calls[0].name == "info_search_web"
+        assert back.tool_calls[0].args == {"query": "x"}
+
+
+class TestExtractJsonObject:
+    def test_plain(self):
+        assert _extract_json_object('{"a": 1}') == {"a": 1}
+
+    def test_markdown_fence(self):
+        assert _extract_json_object('```json\n{"a": 1}\n```') == {"a": 1}
+
+    def test_surrounding_text(self):
+        assert _extract_json_object('here you go: {"a": 1} thanks') == {"a": 1}
+
+    def test_not_json(self):
+        assert _extract_json_object("nope") is None
+
+    def test_none(self):
+        assert _extract_json_object(None) is None
+
+
+class TestParseJsonLocal:
+    async def test_local_extraction_no_network(self):
+        gw = _gateway()
+        assert await gw.parse_json('{"ok": true}') == {"ok": True}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -13,10 +13,11 @@
 
 | 配置项 | 默认值 | 是否必需 | 说明 |
 |--------|--------|----------|------|
-| `MODEL_PROVIDER` | `openai` | 否 | 模型提供商，决定底层使用哪个 LLM 集成（如 `openai`、`deepseek`、`anthropic`、`ollama`） |
+| `MODEL_PROVIDER` | `openai` | 否 | 模型提供商，决定底层使用哪个 LLM 集成（如 `openai`、`deepseek`、`anthropic`、`ollama`），仅在 `LLM_BACKEND=langchain` 时生效 |
 | `MODEL_NAME` | `deepseek-chat` | 是 | 要使用的模型名称 |
 | `TEMPERATURE` | `0.7` | 否 | 模型响应的随机性程度，范围 0-1 |
 | `MAX_TOKENS` | `2000` | 否 | 模型响应的最大 token 数量 |
+| `LLM_BACKEND` | `langchain` | 否 | LLM 网关实现：`langchain`（默认，经 `init_chat_model` 支持多种提供商）或 `openai`（直接使用官方 `openai` Python SDK 调用 OpenAI / 兼容端点） |
 | `EXTRA_HEADERS` | - | 否 | 为模型请求附加的自定义 HTTP 头，JSON 对象字符串（如 `{"X-Api-Key":"xxx"}`），部分网关鉴权时需要 |
 
 ### 配置不同的模型 / 提供商
@@ -73,6 +74,27 @@
   ```
 
 > **接入更多提供商**：`init_chat_model` 还支持 Google Gemini、AWS Bedrock、Azure OpenAI、Mistral 等更多提供商。只需在 `backend/pyproject.toml` 增加对应的 `langchain-xxx` 集成包（如 `langchain-google-genai`）并重新构建镜像（`./build.sh` 或 `./dev.sh build`），再将 `MODEL_PROVIDER` 设为对应值即可。完整的提供商列表与命名参见 [LangChain `init_chat_model` 文档](https://python.langchain.com/api_reference/langchain/chat_models/langchain.chat_models.base.init_chat_model.html)。
+
+### 切换 LLM 网关实现（`LLM_BACKEND`）
+
+后端在领域层通过统一的 `LLM` 接口调用大模型，具体实现由 `LLM_BACKEND` 选择：
+
+| `LLM_BACKEND` | 说明 | 适用场景 |
+|---------------|------|----------|
+| `langchain`（默认） | 经 LangChain `init_chat_model` 调用，配合 `MODEL_PROVIDER` 支持 OpenAI、DeepSeek、Anthropic、Ollama 等多种提供商 | 需要多提供商、依赖 LangChain 生态（JSON 修复、重试等）时 |
+| `openai` | 直接使用官方 `openai` Python SDK 调用 OpenAI 及**所有 OpenAI 兼容端点**（通过 `API_BASE`），不经过 LangChain | 只用 OpenAI / 兼容端点、希望减少依赖、更贴近原生 SDK 行为时 |
+
+- 两种实现均消费同一套配置（`MODEL_NAME`、`API_KEY`、`API_BASE`、`TEMPERATURE`、`MAX_TOKENS`、`EXTRA_HEADERS`）。
+- 选择 `openai` 时，`MODEL_PROVIDER` 被忽略（该实现始终使用 OpenAI SDK）。
+
+**配置示例（使用 OpenAI SDK 直连 DeepSeek 兼容端点）：**
+
+```env
+LLM_BACKEND=openai
+MODEL_NAME=deepseek-chat
+API_BASE=https://api.deepseek.com/v1
+API_KEY=sk-...
+```
 
 ### MongoDB 配置
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -13,11 +13,11 @@
 
 | 配置项 | 默认值 | 是否必需 | 说明 |
 |--------|--------|----------|------|
-| `MODEL_PROVIDER` | `openai` | 否 | 模型提供商，决定底层使用哪个 LLM 集成（如 `openai`、`deepseek`、`anthropic`、`ollama`），仅在 `LLM_BACKEND=langchain` 时生效 |
+| `MODEL_PROVIDER` | `openai` | 否 | 模型提供商，决定底层使用哪个 LLM 集成（如 `openai`、`deepseek`、`anthropic`、`ollama`），仅在 `LLM_PROVIDER=langchain` 时生效 |
 | `MODEL_NAME` | `deepseek-chat` | 是 | 要使用的模型名称 |
 | `TEMPERATURE` | `0.7` | 否 | 模型响应的随机性程度，范围 0-1 |
 | `MAX_TOKENS` | `2000` | 否 | 模型响应的最大 token 数量 |
-| `LLM_BACKEND` | `langchain` | 否 | LLM 网关实现：`langchain`（默认，经 `init_chat_model` 支持多种提供商）或 `openai`（直接使用官方 `openai` Python SDK 调用 OpenAI / 兼容端点） |
+| `LLM_PROVIDER` | `langchain` | 否 | LLM 网关实现：`langchain`（默认，经 `init_chat_model` 支持多种提供商）或 `openai`（直接使用官方 `openai` Python SDK 调用 OpenAI / 兼容端点） |
 | `EXTRA_HEADERS` | - | 否 | 为模型请求附加的自定义 HTTP 头，JSON 对象字符串（如 `{"X-Api-Key":"xxx"}`），部分网关鉴权时需要 |
 
 ### 配置不同的模型 / 提供商
@@ -75,11 +75,11 @@
 
 > **接入更多提供商**：`init_chat_model` 还支持 Google Gemini、AWS Bedrock、Azure OpenAI、Mistral 等更多提供商。只需在 `backend/pyproject.toml` 增加对应的 `langchain-xxx` 集成包（如 `langchain-google-genai`）并重新构建镜像（`./build.sh` 或 `./dev.sh build`），再将 `MODEL_PROVIDER` 设为对应值即可。完整的提供商列表与命名参见 [LangChain `init_chat_model` 文档](https://python.langchain.com/api_reference/langchain/chat_models/langchain.chat_models.base.init_chat_model.html)。
 
-### 切换 LLM 网关实现（`LLM_BACKEND`）
+### 切换 LLM 网关实现（`LLM_PROVIDER`）
 
-后端在领域层通过统一的 `LLM` 接口调用大模型，具体实现由 `LLM_BACKEND` 选择：
+后端在领域层通过统一的 `LLM` 接口调用大模型，具体实现由 `LLM_PROVIDER` 选择：
 
-| `LLM_BACKEND` | 说明 | 适用场景 |
+| `LLM_PROVIDER` | 说明 | 适用场景 |
 |---------------|------|----------|
 | `langchain`（默认） | 经 LangChain `init_chat_model` 调用，配合 `MODEL_PROVIDER` 支持 OpenAI、DeepSeek、Anthropic、Ollama 等多种提供商 | 需要多提供商、依赖 LangChain 生态（JSON 修复、重试等）时 |
 | `openai` | 直接使用官方 `openai` Python SDK 调用 OpenAI 及**所有 OpenAI 兼容端点**（通过 `API_BASE`），不经过 LangChain | 只用 OpenAI / 兼容端点、希望减少依赖、更贴近原生 SDK 行为时 |
@@ -90,7 +90,7 @@
 **配置示例（使用 OpenAI SDK 直连 DeepSeek 兼容端点）：**
 
 ```env
-LLM_BACKEND=openai
+LLM_PROVIDER=openai
 MODEL_NAME=deepseek-chat
 API_BASE=https://api.deepseek.com/v1
 API_KEY=sk-...

--- a/docs/en/configuration.md
+++ b/docs/en/configuration.md
@@ -13,11 +13,11 @@
 
 | Configuration | Default Value | Required | Description |
 |---------------|---------------|----------|-------------|
-| `MODEL_PROVIDER` | `openai` | No | Model provider that selects the underlying LLM integration (e.g. `openai`, `deepseek`, `anthropic`, `ollama`); only used when `LLM_BACKEND=langchain` |
+| `MODEL_PROVIDER` | `openai` | No | Model provider that selects the underlying LLM integration (e.g. `openai`, `deepseek`, `anthropic`, `ollama`); only used when `LLM_PROVIDER=langchain` |
 | `MODEL_NAME` | `deepseek-chat` | Yes | Name of the model to use |
 | `TEMPERATURE` | `0.7` | No | Randomness level of model responses, range 0-1 |
 | `MAX_TOKENS` | `2000` | No | Maximum number of tokens in model response |
-| `LLM_BACKEND` | `langchain` | No | LLM gateway implementation: `langchain` (default, many providers via `init_chat_model`) or `openai` (direct OpenAI Python SDK for OpenAI / compatible endpoints) |
+| `LLM_PROVIDER` | `langchain` | No | LLM gateway implementation: `langchain` (default, many providers via `init_chat_model`) or `openai` (direct OpenAI Python SDK for OpenAI / compatible endpoints) |
 | `EXTRA_HEADERS` | - | No | Extra HTTP headers for model requests, as a JSON object string (e.g. `{"X-Api-Key":"xxx"}`); required by some gateways |
 
 ### Configuring Different Models / Providers
@@ -75,11 +75,11 @@ The following providers are built in (their LangChain integration packages are p
 
 > **Adding more providers**: `init_chat_model` also supports Google Gemini, AWS Bedrock, Azure OpenAI, Mistral and many more. Just add the matching `langchain-xxx` integration package (e.g. `langchain-google-genai`) to `backend/pyproject.toml`, rebuild the images (`./build.sh` or `./dev.sh build`), and set `MODEL_PROVIDER` accordingly. See the [LangChain `init_chat_model` docs](https://python.langchain.com/api_reference/langchain/chat_models/langchain.chat_models.base.init_chat_model.html) for the full list of providers and names.
 
-### Switching the LLM Gateway Backend (`LLM_BACKEND`)
+### Switching the LLM Gateway Provider (`LLM_PROVIDER`)
 
-The backend calls the LLM through a single domain `LLM` interface, whose concrete implementation is chosen by `LLM_BACKEND`:
+The backend calls the LLM through a single domain `LLM` interface, whose concrete implementation is chosen by `LLM_PROVIDER`:
 
-| `LLM_BACKEND` | Description | When to use |
+| `LLM_PROVIDER` | Description | When to use |
 |---------------|-------------|-------------|
 | `langchain` (default) | Calls via LangChain `init_chat_model`; combined with `MODEL_PROVIDER` it supports OpenAI, DeepSeek, Anthropic, Ollama and more | When you need multiple providers or the LangChain ecosystem (JSON repair, retries, …) |
 | `openai` | Uses the official `openai` Python SDK directly to call OpenAI and **any OpenAI-compatible endpoint** (via `API_BASE`), without going through LangChain | When you only use OpenAI / compatible endpoints and want fewer dependencies / native SDK behavior |
@@ -90,7 +90,7 @@ The backend calls the LLM through a single domain `LLM` interface, whose concret
 **Example (OpenAI SDK talking directly to a DeepSeek-compatible endpoint):**
 
 ```env
-LLM_BACKEND=openai
+LLM_PROVIDER=openai
 MODEL_NAME=deepseek-chat
 API_BASE=https://api.deepseek.com/v1
 API_KEY=sk-...

--- a/docs/en/configuration.md
+++ b/docs/en/configuration.md
@@ -13,10 +13,11 @@
 
 | Configuration | Default Value | Required | Description |
 |---------------|---------------|----------|-------------|
-| `MODEL_PROVIDER` | `openai` | No | Model provider that selects the underlying LLM integration (e.g. `openai`, `deepseek`, `anthropic`, `ollama`) |
+| `MODEL_PROVIDER` | `openai` | No | Model provider that selects the underlying LLM integration (e.g. `openai`, `deepseek`, `anthropic`, `ollama`); only used when `LLM_BACKEND=langchain` |
 | `MODEL_NAME` | `deepseek-chat` | Yes | Name of the model to use |
 | `TEMPERATURE` | `0.7` | No | Randomness level of model responses, range 0-1 |
 | `MAX_TOKENS` | `2000` | No | Maximum number of tokens in model response |
+| `LLM_BACKEND` | `langchain` | No | LLM gateway implementation: `langchain` (default, many providers via `init_chat_model`) or `openai` (direct OpenAI Python SDK for OpenAI / compatible endpoints) |
 | `EXTRA_HEADERS` | - | No | Extra HTTP headers for model requests, as a JSON object string (e.g. `{"X-Api-Key":"xxx"}`); required by some gateways |
 
 ### Configuring Different Models / Providers
@@ -73,6 +74,27 @@ The following providers are built in (their LangChain integration packages are p
   ```
 
 > **Adding more providers**: `init_chat_model` also supports Google Gemini, AWS Bedrock, Azure OpenAI, Mistral and many more. Just add the matching `langchain-xxx` integration package (e.g. `langchain-google-genai`) to `backend/pyproject.toml`, rebuild the images (`./build.sh` or `./dev.sh build`), and set `MODEL_PROVIDER` accordingly. See the [LangChain `init_chat_model` docs](https://python.langchain.com/api_reference/langchain/chat_models/langchain.chat_models.base.init_chat_model.html) for the full list of providers and names.
+
+### Switching the LLM Gateway Backend (`LLM_BACKEND`)
+
+The backend calls the LLM through a single domain `LLM` interface, whose concrete implementation is chosen by `LLM_BACKEND`:
+
+| `LLM_BACKEND` | Description | When to use |
+|---------------|-------------|-------------|
+| `langchain` (default) | Calls via LangChain `init_chat_model`; combined with `MODEL_PROVIDER` it supports OpenAI, DeepSeek, Anthropic, Ollama and more | When you need multiple providers or the LangChain ecosystem (JSON repair, retries, …) |
+| `openai` | Uses the official `openai` Python SDK directly to call OpenAI and **any OpenAI-compatible endpoint** (via `API_BASE`), without going through LangChain | When you only use OpenAI / compatible endpoints and want fewer dependencies / native SDK behavior |
+
+- Both implementations consume the same settings (`MODEL_NAME`, `API_KEY`, `API_BASE`, `TEMPERATURE`, `MAX_TOKENS`, `EXTRA_HEADERS`).
+- When `openai` is selected, `MODEL_PROVIDER` is ignored (this backend always uses the OpenAI SDK).
+
+**Example (OpenAI SDK talking directly to a DeepSeek-compatible endpoint):**
+
+```env
+LLM_BACKEND=openai
+MODEL_NAME=deepseek-chat
+API_BASE=https://api.deepseek.com/v1
+API_KEY=sk-...
+```
 
 ### MongoDB Configuration
 

--- a/docs/en/quick_start.md
+++ b/docs/en/quick_start.md
@@ -133,6 +133,12 @@ MODEL_NAME=deepseek-chat
 TEMPERATURE=0.7
 MAX_TOKENS=2000
 
+# LLM gateway backend: langchain (default) or openai.
+# - langchain: uses init_chat_model, supports many providers via MODEL_PROVIDER.
+# - openai:    talks to OpenAI / OpenAI-compatible endpoints (API_BASE) directly
+#              via the official openai Python SDK (MODEL_PROVIDER is ignored).
+#LLM_BACKEND=langchain
+
 # MongoDB configuration
 #MONGODB_URI=mongodb://mongodb:27017
 #MONGODB_DATABASE=manus

--- a/docs/en/quick_start.md
+++ b/docs/en/quick_start.md
@@ -133,11 +133,11 @@ MODEL_NAME=deepseek-chat
 TEMPERATURE=0.7
 MAX_TOKENS=2000
 
-# LLM gateway backend: langchain (default) or openai.
+# LLM gateway provider: langchain (default) or openai.
 # - langchain: uses init_chat_model, supports many providers via MODEL_PROVIDER.
 # - openai:    talks to OpenAI / OpenAI-compatible endpoints (API_BASE) directly
 #              via the official openai Python SDK (MODEL_PROVIDER is ignored).
-#LLM_BACKEND=langchain
+#LLM_PROVIDER=langchain
 
 # MongoDB configuration
 #MONGODB_URI=mongodb://mongodb:27017

--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -134,11 +134,11 @@ MODEL_NAME=deepseek-chat
 TEMPERATURE=0.7
 MAX_TOKENS=2000
 
-# LLM gateway backend: langchain (default) or openai.
+# LLM gateway provider: langchain (default) or openai.
 # - langchain: uses init_chat_model, supports many providers via MODEL_PROVIDER.
 # - openai:    talks to OpenAI / OpenAI-compatible endpoints (API_BASE) directly
 #              via the official openai Python SDK (MODEL_PROVIDER is ignored).
-#LLM_BACKEND=langchain
+#LLM_PROVIDER=langchain
 
 # MongoDB configuration
 #MONGODB_URI=mongodb://mongodb:27017

--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -134,6 +134,12 @@ MODEL_NAME=deepseek-chat
 TEMPERATURE=0.7
 MAX_TOKENS=2000
 
+# LLM gateway backend: langchain (default) or openai.
+# - langchain: uses init_chat_model, supports many providers via MODEL_PROVIDER.
+# - openai:    talks to OpenAI / OpenAI-compatible endpoints (API_BASE) directly
+#              via the official openai Python SDK (MODEL_PROVIDER is ignored).
+#LLM_BACKEND=langchain
+
 # MongoDB configuration
 #MONGODB_URI=mongodb://mongodb:27017
 #MONGODB_DATABASE=manus


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Background

Follow-up to the LangChain decoupling (#164, already merged). Now that all LLM-framework concerns sit behind the domain `LLM` Protocol, this PR proves the abstraction is pluggable by adding a **second, LangChain-free gateway** built on the official OpenAI Python SDK, selectable at runtime via `LLM_PROVIDER`.

## What changed

- New `infrastructure/external/llm/openai_llm.py` — `OpenAILLM` implements the domain `LLM` Protocol (`ask` / `parse_json`) using `openai.AsyncOpenAI` directly (no LangChain):
  - `_to_openai` / `_from_openai` translate domain messages ↔ chat-completion payloads (tool_calls, tool results, null content).
  - Local JSON extraction/repair for tool arguments and `parse_json` (raw → markdown-fence strip → brace slice), with model-level retry and a `response_format=json_object` repair round-trip as fallback.
- New `LLM_PROVIDER` setting (`config.py`) selects the gateway; `get_llm()` factory in `infrastructure/external/llm/__init__.py` returns `OpenAILLM` or `LangchainLLM` (LangChain's factory renamed to `get_langchain_llm`). Default stays `langchain` — no behavior change.
- Docs: `.env.example`, `docs/{,en/}configuration.md` (new `LLM_PROVIDER` table + OpenAI SDK example), synced quick-start; `MODEL_PROVIDER` noted as langchain-only.
- New unit tests `backend/tests/test_openai_gateway.py`.

## Testing

- ✅ `uv run pytest tests/test_openai_gateway.py tests/test_llm_gateway.py tests/test_domain_tools.py` — passing, rebased on merged `main`.
- ✅ **E2E full agent loop with `LLM_PROVIDER=openai`** against the OpenAI-compatible mockserver via `./dev.sh up`: backend logged `Creating OpenAILLM gateway`, then a chat drove plan → step → tool calls (`message_notify_user`, `info_search_web` with real results, `file_write` ×3, `shell_exec`, `browser_navigate`) → step completed → plan completed, with **0 error events**.
- ✅ **GUI test** in Chrome at `http://localhost:5173` with the OpenAI provider: submitted a chat message, agent created a plan and executed file writes, `ls -a` shell, and browser navigation to example.com (shown in the "Manus Computer" side panel), ending in "Task Completed 1/1" — no errors.

### GUI walkthrough
[openai_sdk_llm_gui_chat.mp4](https://cursor.com/agents/bc-019f1e19-2940-7d61-8e3e-b9501ea05f2e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fopenai_sdk_llm_gui_chat.mp4)

[Tools running with Manus Computer browser panel](https://cursor.com/agents/bc-019f1e19-2940-7d61-8e3e-b9501ea05f2e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fopenai_sdk_llm_gui_tools_running.webp)
[Task Completed 1/1 with created files and final message](https://cursor.com/agents/bc-019f1e19-2940-7d61-8e3e-b9501ea05f2e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fopenai_sdk_llm_gui_final.webp)

[openai_sdk_llm_e2e.log](https://cursor.com/agents/bc-019f1e19-2940-7d61-8e3e-b9501ea05f2e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fopenai_sdk_llm_e2e.log)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f1e19-2940-7d61-8e3e-b9501ea05f2e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f1e19-2940-7d61-8e3e-b9501ea05f2e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

