### PR TITLE
梳理数据转换:显式 EventMapper、统一 from_domain 命名、前端共享事件转换 composable

### DIFF
--- a/backend/app/application/services/agent_service.py
+++ b/backend/app/application/services/agent_service.py
@@ -86,7 +86,7 @@ class AgentService:
         message: Optional[str] = None,
         timestamp: Optional[datetime] = None,
         event_id: Optional[str] = None,
-        attachments: Optional[List[dict]] = None
+        attachments: Optional[List[FileInfo]] = None
     ) -> AsyncGenerator[AgentEvent, None]:
         logger.info(f"Starting chat with session {session_id}: {message[:50]}...")
         # Directly use the domain service's chat method, which will check if the session exists

--- a/backend/app/domain/services/agent_domain_service.py
+++ b/backend/app/domain/services/agent_domain_service.py
@@ -101,7 +101,7 @@ class AgentDomainService:
         message: Optional[str] = None,
         timestamp: Optional[datetime] = None,
         latest_event_id: Optional[str] = None,
-        attachments: Optional[List[dict]] = None
+        attachments: Optional[List[FileInfo]] = None
     ) -> AsyncGenerator[BaseEvent, None]:
         """
         Chat with an agent
@@ -126,7 +126,7 @@ class AgentDomainService:
                 message_event = MessageEvent(
                     message=message, 
                     role="user", 
-                    attachments=[FileInfo(file_id=attachment["file_id"], filename=attachment["filename"]) for attachment in attachments] if attachments else None
+                    attachments=attachments
                 )
 
                 event_id = await task.input_stream.put(message_event.model_dump_json())

--- a/backend/app/interfaces/api/auth_routes.py
+++ b/backend/app/interfaces/api/auth_routes.py
@@ -38,7 +38,7 @@ async def login(
     
     # Return success response with tokens
     return APIResponse.success(LoginResponse(
-        user=UserResponse.from_user(auth_result.user),
+        user=UserResponse.from_domain(auth_result.user),
         access_token=auth_result.access_token,
         refresh_token=auth_result.refresh_token,
         token_type=auth_result.token_type
@@ -64,7 +64,7 @@ async def register(
     
     # Return success response with tokens
     return APIResponse.success(RegisterResponse(
-        user=UserResponse.from_user(user),
+        user=UserResponse.from_domain(user),
         access_token=access_token,
         refresh_token=refresh_token,
         token_type="bearer"
@@ -106,7 +106,7 @@ async def change_fullname(
     # Change fullname for current user
     updated_user = await auth_service.change_fullname(current_user.id, request.fullname)
     
-    return APIResponse.success(UserResponse.from_user(updated_user))
+    return APIResponse.success(UserResponse.from_domain(updated_user))
 
 
 @router.get("/me", response_model=APIResponse[UserResponse])
@@ -114,7 +114,7 @@ async def get_current_user_info(
     current_user: User = Depends(get_current_user)
 ) -> APIResponse[UserResponse]:
     """Get current user information"""
-    return APIResponse.success(UserResponse.from_user(current_user))
+    return APIResponse.success(UserResponse.from_domain(current_user))
 
 
 @router.get("/user/{user_id}", response_model=APIResponse[UserResponse])
@@ -133,7 +133,7 @@ async def get_user(
     if not user:
         raise NotFoundError("User not found")
     
-    return APIResponse.success(UserResponse.from_user(user))
+    return APIResponse.success(UserResponse.from_domain(user))
 
 
 @router.post("/user/{user_id}/deactivate", response_model=APIResponse[dict])

--- a/backend/app/interfaces/api/claw_routes.py
+++ b/backend/app/interfaces/api/claw_routes.py
@@ -38,7 +38,7 @@ async def get_claw(
     claw = await claw_service.get_claw(current_user.id)
     if not claw:
         raise NotFoundError("No claw instance found")
-    return APIResponse.success(ClawResponse.from_claw(claw))
+    return APIResponse.success(ClawResponse.from_domain(claw))
 
 
 @router.post("", response_model=APIResponse[ClawResponse])
@@ -48,7 +48,7 @@ async def create_claw(
 ) -> APIResponse[ClawResponse]:
     """Create a new claw instance for the current user"""
     claw = await claw_service.create_claw(current_user.id)
-    return APIResponse.success(ClawResponse.from_claw(claw))
+    return APIResponse.success(ClawResponse.from_domain(claw))
 
 
 @router.delete("", response_model=APIResponse[dict])
@@ -90,7 +90,7 @@ async def upload_claw_file(
         user_id=user_id,
         content_type=file.content_type,
     )
-    return APIResponse.success(await FileInfoResponse.from_file_info(result))
+    return APIResponse.success(await FileInfoResponse.from_domain(result))
 
 
 @router.get("/files/{filename}")
@@ -128,7 +128,7 @@ async def resolve_claw_file_meta(
     file_info = await file_service.get_file_info(file_id)
     if not file_info:
         raise NotFoundError("File not found")
-    return APIResponse.success(await FileInfoResponse.from_file_info(file_info))
+    return APIResponse.success(await FileInfoResponse.from_domain(file_info))
 
 
 @router.get("/resolve/{file_id}/download")

--- a/backend/app/interfaces/api/file_routes.py
+++ b/backend/app/interfaces/api/file_routes.py
@@ -29,7 +29,7 @@ async def upload_file(
         content_type=file.content_type
     )
     
-    return APIResponse.success(await FileInfoResponse.from_file_info(result))
+    return APIResponse.success(await FileInfoResponse.from_domain(result))
 
 @router.get("/{file_id}")
 async def download_file_with_signature(
@@ -116,7 +116,7 @@ async def get_file_info(
     if not file_info:
         raise NotFoundError("File not found")
     
-    return APIResponse.success(await FileInfoResponse.from_file_info(file_info))
+    return APIResponse.success(await FileInfoResponse.from_domain(file_info))
 
 
 @router.post("/{file_id}/signed-url", response_model=APIResponse[SignedUrlResponse])

--- a/backend/app/interfaces/api/session_routes.py
+++ b/backend/app/interfaces/api/session_routes.py
@@ -91,17 +91,7 @@ async def get_all_sessions(
     agent_service: AgentService = Depends(get_agent_service)
 ) -> APIResponse[ListSessionResponse]:
     summaries = await agent_service.get_all_sessions(current_user.id)
-    session_items = [
-        ListSessionItem(
-            session_id=s.id,
-            title=s.title,
-            status=s.status,
-            unread_message_count=s.unread_message_count,
-            latest_message=s.latest_message,
-            latest_message_at=int(s.latest_message_at.timestamp()) if s.latest_message_at else None,
-            is_shared=s.is_shared
-        ) for s in summaries
-    ]
+    session_items = [ListSessionItem.from_domain(s) for s in summaries]
     return APIResponse.success(ListSessionResponse(sessions=session_items))
 
 @router.post("")
@@ -112,17 +102,7 @@ async def stream_sessions(
     async def event_generator() -> AsyncGenerator[ServerSentEvent, None]:
         while True:
             summaries = await agent_service.get_all_sessions(current_user.id)
-            session_items = [
-                ListSessionItem(
-                    session_id=s.id,
-                    title=s.title,
-                    status=s.status,
-                    unread_message_count=s.unread_message_count,
-                    latest_message=s.latest_message,
-                    latest_message_at=int(s.latest_message_at.timestamp()) if s.latest_message_at else None,
-                    is_shared=s.is_shared
-                ) for s in summaries
-            ]
+            session_items = [ListSessionItem.from_domain(s) for s in summaries]
             yield ServerSentEvent(
                 event="sessions",
                 data=ListSessionResponse(sessions=session_items).model_dump_json()
@@ -144,7 +124,7 @@ async def chat(
             message=request.message,
             timestamp=datetime.fromtimestamp(request.timestamp) if request.timestamp else None,
             event_id=request.event_id,
-            attachments=request.attachments
+            attachments=[attachment.to_domain() for attachment in request.attachments] if request.attachments else None
         ):
             logger.debug(f"Received event from chat: {event}")
             sse_event = await EventMapper.event_to_sse_event(event)

--- a/backend/app/interfaces/schemas/auth.py
+++ b/backend/app/interfaces/schemas/auth.py
@@ -150,7 +150,7 @@ class UserResponse(BaseModel):
     last_login_at: Optional[datetime] = None
     
     @staticmethod
-    def from_user(user) -> 'UserResponse':
+    def from_domain(user) -> 'UserResponse':
         """Convert user domain model to response schema"""
         return UserResponse(
             id=user.id,

--- a/backend/app/interfaces/schemas/claw.py
+++ b/backend/app/interfaces/schemas/claw.py
@@ -16,7 +16,7 @@ class ClawResponse(BaseModel):
     updated_at: datetime
 
     @staticmethod
-    def from_claw(claw) -> 'ClawResponse':
+    def from_domain(claw) -> 'ClawResponse':
         return ClawResponse(
             id=claw.id,
             user_id=claw.user_id,

--- a/backend/app/interfaces/schemas/event.py
+++ b/backend/app/interfaces/schemas/event.py
@@ -1,8 +1,7 @@
-from pydantic import BaseModel, Field, TypeAdapter
+from pydantic import BaseModel, Field
 from typing import Any, Union, Literal, Dict, Optional, List, Self, Type
 from datetime import datetime
-from dataclasses import dataclass
-from app.domain.models.plan import ExecutionStatus, Step
+from app.domain.models.plan import ExecutionStatus
 from app.interfaces.schemas.file import FileInfoResponse
 from app.domain.models.event import ToolStatus, ToolContent, BrowserToolContent
 from app.domain.models.event import (
@@ -51,7 +50,7 @@ class BaseSSEEvent(BaseModel):
 
     @classmethod
     def from_event(cls, event: AgentEvent) -> Self:
-        data_class: Type[BaseEventData] = cls.__annotations__.get('data', BaseEventData)
+        data_class: Type[BaseEventData] = cls.model_fields["data"].annotation or BaseEventData
         return cls(
             event=event.type,
             data=data_class.from_event(event)
@@ -73,7 +72,7 @@ class MessageSSEEvent(BaseSSEEvent):
                 **BaseEventData.base_event_data(event),
                 role=event.role,
                 content=event.message,
-                attachments=[await FileInfoResponse.from_file_info(attachment) for attachment in event.attachments] if event.attachments else None
+                attachments=[await FileInfoResponse.from_domain(attachment) for attachment in event.attachments] if event.attachments else None
             )
         )
 
@@ -173,7 +172,6 @@ class CommonSSEEvent(BaseSSEEvent):
     data: CommonEventData
 
 AgentSSEEvent = Union[
-    CommonEventData,
     PlanSSEEvent,
     MessageSSEEvent,
     TitleSSEEvent,
@@ -182,80 +180,37 @@ AgentSSEEvent = Union[
     DoneSSEEvent,
     ErrorSSEEvent,
     WaitSSEEvent,
+    CommonSSEEvent,
 ]
 
-@dataclass
-class EventMapping:
-    """Data class to store event type mapping information"""
-    sse_event_class: Type[BaseEventData]
-    data_class: Type[BaseEventData]
-    event_type: str
+# Explicit registry: domain event type -> SSE event class.
+# Register new event types here when adding them to AgentEvent.
+_EVENT_TYPE_TO_SSE_CLASS: Dict[str, Type[BaseSSEEvent]] = {
+    "plan": PlanSSEEvent,
+    "message": MessageSSEEvent,
+    "title": TitleSSEEvent,
+    "tool": ToolSSEEvent,
+    "step": StepSSEEvent,
+    "done": DoneSSEEvent,
+    "error": ErrorSSEEvent,
+    "wait": WaitSSEEvent,
+}
 
 class EventMapper:
-    """Map AgentEvent to SSEEvent"""
-    
-    _cached_mapping: Optional[Dict[str, EventMapping]] = None
-    
-    @staticmethod
-    def _get_event_type_mapping() -> Dict[str, EventMapping]:
-        """Dynamically get mapping from event type to SSE event class with caching"""
-        if EventMapper._cached_mapping is not None:
-            return EventMapper._cached_mapping
-            
-        from typing import get_args
-        
-        # Get all subclasses of AgentSSEEvent Union
-        sse_event_classes = get_args(AgentSSEEvent)
-        mapping = {}
-        
-        for sse_event_class in sse_event_classes:
-            # Skip base class
-            if sse_event_class == BaseSSEEvent:
-                continue
-                
-            # Get event type
-            if hasattr(sse_event_class, '__annotations__') and 'event' in sse_event_class.__annotations__:
-                event_field = sse_event_class.__annotations__['event']
-                if hasattr(event_field, '__args__') and len(event_field.__args__) > 0:
-                    event_type = event_field.__args__[0]  # Get Literal value
-                    
-                    # Get data class from sse_event_class
-                    data_class = None
-                    if hasattr(sse_event_class, '__annotations__') and 'data' in sse_event_class.__annotations__:
-                        data_class = sse_event_class.__annotations__['data']
-                    
-                    mapping[event_type] = EventMapping(
-                        sse_event_class=sse_event_class,
-                        data_class=data_class,
-                        event_type=event_type
-                    )
-        
-        # Cache the mapping
-        EventMapper._cached_mapping = mapping
-        return mapping
-    
+    """Map AgentEvent (domain) to SSEEvent (wire format)"""
+
     @staticmethod
     async def event_to_sse_event(event: AgentEvent) -> AgentSSEEvent:
-        # Get mapping dynamically
-        event_type_mapping = EventMapper._get_event_type_mapping()
-        
-        # Find matching SSE event class
-        event_mapping = event_type_mapping.get(event.type)
-        
-        if event_mapping:
-            # Prioritize from_event_async class method if exists, otherwise use from_event
-            sse_event_class = event_mapping.sse_event_class
-            if hasattr(sse_event_class, 'from_event_async'):
-                sse_event = await sse_event_class.from_event_async(event)
-            else:
-                sse_event = sse_event_class.from_event(event)
-            return sse_event
-        # If no matching type found, return base event
-        return CommonEventData.from_event(event)
-    
+        sse_event_class = _EVENT_TYPE_TO_SSE_CLASS.get(event.type, CommonSSEEvent)
+        # Classes needing IO (e.g. signed URLs) define from_event_async
+        from_event_async = getattr(sse_event_class, "from_event_async", None)
+        if from_event_async is not None:
+            return await from_event_async(event)
+        return sse_event_class.from_event(event)
+
     @staticmethod
     async def events_to_sse_events(events: List[AgentEvent]) -> List[AgentSSEEvent]:
         """Create SSE event list from event list"""
-        return list(filter(lambda x: x is not None, [
+        return [
             await EventMapper.event_to_sse_event(event) for event in events if event
-        ]))
+        ]

--- a/backend/app/interfaces/schemas/file.py
+++ b/backend/app/interfaces/schemas/file.py
@@ -26,7 +26,7 @@ class FileInfoResponse(BaseModel):
     file_url: Optional[str]
 
     @staticmethod
-    async def from_file_info(file_info: FileInfo) -> "FileInfoResponse":
+    async def from_domain(file_info: FileInfo) -> "FileInfoResponse":
         from app.interfaces.dependencies import get_file_service
         file_service = get_file_service()
         return FileInfoResponse(

--- a/backend/app/interfaces/schemas/session.py
+++ b/backend/app/interfaces/schemas/session.py
@@ -1,14 +1,24 @@
 from pydantic import BaseModel
 from typing import Optional, List
 from app.interfaces.schemas.event import AgentSSEEvent
-from app.domain.models.session import SessionStatus
+from app.domain.models.file import FileInfo
+from app.domain.models.session import SessionStatus, SessionSummary
+
+
+class ChatAttachment(BaseModel):
+    """File attachment reference in a chat request"""
+    file_id: str
+    filename: str
+
+    def to_domain(self) -> FileInfo:
+        return FileInfo(file_id=self.file_id, filename=self.filename)
 
 
 class ChatRequest(BaseModel):
     """Chat request schema"""
     timestamp: Optional[int] = None
     message: Optional[str] = None
-    attachments: Optional[List[dict]] = None
+    attachments: Optional[List[ChatAttachment]] = None
     event_id: Optional[str] = None
 
 
@@ -40,6 +50,18 @@ class ListSessionItem(BaseModel):
     status: SessionStatus
     unread_message_count: int
     is_shared: bool = False
+
+    @staticmethod
+    def from_domain(summary: SessionSummary) -> 'ListSessionItem':
+        return ListSessionItem(
+            session_id=summary.id,
+            title=summary.title,
+            status=summary.status,
+            unread_message_count=summary.unread_message_count,
+            latest_message=summary.latest_message,
+            latest_message_at=int(summary.latest_message_at.timestamp()) if summary.latest_message_at else None,
+            is_shared=summary.is_shared
+        )
 
 
 class ListSessionResponse(BaseModel):

--- a/claw/manus-claw/src/http-server.js
+++ b/claw/manus-claw/src/http-server.js
@@ -185,7 +185,9 @@ export class ManusClawHttpServer {
       return sendJSON(res, 400, { error: 'message is required' });
     }
 
-    const sessionId = session_id || 'manus-main';
+    // Keep in sync with /history and the backend (ClawChatRequest), which
+    // all default to "default" (mapped internally to "manus:default").
+    const sessionId = session_id || 'default';
 
     if (!this.gatewayBridge?.isGatewayReady?.()) {
       return sendJSON(res, 503, { error: 'Gateway not ready' });

--- a/frontend/src/api/agent.ts
+++ b/frontend/src/api/agent.ts
@@ -77,6 +77,15 @@ export const getVNCUrl = async (
 }
 
 /**
+ * File attachment reference sent with a chat request.
+ * Mirrors the backend `ChatAttachment` schema.
+ */
+export interface ChatAttachment {
+  file_id: string;
+  filename: string;
+}
+
+/**
  * Chat with Session (using SSE to receive streaming responses)
  * @returns A function to cancel the SSE connection
  */
@@ -84,7 +93,7 @@ export const chatWithSession = async (
   sessionId: string, 
   message: string = '',
   eventId?: string,
-  attachments?: string[],
+  attachments?: ChatAttachment[],
   callbacks?: SSECallbacks<AgentSSEEvent['data']>
 ): Promise<() => void> => {
   return createSSEConnection<AgentSSEEvent['data']>(

--- a/frontend/src/composables/useAgentEvents.ts
+++ b/frontend/src/composables/useAgentEvents.ts
@@ -1,0 +1,147 @@
+import type { Ref } from 'vue';
+import {
+  Message,
+  MessageContent,
+  ToolContent,
+  StepContent,
+  AttachmentsContent,
+} from '../types/message';
+import {
+  StepEventData,
+  ToolEventData,
+  MessageEventData,
+  ErrorEventData,
+  TitleEventData,
+  PlanEventData,
+  AgentSSEEvent,
+} from '../types/event';
+
+export interface AgentEventState {
+  messages: Ref<Message[]>;
+  title: Ref<string>;
+  plan: Ref<PlanEventData | undefined>;
+  isLoading: Ref<boolean>;
+  lastEventId: Ref<string | undefined>;
+  lastTool: Ref<ToolContent | undefined>;
+  lastNoMessageTool: Ref<ToolContent | undefined>;
+}
+
+export interface AgentEventOptions {
+  /** Called when a non-message tool is created or updated, so the page can surface it (e.g. in the tool panel). */
+  onToolActivity?: (tool: ToolContent) => void;
+}
+
+/**
+ * Shared conversion of agent SSE events into the UI message list.
+ * Used by both ChatPage (live chat) and SharePage (replay).
+ */
+export function useAgentEvents(state: AgentEventState, options: AgentEventOptions = {}) {
+  const { messages, title, plan, isLoading, lastEventId, lastTool, lastNoMessageTool } = state;
+
+  const getLastStep = (): StepContent | undefined => {
+    return messages.value.filter(message => message.type === 'step').pop()?.content as StepContent;
+  };
+
+  const handleMessageEvent = (messageData: MessageEventData) => {
+    messages.value.push({
+      type: messageData.role,
+      content: {
+        ...messageData
+      } as MessageContent,
+    });
+
+    if (messageData.attachments && messageData.attachments.length > 0) {
+      messages.value.push({
+        type: 'attachments',
+        content: {
+          ...messageData
+        } as AttachmentsContent,
+      });
+    }
+  };
+
+  const handleToolEvent = (toolData: ToolEventData) => {
+    const lastStep = getLastStep();
+    const toolContent: ToolContent = {
+      ...toolData
+    };
+    if (lastTool.value && lastTool.value.tool_call_id === toolContent.tool_call_id) {
+      Object.assign(lastTool.value, toolContent);
+    } else {
+      if (lastStep?.status === 'running') {
+        lastStep.tools.push(toolContent);
+      } else {
+        messages.value.push({
+          type: 'tool',
+          content: toolContent,
+        });
+      }
+      lastTool.value = toolContent;
+    }
+    if (toolContent.name !== 'message') {
+      lastNoMessageTool.value = toolContent;
+      options.onToolActivity?.(toolContent);
+    }
+  };
+
+  const handleStepEvent = (stepData: StepEventData) => {
+    const lastStep = getLastStep();
+    if (stepData.status === 'running') {
+      messages.value.push({
+        type: 'step',
+        content: {
+          ...stepData,
+          tools: []
+        } as StepContent,
+      });
+    } else if (stepData.status === 'completed') {
+      if (lastStep) {
+        lastStep.status = stepData.status;
+      }
+    } else if (stepData.status === 'failed') {
+      isLoading.value = false;
+    }
+  };
+
+  const handleErrorEvent = (errorData: ErrorEventData) => {
+    isLoading.value = false;
+    messages.value.push({
+      type: 'assistant',
+      content: {
+        content: errorData.error,
+        timestamp: errorData.timestamp
+      } as MessageContent,
+    });
+  };
+
+  const handleTitleEvent = (titleData: TitleEventData) => {
+    title.value = titleData.title;
+  };
+
+  const handlePlanEvent = (planData: PlanEventData) => {
+    plan.value = planData;
+  };
+
+  const handleEvent = (event: AgentSSEEvent) => {
+    if (event.event === 'message') {
+      handleMessageEvent(event.data as MessageEventData);
+    } else if (event.event === 'tool') {
+      handleToolEvent(event.data as ToolEventData);
+    } else if (event.event === 'step') {
+      handleStepEvent(event.data as StepEventData);
+    } else if (event.event === 'done') {
+      // Loading state is cleared when the SSE connection closes
+    } else if (event.event === 'wait') {
+      // TODO: handle wait event
+    } else if (event.event === 'error') {
+      handleErrorEvent(event.data as ErrorEventData);
+    } else if (event.event === 'title') {
+      handleTitleEvent(event.data as TitleEventData);
+    } else if (event.event === 'plan') {
+      handlePlanEvent(event.data as PlanEventData);
+    }
+    lastEventId.value = event.data.event_id;
+  };
+
+  return { handleEvent };
+}

--- a/frontend/src/pages/ChatPage.vue
+++ b/frontend/src/pages/ChatPage.vue
@@ -135,16 +135,9 @@ import { useI18n } from 'vue-i18n';
 import ChatBox from '../components/ChatBox.vue';
 import ChatMessage from '../components/ChatMessage.vue';
 import * as agentApi from '../api/agent';
-import { Message, MessageContent, ToolContent, StepContent, AttachmentsContent, isConsecutiveAssistant } from '../types/message';
-import {
-  StepEventData,
-  ToolEventData,
-  MessageEventData,
-  ErrorEventData,
-  TitleEventData,
-  PlanEventData,
-  AgentSSEEvent,
-} from '../types/event';
+import { Message, MessageContent, ToolContent, AttachmentsContent, isConsecutiveAssistant } from '../types/message';
+import { PlanEventData, AgentSSEEvent } from '../types/event';
+import { useAgentEvents } from '../composables/useAgentEvents';
 import ToolPanel from '../components/ToolPanel.vue'
 import PlanPanel from '../components/PlanPanel.vue';
 import { ArrowDown, FileSearch, PanelLeft, Lock, Globe, Link, Check } from 'lucide-vue-next';
@@ -217,6 +210,18 @@ const simpleBarRef = ref<InstanceType<typeof SimpleBar>>();
 const observerRef = ref<HTMLDivElement>();
 const chatContainerRef = ref<HTMLDivElement>();
 
+// Shared SSE event -> message list conversion
+const { handleEvent } = useAgentEvents(
+  { messages, title, plan, isLoading, lastEventId, lastTool, lastNoMessageTool },
+  {
+    onToolActivity: (tool: ToolContent) => {
+      if (realTime.value) {
+        toolPanel.value?.showToolPanel(tool, true);
+      }
+    },
+  }
+);
+
 // Reset all refs to their initial values
 const resetState = () => {
   // Cancel any existing chat connection
@@ -237,120 +242,6 @@ watch(messages, async () => {
 }, { deep: true });
 
 
-
-const getLastStep = (): StepContent | undefined => {
-  return messages.value.filter(message => message.type === 'step').pop()?.content as StepContent;
-}
-
-// Handle message event
-const handleMessageEvent = (messageData: MessageEventData) => {
-  messages.value.push({
-    type: messageData.role,
-    content: {
-      ...messageData
-    } as MessageContent,
-  });
-
-  if (messageData.attachments?.length > 0) {
-    messages.value.push({
-      type: 'attachments',
-      content: {
-        ...messageData
-      } as AttachmentsContent,
-    });
-  }
-}
-
-// Handle tool event
-const handleToolEvent = (toolData: ToolEventData) => {
-  const lastStep = getLastStep();
-  let toolContent: ToolContent = {
-    ...toolData
-  }
-  if (lastTool.value && lastTool.value.tool_call_id === toolContent.tool_call_id) {
-    Object.assign(lastTool.value, toolContent);
-  } else {
-    if (lastStep?.status === 'running') {
-      lastStep.tools.push(toolContent);
-    } else {
-      messages.value.push({
-        type: 'tool',
-        content: toolContent,
-      });
-    }
-    lastTool.value = toolContent;
-  }
-  if (toolContent.name !== 'message') {
-    lastNoMessageTool.value = toolContent;
-    if (realTime.value) {
-      toolPanel.value?.showToolPanel(toolContent, true);
-    }
-  }
-}
-
-// Handle step event
-const handleStepEvent = (stepData: StepEventData) => {
-  const lastStep = getLastStep();
-  if (stepData.status === 'running') {
-    messages.value.push({
-      type: 'step',
-      content: {
-        ...stepData,
-        tools: []
-      } as StepContent,
-    });
-  } else if (stepData.status === 'completed') {
-    if (lastStep) {
-      lastStep.status = stepData.status;
-    }
-  } else if (stepData.status === 'failed') {
-    isLoading.value = false;
-  }
-}
-
-// Handle error event
-const handleErrorEvent = (errorData: ErrorEventData) => {
-  isLoading.value = false;
-  messages.value.push({
-    type: 'assistant',
-    content: {
-      content: errorData.error,
-      timestamp: errorData.timestamp
-    } as MessageContent,
-  });
-}
-
-// Handle title event
-const handleTitleEvent = (titleData: TitleEventData) => {
-  title.value = titleData.title;
-}
-
-// Handle plan event
-const handlePlanEvent = (planData: PlanEventData) => {
-  plan.value = planData;
-}
-
-// Main event handler function
-const handleEvent = (event: AgentSSEEvent) => {
-  if (event.event === 'message') {
-    handleMessageEvent(event.data as MessageEventData);
-  } else if (event.event === 'tool') {
-    handleToolEvent(event.data as ToolEventData);
-  } else if (event.event === 'step') {
-    handleStepEvent(event.data as StepEventData);
-  } else if (event.event === 'done') {
-    //isLoading.value = false;
-  } else if (event.event === 'wait') {
-    // TODO: handle wait event
-  } else if (event.event === 'error') {
-    handleErrorEvent(event.data as ErrorEventData);
-  } else if (event.event === 'title') {
-    handleTitleEvent(event.data as TitleEventData);
-  } else if (event.event === 'plan') {
-    handlePlanEvent(event.data as PlanEventData);
-  }
-  lastEventId.value = event.data.event_id;
-}
 
 const handleSubmit = () => {
   chat(inputMessage.value, attachments.value);

--- a/frontend/src/pages/SharePage.vue
+++ b/frontend/src/pages/SharePage.vue
@@ -97,16 +97,9 @@ import { useRouter } from 'vue-router';
 import { useI18n } from 'vue-i18n';
 import ChatMessage from '../components/ChatMessage.vue';
 import * as agentApi from '../api/agent';
-import { Message, MessageContent, ToolContent, StepContent, AttachmentsContent, isConsecutiveAssistant } from '../types/message';
-import {
-  StepEventData,
-  ToolEventData,
-  MessageEventData,
-  ErrorEventData,
-  TitleEventData,
-  PlanEventData,
-  AgentSSEEvent,
-} from '../types/event';
+import { Message, ToolContent, isConsecutiveAssistant } from '../types/message';
+import { PlanEventData } from '../types/event';
+import { useAgentEvents } from '../composables/useAgentEvents';
 import ToolPanel from '../components/ToolPanel.vue'
 import PlanPanel from '../components/PlanPanel.vue';
 import { ArrowDown, FileSearch, Link, Bot } from 'lucide-vue-next';
@@ -172,6 +165,18 @@ const toolPanel = ref<InstanceType<typeof ToolPanel>>()
 const simpleBarRef = ref<InstanceType<typeof SimpleBar>>();
 let countdownTimer: number | null = null;
 
+// Shared SSE event -> message list conversion
+const { handleEvent } = useAgentEvents(
+  { messages, title, plan, isLoading, lastEventId, lastTool, lastNoMessageTool },
+  {
+    onToolActivity: (tool: ToolContent) => {
+      if (realTime.value) {
+        toolPanel.value?.showToolPanel(tool, false);
+      }
+    },
+  }
+);
+
 // Watch message changes and automatically scroll to bottom
 watch(messages, async () => {
   await nextTick();
@@ -181,120 +186,6 @@ watch(messages, async () => {
 }, { deep: true });
 
 
-
-const getLastStep = (): StepContent | undefined => {
-  return messages.value.filter(message => message.type === 'step').pop()?.content as StepContent;
-}
-
-// Handle message event
-const handleMessageEvent = (messageData: MessageEventData) => {
-  messages.value.push({
-    type: messageData.role,
-    content: {
-      ...messageData
-    } as MessageContent,
-  });
-
-  if (messageData.attachments?.length > 0) {
-    messages.value.push({
-      type: 'attachments',
-      content: {
-        ...messageData
-      } as AttachmentsContent,
-    });
-  }
-}
-
-// Handle tool event
-const handleToolEvent = (toolData: ToolEventData) => {
-  const lastStep = getLastStep();
-  let toolContent: ToolContent = {
-    ...toolData
-  }
-  if (lastTool.value && lastTool.value.tool_call_id === toolContent.tool_call_id) {
-    Object.assign(lastTool.value, toolContent);
-  } else {
-    if (lastStep?.status === 'running') {
-      lastStep.tools.push(toolContent);
-    } else {
-      messages.value.push({
-        type: 'tool',
-        content: toolContent,
-      });
-    }
-    lastTool.value = toolContent;
-  }
-  if (toolContent.name !== 'message') {
-    lastNoMessageTool.value = toolContent;
-    if (realTime.value) {
-      toolPanel.value?.showToolPanel(toolContent, false);
-    }
-  }
-}
-
-// Handle step event
-const handleStepEvent = (stepData: StepEventData) => {
-  const lastStep = getLastStep();
-  if (stepData.status === 'running') {
-    messages.value.push({
-      type: 'step',
-      content: {
-        ...stepData,
-        tools: []
-      } as StepContent,
-    });
-  } else if (stepData.status === 'completed') {
-    if (lastStep) {
-      lastStep.status = stepData.status;
-    }
-  } else if (stepData.status === 'failed') {
-    isLoading.value = false;
-  }
-}
-
-// Handle error event
-const handleErrorEvent = (errorData: ErrorEventData) => {
-  isLoading.value = false;
-  messages.value.push({
-    type: 'assistant',
-    content: {
-      content: errorData.error,
-      timestamp: errorData.timestamp
-    } as MessageContent,
-  });
-}
-
-// Handle title event
-const handleTitleEvent = (titleData: TitleEventData) => {
-  title.value = titleData.title;
-}
-
-// Handle plan event
-const handlePlanEvent = (planData: PlanEventData) => {
-  plan.value = planData;
-}
-
-// Main event handler function
-const handleEvent = (event: AgentSSEEvent) => {
-  if (event.event === 'message') {
-    handleMessageEvent(event.data as MessageEventData);
-  } else if (event.event === 'tool') {
-    handleToolEvent(event.data as ToolEventData);
-  } else if (event.event === 'step') {
-    handleStepEvent(event.data as StepEventData);
-  } else if (event.event === 'done') {
-    //isLoading.value = false;
-  } else if (event.event === 'wait') {
-    // TODO: handle wait event
-  } else if (event.event === 'error') {
-    handleErrorEvent(event.data as ErrorEventData);
-  } else if (event.event === 'title') {
-    handleTitleEvent(event.data as TitleEventData);
-  } else if (event.event === 'plan') {
-    handlePlanEvent(event.data as PlanEventData);
-  }
-  lastEventId.value = event.data.event_id;
-}
 
 // Reset all refs to their initial values
 const resetState = () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# 梳理数据转换逻辑

对整个代码库中最乱的几处数据转换做集中清理,不改变任何对外行为(wire format 不变)。

## 改动内容

### 后端:Event → SSE 转换 (`interfaces/schemas/event.py`)
- `EventMapper` 从"运行时反射解析 `__annotations__` 里的 Literal + 缓存"改为**显式注册表** `_EVENT_TYPE_TO_SSE_CLASS`,新增事件类型时直接在注册表登记即可
- 修复 `AgentSSEEvent` Union 类型错误:移除混入的 data 类 `CommonEventData`,补上 `CommonSSEEvent`
- 修复未知事件的 fallback:原来返回 `CommonEventData`(没有 `.event`/`.data`,一旦命中会在 SSE 路由崩溃),现在返回 `CommonSSEEvent`
- 删除无用的 `EventMapping` dataclass 和死代码
- `BaseSSEEvent.from_event` 改用 `model_fields` 解析 data 类型(正确处理继承)

### 后端:统一 Domain → Schema 转换命名
- `UserResponse.from_user` / `ClawResponse.from_claw` / `FileInfoResponse.from_file_info` 统一重命名为 **`from_domain`**,与 `ClawMessageSchema.from_domain` 等保持一致

### 后端:API → Domain 反向转换类型化
- `ChatRequest.attachments` 从 `List[dict]` 改为类型化的 `ChatAttachment`(带 `to_domain()`),`dict["file_id"]` 的手工取值从 domain 层移除,`chat()` 调用链签名改为 `List[FileInfo]`
- 新增 `ListSessionItem.from_domain(summary)`,消除 `session_routes.py` 中两处重复的手工字段映射(含 datetime→int 时间戳转换)

### 前端:消除 ChatPage/SharePage 的重复转换
- 新增 `composables/useAgentEvents.ts`,把两个页面几乎完全相同的 120+ 行 SSE 事件 → `Message[]` 转换逻辑(message/tool/step/error/title/plan 处理、步骤内工具聚合、tool_call 更新合并)抽取为共享 composable,页面差异(工具面板展示行为)通过 `onToolActivity` 回调注入
- `chatWithSession` 的 `attachments` 参数类型从错误的 `string[]` 修正为 `ChatAttachment[]`(修复了一个预先存在的 type-check 报错)

### Claw:统一 session 默认值
- `manus-claw/src/http-server.js` 的 `/chat` 默认 session 从 `'manus-main'` 改为 `'default'`,与 `/history`、后端 `ClawChatRequest`、WebSocket 路由一致(此前不带 session_id 的 chat 会写入 `manus:manus-main`,而 history 读取 `manus:default`,历史对不上)

## 测试

- ✅ `cd backend && uv run pytest`(72 passed;16 failed 为 main 基线上同样存在的预先存在失败,已对照验证)
- ✅ EventMapper 冒烟测试:8 种事件类型全部正确映射为对应 SSE 类
- ✅ `cd frontend && npm run type-check`(剩余报错与 main 基线一致,均为预先存在;本 PR 还顺带修复了 ChatPage 的一个基线报错)
- ✅ `cd frontend && npm run build`
- ✅ `node --check claw/manus-claw/src/http-server.js`
- ✅ GUI 手动测试(mockserver):首页发消息 → 计划/步骤/工具卡/附件全部正常渲染 → 刷新后历史恢复 → 分享 → 分享页渐进式回放,内容与聊天页一致
- ✅ curl 验证类型化附件链路:上传文件 → 带 attachments 的 chat → GET session 中用户消息 attachments 正确带出 signed URL

[chat_history_and_share_replay_demo.mp4](https://cursor.com/agents/bc-aeafc164-52ed-4f5e-8168-4a51538dda98/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fchat_history_and_share_replay_demo.mp4)

[聊天页历史渲染](https://cursor.com/agents/bc-aeafc164-52ed-4f5e-8168-4a51538dda98/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshot_chat_page_history.webp)
[分享回放完成](https://cursor.com/agents/bc-aeafc164-52ed-4f5e-8168-4a51538dda98/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshot_share_replay_completed.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-aeafc164-52ed-4f5e-8168-4a51538dda98"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-aeafc164-52ed-4f5e-8168-4a51538dda98"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

