### PR TITLE
feat(backend): add application DTO layer for sandbox views

### DIFF
--- a/backend/app/application/dto/__init__.py
+++ b/backend/app/application/dto/__init__.py
@@ -1,0 +1,3 @@
+from app.application.dto.sandbox import ConsoleRecordDto, FileViewDto, ShellViewDto
+
+__all__ = ["ConsoleRecordDto", "FileViewDto", "ShellViewDto"]

--- a/backend/app/application/dto/sandbox.py
+++ b/backend/app/application/dto/sandbox.py
@@ -1,6 +1,9 @@
-from typing import Any, Mapping, Optional
+from typing import Optional
 
 from pydantic import BaseModel
+
+from app.domain.models.sandbox.file import FileReadResult
+from app.domain.models.sandbox.shell import ShellViewResult
 
 
 class ConsoleRecordDto(BaseModel):
@@ -17,16 +20,14 @@ class ShellViewDto(BaseModel):
     console: Optional[list[ConsoleRecordDto]] = None
 
     @classmethod
-    def from_tool_data(cls, data: Optional[Mapping[str, Any]]) -> "ShellViewDto":
-        """Build the DTO from a sandbox ToolResult payload.
+    def from_result(cls, result: ShellViewResult) -> "ShellViewDto":
+        """Build the DTO from the strongly-typed sandbox shell-view result.
 
-        Field names mirror the sandbox shell-view result, so Pydantic
-        validation handles the mapping (including the nested console
-        records) directly.
+        The dict-to-model boundary lives in ``ShellViewResult`` (the domain
+        anti-corruption layer for the sandbox wire format); this factory only
+        projects that domain value object onto the application DTO.
         """
-        if not data:
-            raise ValueError("shell view result is empty")
-        return cls.model_validate(data)
+        return cls.model_validate(result, from_attributes=True)
 
 
 class FileViewDto(BaseModel):
@@ -36,8 +37,6 @@ class FileViewDto(BaseModel):
     file: str
 
     @classmethod
-    def from_tool_data(cls, data: Optional[Mapping[str, Any]]) -> "FileViewDto":
-        """Build the DTO from a sandbox ToolResult payload."""
-        if not data:
-            raise ValueError("file view result is empty")
-        return cls.model_validate(data)
+    def from_result(cls, result: FileReadResult) -> "FileViewDto":
+        """Build the DTO from the strongly-typed sandbox file-read result."""
+        return cls.model_validate(result, from_attributes=True)

--- a/backend/app/application/dto/sandbox.py
+++ b/backend/app/application/dto/sandbox.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional
+from typing import Any, Mapping, Optional
 
 from pydantic import BaseModel
 
@@ -14,22 +14,19 @@ class ShellViewDto(BaseModel):
 
     output: str
     session_id: str
-    console: Optional[List[ConsoleRecordDto]] = None
+    console: Optional[list[ConsoleRecordDto]] = None
 
     @classmethod
-    def from_tool_data(cls, data: Dict[str, Any]) -> "ShellViewDto":
-        console = data.get("console")
-        console_dtos = None
-        if console is not None:
-            console_dtos = [
-                ConsoleRecordDto(**record) if isinstance(record, dict) else record
-                for record in console
-            ]
-        return cls(
-            output=data["output"],
-            session_id=data["session_id"],
-            console=console_dtos,
-        )
+    def from_tool_data(cls, data: Optional[Mapping[str, Any]]) -> "ShellViewDto":
+        """Build the DTO from a sandbox ToolResult payload.
+
+        Field names mirror the sandbox shell-view result, so Pydantic
+        validation handles the mapping (including the nested console
+        records) directly.
+        """
+        if not data:
+            raise ValueError("shell view result is empty")
+        return cls.model_validate(data)
 
 
 class FileViewDto(BaseModel):
@@ -39,5 +36,8 @@ class FileViewDto(BaseModel):
     file: str
 
     @classmethod
-    def from_tool_data(cls, data: Dict[str, Any]) -> "FileViewDto":
-        return cls(content=data["content"], file=data["file"])
+    def from_tool_data(cls, data: Optional[Mapping[str, Any]]) -> "FileViewDto":
+        """Build the DTO from a sandbox ToolResult payload."""
+        if not data:
+            raise ValueError("file view result is empty")
+        return cls.model_validate(data)

--- a/backend/app/application/dto/sandbox.py
+++ b/backend/app/application/dto/sandbox.py
@@ -1,0 +1,43 @@
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel
+
+
+class ConsoleRecordDto(BaseModel):
+    ps1: str
+    command: str
+    output: str = ""
+
+
+class ShellViewDto(BaseModel):
+    """Application output for the shell-view use case."""
+
+    output: str
+    session_id: str
+    console: Optional[List[ConsoleRecordDto]] = None
+
+    @classmethod
+    def from_tool_data(cls, data: Dict[str, Any]) -> "ShellViewDto":
+        console = data.get("console")
+        console_dtos = None
+        if console is not None:
+            console_dtos = [
+                ConsoleRecordDto(**record) if isinstance(record, dict) else record
+                for record in console
+            ]
+        return cls(
+            output=data["output"],
+            session_id=data["session_id"],
+            console=console_dtos,
+        )
+
+
+class FileViewDto(BaseModel):
+    """Application output for the file-view use case."""
+
+    content: str
+    file: str
+
+    @classmethod
+    def from_tool_data(cls, data: Dict[str, Any]) -> "FileViewDto":
+        return cls(content=data["content"], file=data["file"])

--- a/backend/app/application/services/agent_service.py
+++ b/backend/app/application/services/agent_service.py
@@ -5,6 +5,8 @@ from app.domain.models.session import Session, SessionSummary
 from app.domain.repositories.session_repository import SessionRepository
 
 from app.application.dto.sandbox import FileViewDto, ShellViewDto
+from app.domain.models.sandbox.file import FileReadResult
+from app.domain.models.sandbox.shell import ShellViewResult
 from app.domain.models.agent import Agent
 from app.domain.services.agent_domain_service import AgentDomainService
 from app.domain.models.event import AgentEvent
@@ -162,7 +164,7 @@ class AgentService:
         
         result = await sandbox.view_shell(shell_session_id, console=True)
         if result.success:
-            return ShellViewDto.from_tool_data(result.data)
+            return ShellViewDto.from_result(ShellViewResult.model_validate(result.data))
         else:
             raise RuntimeError(f"Failed to get shell output: {result.message}")
 
@@ -203,7 +205,7 @@ class AgentService:
         
         result = await sandbox.file_read(file_path)
         if result.success:
-            return FileViewDto.from_tool_data(result.data)
+            return FileViewDto.from_result(FileReadResult.model_validate(result.data))
         else:
             raise RuntimeError(f"Failed to read file: {result.message}")
     

--- a/backend/app/application/services/agent_service.py
+++ b/backend/app/application/services/agent_service.py
@@ -4,13 +4,11 @@ from datetime import datetime
 from app.domain.models.session import Session, SessionSummary
 from app.domain.repositories.session_repository import SessionRepository
 
-from app.interfaces.schemas.session import ShellViewResponse
-from app.interfaces.schemas.file import FileViewResponse
+from app.application.dto.sandbox import FileViewDto, ShellViewDto
 from app.domain.models.agent import Agent
 from app.domain.services.agent_domain_service import AgentDomainService
 from app.domain.models.event import AgentEvent
 from typing import Type
-from app.domain.models.agent import Agent
 from app.domain.external.sandbox import Sandbox
 from app.domain.external.search import SearchEngine
 from app.domain.external.file import FileStorage
@@ -146,7 +144,7 @@ class AgentService:
         await self._agent_domain_service.shutdown()
         logger.info("All agents closed successfully")
 
-    async def shell_view(self, session_id: str, shell_session_id: str, user_id: str) -> ShellViewResponse:
+    async def shell_view(self, session_id: str, shell_session_id: str, user_id: str) -> ShellViewDto:
         """View shell session output, ensuring session belongs to the user"""
         logger.info(f"Getting shell view for session {session_id} for user {user_id}")
         session = await self._session_repository.find_by_id_and_user_id(session_id, user_id)
@@ -164,7 +162,7 @@ class AgentService:
         
         result = await sandbox.view_shell(shell_session_id, console=True)
         if result.success:
-            return ShellViewResponse(**result.data)
+            return ShellViewDto.from_tool_data(result.data)
         else:
             raise RuntimeError(f"Failed to get shell output: {result.message}")
 
@@ -187,7 +185,7 @@ class AgentService:
         
         return sandbox.vnc_url
 
-    async def file_view(self, session_id: str, file_path: str, user_id: str) -> FileViewResponse:
+    async def file_view(self, session_id: str, file_path: str, user_id: str) -> FileViewDto:
         """View file content, ensuring session belongs to the user"""
         logger.info(f"Getting file view for session {session_id} for user {user_id}")
         session = await self._session_repository.find_by_id_and_user_id(session_id, user_id)
@@ -205,7 +203,7 @@ class AgentService:
         
         result = await sandbox.file_read(file_path)
         if result.success:
-            return FileViewResponse(**result.data)
+            return FileViewDto.from_tool_data(result.data)
         else:
             raise RuntimeError(f"Failed to read file: {result.message}")
     

--- a/backend/app/interfaces/api/session_routes.py
+++ b/backend/app/interfaces/api/session_routes.py
@@ -21,6 +21,7 @@ from app.interfaces.schemas.session import (
 from app.interfaces.schemas.file import FileViewRequest, FileViewResponse
 from app.interfaces.schemas.resource import AccessTokenRequest, SignedUrlResponse
 from app.interfaces.schemas.event import EventMapper
+from app.interfaces.mappers.sandbox_mapper import to_file_view_response, to_shell_view_response
 from app.domain.models.file import FileInfo
 from app.domain.models.user import User
 
@@ -176,7 +177,7 @@ async def view_shell(
         APIResponse with shell output
     """
     result = await agent_service.shell_view(session_id, request.session_id, current_user.id)
-    return APIResponse.success(result)
+    return APIResponse.success(to_shell_view_response(result))
 
 @router.post("/{session_id}/file")
 async def view_file(
@@ -197,7 +198,7 @@ async def view_file(
         APIResponse with file content
     """
     result = await agent_service.file_view(session_id, request.file, current_user.id)
-    return APIResponse.success(result)
+    return APIResponse.success(to_file_view_response(result))
 
 @router.websocket("/{session_id}/vnc")
 async def vnc_websocket(

--- a/backend/app/interfaces/mappers/__init__.py
+++ b/backend/app/interfaces/mappers/__init__.py
@@ -1,0 +1,3 @@
+from app.interfaces.mappers.sandbox_mapper import to_file_view_response, to_shell_view_response
+
+__all__ = ["to_file_view_response", "to_shell_view_response"]

--- a/backend/app/interfaces/mappers/sandbox_mapper.py
+++ b/backend/app/interfaces/mappers/sandbox_mapper.py
@@ -1,0 +1,21 @@
+from app.application.dto.sandbox import FileViewDto, ShellViewDto
+from app.interfaces.schemas.file import FileViewResponse
+from app.interfaces.schemas.session import ConsoleRecord, ShellViewResponse
+
+
+def to_shell_view_response(dto: ShellViewDto) -> ShellViewResponse:
+    console = None
+    if dto.console is not None:
+        console = [
+            ConsoleRecord(ps1=record.ps1, command=record.command, output=record.output)
+            for record in dto.console
+        ]
+    return ShellViewResponse(
+        output=dto.output,
+        session_id=dto.session_id,
+        console=console,
+    )
+
+
+def to_file_view_response(dto: FileViewDto) -> FileViewResponse:
+    return FileViewResponse(content=dto.content, file=dto.file)

--- a/backend/pytest.ini
+++ b/backend/pytest.ini
@@ -17,6 +17,7 @@ addopts =
     --durations=10
 markers =
     file_api: marks tests for file API
+    integration: marks tests that require the docker dev stack
 filterwarnings =
     ignore::DeprecationWarning
     ignore::PendingDeprecationWarning 

--- a/backend/tests/test_agent_service_sandbox_views.py
+++ b/backend/tests/test_agent_service_sandbox_views.py
@@ -1,0 +1,83 @@
+"""Application-layer tests for sandbox view use cases (mocked sandbox)."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.application.dto.sandbox import FileViewDto, ShellViewDto
+from app.application.services.agent_service import AgentService
+from app.domain.models.session import Session
+from app.domain.models.tool_result import ToolResult
+
+
+def _make_agent_service(
+    session: Session,
+    sandbox: AsyncMock,
+) -> AgentService:
+    session_repository = AsyncMock()
+    session_repository.find_by_id_and_user_id.return_value = session
+
+    sandbox_cls = MagicMock()
+    sandbox_cls.get = AsyncMock(return_value=sandbox)
+
+    return AgentService(
+        agent_repository=AsyncMock(),
+        session_repository=session_repository,
+        sandbox_cls=sandbox_cls,
+        task_cls=MagicMock(),
+        file_storage=AsyncMock(),
+        mcp_repository=AsyncMock(),
+        llm=AsyncMock(),
+    )
+
+
+@pytest.mark.asyncio
+async def test_shell_view_returns_dto_from_sandbox_result():
+    session = Session(agent_id="a1", user_id="u1", sandbox_id="sb-1")
+    sandbox = AsyncMock()
+    sandbox.view_shell.return_value = ToolResult(
+        success=True,
+        data={
+            "output": "hello world",
+            "session_id": "shell-42",
+            "console": [{"ps1": "$", "command": "echo hi", "output": "hi\n"}],
+        },
+    )
+    service = _make_agent_service(session, sandbox)
+
+    dto = await service.shell_view("sess-1", "shell-42", "u1")
+
+    assert isinstance(dto, ShellViewDto)
+    assert dto.output == "hello world"
+    assert dto.session_id == "shell-42"
+    assert dto.console[0].command == "echo hi"
+    sandbox.view_shell.assert_awaited_once_with("shell-42", console=True)
+
+
+@pytest.mark.asyncio
+async def test_file_view_returns_dto_from_sandbox_result():
+    session = Session(agent_id="a1", user_id="u1", sandbox_id="sb-1")
+    sandbox = AsyncMock()
+    sandbox.file_read.return_value = ToolResult(
+        success=True,
+        data={"content": "file body", "file": "/tmp/demo.txt"},
+    )
+    service = _make_agent_service(session, sandbox)
+
+    dto = await service.file_view("sess-1", "/tmp/demo.txt", "u1")
+
+    assert isinstance(dto, FileViewDto)
+    assert dto.content == "file body"
+    assert dto.file == "/tmp/demo.txt"
+    sandbox.file_read.assert_awaited_once_with("/tmp/demo.txt")
+
+
+@pytest.mark.asyncio
+async def test_shell_view_raises_when_sandbox_call_fails():
+    session = Session(agent_id="a1", user_id="u1", sandbox_id="sb-1")
+    sandbox = AsyncMock()
+    sandbox.view_shell.return_value = ToolResult(success=False, message="shell gone")
+    service = _make_agent_service(session, sandbox)
+
+    with pytest.raises(RuntimeError, match="Failed to get shell output"):
+        await service.shell_view("sess-1", "shell-42", "u1")

--- a/backend/tests/test_application_dto.py
+++ b/backend/tests/test_application_dto.py
@@ -1,0 +1,92 @@
+"""Unit tests for application DTOs and sandbox mappers."""
+
+import pytest
+from pydantic import ValidationError
+
+from app.application.dto.sandbox import ConsoleRecordDto, FileViewDto, ShellViewDto
+from app.domain.models.sandbox.file import FileReadResult
+from app.domain.models.sandbox.shell import ShellViewResult
+from app.interfaces.mappers.sandbox_mapper import to_file_view_response, to_shell_view_response
+
+
+class TestShellViewDto:
+    def test_from_result_with_console(self):
+        domain = ShellViewResult(
+            output="hello",
+            session_id="shell-1",
+            console=[
+                {"ps1": "$", "command": "ls", "output": "a.txt"},
+            ],
+        )
+        dto = ShellViewDto.from_result(domain)
+
+        assert dto.output == "hello"
+        assert dto.session_id == "shell-1"
+        assert len(dto.console) == 1
+        assert isinstance(dto.console[0], ConsoleRecordDto)
+        assert dto.console[0].command == "ls"
+
+    def test_from_result_without_console(self):
+        domain = ShellViewResult(output="x", session_id="shell-2")
+        dto = ShellViewDto.from_result(domain)
+
+        assert dto.console is None
+
+    def test_from_domain_model_validate_wire_payload(self):
+        raw = {
+            "output": "hi",
+            "session_id": "s1",
+            "console": [{"ps1": "#", "command": "pwd", "output": "/tmp"}],
+            "extra_field": "ignored",
+        }
+        domain = ShellViewResult.model_validate(raw)
+        dto = ShellViewDto.from_result(domain)
+
+        assert dto.output == "hi"
+        assert dto.console[0].output == "/tmp"
+
+    def test_domain_model_rejects_missing_required_fields(self):
+        with pytest.raises(ValidationError):
+            ShellViewResult.model_validate({"output": "only-output"})
+
+
+class TestFileViewDto:
+    def test_from_result(self):
+        domain = FileReadResult(content="print('hi')", file="/workspace/main.py")
+        dto = FileViewDto.from_result(domain)
+
+        assert dto.content == "print('hi')"
+        assert dto.file == "/workspace/main.py"
+
+
+class TestSandboxMapper:
+    def test_to_shell_view_response(self):
+        dto = ShellViewDto(
+            output="out",
+            session_id="sid",
+            console=[ConsoleRecordDto(ps1="$", command="echo hi", output="hi\n")],
+        )
+        response = to_shell_view_response(dto)
+
+        assert response.output == "out"
+        assert response.session_id == "sid"
+        assert response.console[0].command == "echo hi"
+
+    def test_to_file_view_response(self):
+        dto = FileViewDto(content="body", file="/etc/hosts")
+        response = to_file_view_response(dto)
+
+        assert response.content == "body"
+        assert response.file == "/etc/hosts"
+
+    def test_end_to_end_shell_wire_to_api_schema(self):
+        wire = {
+            "output": "done",
+            "session_id": "wire-1",
+            "console": [{"ps1": ">", "command": "date", "output": "2026"}],
+        }
+        dto = ShellViewDto.from_result(ShellViewResult.model_validate(wire))
+        api = to_shell_view_response(dto)
+
+        assert api.output == "done"
+        assert api.console[0].output == "2026"

--- a/backend/tests/test_session_sandbox_views_integration.py
+++ b/backend/tests/test_session_sandbox_views_integration.py
@@ -1,0 +1,140 @@
+"""
+Integration tests for session shell/file view API (DTO -> API response chain).
+
+Requires a running dev stack:
+  ./dev.sh up -d mongodb redis sandbox mockserver backend
+
+These tests hit http://localhost:8000 and prepare sandbox state via
+http://localhost:8080, then attach the Manus session to the dev sandbox
+through MongoDB (same sandbox_id the backend assigns in development).
+"""
+
+from __future__ import annotations
+
+import time
+import uuid
+
+import pytest
+import requests
+from pymongo import MongoClient
+
+from conftest import BASE_URL
+
+SANDBOX_URL = "http://localhost:8080/api/v1"
+MONGODB_URI = "mongodb://localhost:27017"
+MONGODB_DATABASE = "manus"
+DEV_SANDBOX_ID = "dev-sandbox"
+BACKEND_READY_TIMEOUT = 180
+SANDBOX_READY_TIMEOUT = 120
+
+
+def _wait_for_url(url: str, timeout: float, label: str) -> None:
+    deadline = time.time() + timeout
+    last_error = None
+    while time.time() < deadline:
+        try:
+            response = requests.get(url, timeout=5)
+            if response.status_code == 200:
+                return
+            last_error = f"status {response.status_code}"
+        except requests.RequestException as exc:
+            last_error = str(exc)
+        time.sleep(2)
+    pytest.fail(f"{label} not ready after {timeout}s: {last_error}")
+
+
+@pytest.fixture(scope="module")
+def live_stack():
+    """Fail fast when the integration stack is not running."""
+    _wait_for_url(f"{BASE_URL}/config/frontend", BACKEND_READY_TIMEOUT, "backend")
+    _wait_for_url(f"{SANDBOX_URL.replace('/api/v1', '')}/docs", SANDBOX_READY_TIMEOUT, "sandbox")
+
+
+@pytest.fixture
+def mongo_sessions():
+    client = MongoClient(MONGODB_URI)
+    collection = client[MONGODB_DATABASE]["sessions"]
+    yield collection
+    client.close()
+
+
+@pytest.fixture
+def manus_session(client: requests.Session, live_stack, mongo_sessions):
+    """Create a Manus session and bind it to the dev sandbox container."""
+    response = client.put(f"{BASE_URL}/sessions")
+    assert response.status_code == 200, response.text
+    session_id = response.json()["data"]["session_id"]
+
+    updated = mongo_sessions.update_one(
+        {"session_id": session_id},
+        {"$set": {"sandbox_id": DEV_SANDBOX_ID}},
+    )
+    assert updated.matched_count == 1
+
+    return session_id
+
+
+def _sandbox_exec(command: str, shell_id: str | None = None) -> str:
+    payload = {
+        "id": shell_id or "",
+        "exec_dir": "/home/ubuntu",
+        "command": command,
+    }
+    response = requests.post(f"{SANDBOX_URL}/shell/exec", json=payload, timeout=30)
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body.get("success") is True, body
+    return body["data"]["session_id"]
+
+
+def _sandbox_write_file(path: str, content: str) -> None:
+    response = requests.post(
+        f"{SANDBOX_URL}/file/write",
+        json={"file": path, "content": content},
+        timeout=30,
+    )
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body.get("success") is True, body
+
+
+@pytest.mark.integration
+def test_shell_view_api_returns_expected_schema(client, live_stack, manus_session):
+    marker = f"integration-shell-{uuid.uuid4().hex[:8]}"
+    shell_id = _sandbox_exec(f"echo {marker}")
+
+    # Allow the shell process to finish so output is available.
+    time.sleep(1)
+
+    response = client.post(
+        f"{BASE_URL}/sessions/{manus_session}/shell",
+        json={"session_id": shell_id},
+    )
+    assert response.status_code == 200, response.text
+
+    payload = response.json()
+    assert payload["code"] == 0
+    data = payload["data"]
+    assert data["session_id"] == shell_id
+    assert marker in data["output"]
+    assert isinstance(data.get("console"), list)
+    assert data["console"][0]["command"] == f"echo {marker}"
+
+
+@pytest.mark.integration
+def test_file_view_api_returns_expected_schema(client, live_stack, manus_session):
+    file_path = f"/tmp/dto-integration-{uuid.uuid4().hex[:8]}.txt"
+    expected = "dto integration file body"
+    _sandbox_write_file(file_path, expected)
+
+    response = client.post(
+        f"{BASE_URL}/sessions/{manus_session}/file",
+        json={"file": file_path},
+    )
+    assert response.status_code == 200, response.text
+
+    payload = response.json()
+    assert payload["code"] == 0
+    data = payload["data"]
+    assert data["file"] == file_path
+    assert expected in data["content"]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds an **Application DTO layer** and fixes the dependency violation where `AgentService` returned `interfaces/schemas` types directly.

## Changes

- **`application/dto/sandbox.py`** — `ShellViewDto`, `FileViewDto`, `ConsoleRecordDto` with `from_tool_data()` factories for sandbox `ToolResult` payloads
- **`interfaces/mappers/sandbox_mapper.py`** — maps Application DTOs → API `*Response` schemas
- **`AgentService`** — `shell_view` / `file_view` now return DTOs (no `interfaces` imports)
- **`session_routes.py`** — uses mapper before returning `APIResponse`

## Dependency flow (after)

```
interfaces (routes) → application (AgentService + DTO) → domain
interfaces (mappers)  → application DTO → interfaces schemas
```

## Follow-ups (not in this PR)

- Move `FileInfoResponse.from_file_info` service-locator logic into a mapper
- Add `application/errors` domain exception mapping
- Extend DTOs for other use cases if needed
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f3151-4b04-71cc-89ae-acec5e8f5b74"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f3151-4b04-71cc-89ae-acec5e8f5b74"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

