### PR TITLE
refactor(sandbox): tidy up service, API, and test code; truncate shell output

### DIFF
--- a/sandbox/app/api/v1/file.py
+++ b/sandbox/app/api/v1/file.py
@@ -1,6 +1,8 @@
 """
 File operation API interfaces
 """
+import os
+from typing import Optional
 from fastapi import APIRouter, UploadFile, File, Form
 from fastapi.responses import FileResponse
 from app.schemas.file import (
@@ -11,6 +13,7 @@ from app.schemas.response import Response
 from app.services.file import file_service
 
 router = APIRouter()
+
 
 @router.post("/read", response_model=Response)
 async def read_file(request: FileReadRequest):
@@ -24,13 +27,13 @@ async def read_file(request: FileReadRequest):
         sudo=request.sudo,
         max_length=request.max_length
     )
-    
-    # Construct response
+
     return Response(
         success=True,
         message="File read successfully",
         data=result.model_dump()
     )
+
 
 @router.post("/write", response_model=Response)
 async def write_file(request: FileWriteRequest):
@@ -45,13 +48,13 @@ async def write_file(request: FileWriteRequest):
         trailing_newline=request.trailing_newline,
         sudo=request.sudo
     )
-    
-    # Construct response
+
     return Response(
         success=True,
         message="File written successfully",
         data=result.model_dump()
     )
+
 
 @router.post("/replace", response_model=Response)
 async def replace_in_file(request: FileReplaceRequest):
@@ -64,13 +67,13 @@ async def replace_in_file(request: FileReplaceRequest):
         new_str=request.new_str,
         sudo=request.sudo
     )
-    
-    # Construct response
+
     return Response(
         success=True,
         message=f"Replacement completed, replaced {result.replaced_count} occurrences",
         data=result.model_dump()
     )
+
 
 @router.post("/search", response_model=Response)
 async def search_in_file(request: FileSearchRequest):
@@ -82,13 +85,13 @@ async def search_in_file(request: FileSearchRequest):
         regex=request.regex,
         sudo=request.sudo
     )
-    
-    # Construct response
+
     return Response(
         success=True,
         message=f"Search completed, found {len(result.matches)} matches",
         data=result.model_dump()
     )
+
 
 @router.post("/find", response_model=Response)
 async def find_files(request: FileFindRequest):
@@ -99,49 +102,47 @@ async def find_files(request: FileFindRequest):
         path=request.path,
         glob_pattern=request.glob
     )
-    
-    # Construct response
+
     return Response(
         success=True,
         message=f"Search completed, found {len(result.files)} files",
         data=result.model_dump()
     )
 
-@router.post("/upload")
+
+@router.post("/upload", response_model=Response)
 async def upload_file(
     file: UploadFile = File(...),
-    path: str = Form(None)
+    path: Optional[str] = Form(None)
 ):
     """
     Upload file using streaming
     """
     if not path:
         path = f"/tmp/{file.filename}"
-    
+
     result = await file_service.upload_file(
         path=path,
         file_stream=file
     )
-    
+
     return Response(
         success=True,
         message="File uploaded successfully",
         data=result.model_dump()
     )
 
+
 @router.get("/download")
 async def download_file(path: str):
     """
     Download file using FileResponse
     """
-    # Check if file exists (this will raise appropriate exception if not found)
+    # Check if file exists (raises ResourceNotFoundException if not found)
     file_service.ensure_file(path)
-    
-    # Determine filename from path
-    filename = path.split('/')[-1]
-    
+
     return FileResponse(
         path=path,
-        filename=filename,
+        filename=os.path.basename(path),
         media_type='application/octet-stream'
     )

--- a/sandbox/app/api/v1/shell.py
+++ b/sandbox/app/api/v1/shell.py
@@ -1,3 +1,6 @@
+"""
+Shell operation API interfaces
+"""
 from fastapi import APIRouter
 from app.schemas.shell import (
     ShellExecRequest, ShellViewRequest, ShellWaitRequest,
@@ -5,9 +8,9 @@ from app.schemas.shell import (
 )
 from app.schemas.response import Response
 from app.services.shell import shell_service
-from app.core.exceptions import BadRequestException
 
 router = APIRouter()
+
 
 @router.post("/exec", response_model=Response)
 async def exec_command(request: ShellExecRequest):
@@ -15,38 +18,34 @@ async def exec_command(request: ShellExecRequest):
     Execute command in the specified shell session
     """
     # If no session ID is provided, automatically create one
-    if not request.id or request.id == "":
-        request.id = shell_service.create_session_id()
-        
+    session_id = request.id or shell_service.create_session_id()
+
     result = await shell_service.exec_command(
-        session_id=request.id,
+        session_id=session_id,
         exec_dir=request.exec_dir,
         command=request.command
     )
-    
-    # Construct response
+
     return Response(
         success=True,
         message="Command executed",
         data=result.model_dump()
     )
 
+
 @router.post("/view", response_model=Response)
 async def view_shell(request: ShellViewRequest):
     """
     View output of the specified shell session
     """
-    if not request.id or request.id == "":
-        raise BadRequestException("Session ID not provided")
-        
     result = await shell_service.view_shell(session_id=request.id, console=request.console)
-    
-    # Construct response
+
     return Response(
         success=True,
         message="Session content retrieved successfully",
         data=result.model_dump()
     )
+
 
 @router.post("/wait", response_model=Response)
 async def wait_for_process(request: ShellWaitRequest):
@@ -57,34 +56,31 @@ async def wait_for_process(request: ShellWaitRequest):
         session_id=request.id,
         seconds=request.seconds
     )
-    
-    # Construct response
+
     return Response(
         success=True,
         message=f"Process completed, return code: {result.returncode}",
         data=result.model_dump()
     )
 
+
 @router.post("/write", response_model=Response)
 async def write_to_process(request: ShellWriteToProcessRequest):
     """
     Write input to the process in the specified shell session
     """
-    if not request.id or request.id == "":
-        raise BadRequestException("Session ID not provided")
-        
     result = await shell_service.write_to_process(
         session_id=request.id,
         input_text=request.input,
         press_enter=request.press_enter
     )
-    
-    # Construct response
+
     return Response(
         success=True,
         message="Input written",
         data=result.model_dump()
     )
+
 
 @router.post("/kill", response_model=Response)
 async def kill_process(request: ShellKillProcessRequest):
@@ -92,8 +88,7 @@ async def kill_process(request: ShellKillProcessRequest):
     Terminate the process in the specified shell session
     """
     result = await shell_service.kill_process(session_id=request.id)
-    
-    # Construct response
+
     message = "Process terminated" if result.status == "terminated" else "Process ended"
     return Response(
         success=True,

--- a/sandbox/app/api/v1/shell.py
+++ b/sandbox/app/api/v1/shell.py
@@ -38,7 +38,11 @@ async def view_shell(request: ShellViewRequest):
     """
     View output of the specified shell session
     """
-    result = await shell_service.view_shell(session_id=request.id, console=request.console)
+    result = await shell_service.view_shell(
+        session_id=request.id,
+        console=request.console,
+        max_length=request.max_length
+    )
 
     return Response(
         success=True,

--- a/sandbox/app/api/v1/supervisor.py
+++ b/sandbox/app/api/v1/supervisor.py
@@ -1,15 +1,8 @@
 from fastapi import APIRouter
-from pydantic import BaseModel
-from typing import Optional
 
 from app.schemas.response import Response
+from app.schemas.supervisor import TimeoutRequest
 from app.services.supervisor import supervisor_service
-
-
-# Request model
-class TimeoutRequest(BaseModel):
-    minutes: Optional[int] = None
-
 
 router = APIRouter()
 
@@ -22,7 +15,7 @@ async def get_status():
     return Response(
         success=True,
         message="Services status retrieved successfully",
-        data=processes
+        data=[process.model_dump() for process in processes]
     )
 
 @router.post("/stop", response_model=Response)
@@ -34,7 +27,7 @@ async def stop_services():
     return Response(
         success=True,
         message="All services stopped",
-        data=result
+        data=result.model_dump()
     )
 
 @router.post("/shutdown", response_model=Response)
@@ -46,7 +39,7 @@ async def shutdown_supervisor():
     return Response(
         success=True,
         message="Supervisord service shutdown",
-        data=result
+        data=result.model_dump()
     )
 
 @router.post("/restart", response_model=Response)
@@ -58,7 +51,7 @@ async def restart_services():
     return Response(
         success=True,
         message="All services restarted",
-        data=result
+        data=result.model_dump()
     )
 
 @router.post("/timeout/activate", response_model=Response)
@@ -69,8 +62,8 @@ async def activate_timeout(request: TimeoutRequest):
     minutes: Optional, timeout duration (minutes), if not provided, system default configuration will be used
     """
     result = await supervisor_service.activate_timeout(request.minutes)
-    # Disable auto-expand since user explicitly controls timeout
-    supervisor_service.disable_auto_expand()
+    # Disable auto-extend since user explicitly controls timeout
+    supervisor_service.disable_auto_extend()
     return Response(
         success=True,
         message=f"Timeout reset, all services will be shut down after {result.timeout_minutes} minutes",
@@ -85,8 +78,8 @@ async def extend_timeout(request: TimeoutRequest):
     minutes: Optional, number of minutes to extend, if not provided, system default configuration will be used
     """
     result = await supervisor_service.extend_timeout(request.minutes)
-    # Disable auto-expand since user explicitly controls timeout
-    supervisor_service.disable_auto_expand()
+    # Disable auto-extend since user explicitly controls timeout
+    supervisor_service.disable_auto_extend()
     return Response(
         success=True,
         message=f"Timeout extended, all services will be shut down after {result.timeout_minutes} minutes",

--- a/sandbox/app/core/config.py
+++ b/sandbox/app/core/config.py
@@ -1,17 +1,20 @@
 from typing import List, Optional, Union
 from pydantic import field_validator
-from pydantic_settings import BaseSettings
+from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
 class Settings(BaseSettings):
+    model_config = SettingsConfigDict(case_sensitive=True, env_file=".env")
+
+    # CORS allowed origins
     ORIGINS: List[str] = ["*"]
-    
+
     # Service timeout settings (minutes)
     SERVICE_TIMEOUT_MINUTES: Optional[int] = None
-    
+
     # Log configuration
     LOG_LEVEL: str = "INFO"
-    
+
     @field_validator("ORIGINS", mode="before")
     def assemble_cors_origins(cls, v: Union[str, List[str]]) -> Union[List[str], str]:
         if isinstance(v, str) and not v.startswith("["):
@@ -19,10 +22,6 @@ class Settings(BaseSettings):
         elif isinstance(v, (list, str)):
             return v
         raise ValueError(v)
-
-    class Config:
-        case_sensitive = True
-        env_file = ".env"
 
 
 settings = Settings() 

--- a/sandbox/app/core/middleware.py
+++ b/sandbox/app/core/middleware.py
@@ -1,7 +1,5 @@
 import logging
 from fastapi import Request
-from starlette.middleware.base import BaseHTTPMiddleware
-from starlette.responses import Response
 
 from app.core.config import settings
 
@@ -10,23 +8,23 @@ logger = logging.getLogger(__name__)
 
 async def auto_extend_timeout_middleware(request: Request, call_next):
     """
-    Middleware to automatically extend timeout on every API request
-    Only auto-extends when auto-expand is enabled (disabled when user explicitly manages timeout)
+    Middleware to automatically extend timeout on every API request.
+    Only auto-extends when enabled (disabled when user explicitly manages timeout).
     """
+    # Imported lazily to avoid connecting to supervisord at module import time
     from app.services.supervisor import supervisor_service
-    
-    # Only extend timeout if timeout is currently active, it's an API request, 
-    # and not a timeout management API call, and auto-expand is enabled
+
+    # Only extend timeout if timeout is currently active, it's an API request,
+    # and not a timeout management API call, and auto-extend is enabled
     if (settings.SERVICE_TIMEOUT_MINUTES is not None and
-        supervisor_service.timeout_active and 
+        supervisor_service.timeout_active and
         request.url.path.startswith("/api/") and
         not request.url.path.startswith("/api/v1/supervisor/timeout/") and
-        supervisor_service.auto_expand_enabled):
+        supervisor_service.auto_extend_enabled):
         try:
             await supervisor_service.extend_timeout()
             logger.debug("Timeout automatically extended due to API request: %s", request.url.path)
         except Exception as e:
             logger.warning("Failed to auto-extend timeout: %s", str(e))
-    
-    response = await call_next(request)
-    return response 
+
+    return await call_next(request) 

--- a/sandbox/app/main.py
+++ b/sandbox/app/main.py
@@ -16,37 +16,28 @@ from app.core.exceptions import (
 )
 from app.core.middleware import auto_extend_timeout_middleware
 
-# Configure logging
 def setup_logging():
     """
     Set up the application logging system
-    
+
     Configures log level, format, and handlers based on application settings.
     Outputs logs to stdout for container compatibility.
     """
-    log_level = getattr(logging, settings.LOG_LEVEL)
-    log_format = "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
-    
     logging.basicConfig(
-        level=log_level,
-        format=log_format,
+        level=getattr(logging, settings.LOG_LEVEL),
+        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
         handlers=[logging.StreamHandler(sys.stdout)]
     )
-    # Get root logger
-    root_logger = logging.getLogger()
-    
-    # Set root log level
-    log_level = getattr(logging, settings.LOG_LEVEL)
-    root_logger.setLevel(log_level)
-    
-    # Log setup completion
     logging.info("Sandbox logging system initialized with level: %s", settings.LOG_LEVEL)
 
-# Initialize logging
+
 setup_logging()
 logger = logging.getLogger(__name__)
 
+logger.info("Sandbox API server starting")
+
 app = FastAPI(
+    title="Sandbox API",
     version="1.0.0",
 )
 
@@ -58,8 +49,6 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
-
-logger.info("Sandbox API server starting")
 
 # Register middleware
 app.middleware("http")(auto_extend_timeout_middleware)

--- a/sandbox/app/models/__init__.py
+++ b/sandbox/app/models/__init__.py
@@ -1,12 +1,20 @@
 """
-业务模型定义
+Business model definitions
 """
-from app.models.shell import ShellExecResult, ShellViewResult, ShellWaitResult, ShellWriteResult, ShellKillResult
+from app.models.shell import (
+    ConsoleRecord, ShellExecResult, ShellViewResult, ShellWaitResult,
+    ShellWriteResult, ShellKillResult
+)
 from app.models.supervisor import ProcessInfo, SupervisorActionResult, SupervisorTimeout
-from app.models.file import FileReadResult, FileWriteResult, FileReplaceResult, FileSearchResult, FileFindResult
+from app.models.file import (
+    FileReadResult, FileWriteResult, FileReplaceResult,
+    FileSearchResult, FileFindResult, FileUploadResult
+)
 
 __all__ = [
-    'ShellExecResult', 'ShellViewResult', 'ShellWaitResult', 'ShellWriteResult', 'ShellKillResult',
+    'ConsoleRecord', 'ShellExecResult', 'ShellViewResult', 'ShellWaitResult',
+    'ShellWriteResult', 'ShellKillResult',
     'ProcessInfo', 'SupervisorActionResult', 'SupervisorTimeout',
-    'FileReadResult', 'FileWriteResult', 'FileReplaceResult', 'FileSearchResult', 'FileFindResult'
+    'FileReadResult', 'FileWriteResult', 'FileReplaceResult',
+    'FileSearchResult', 'FileFindResult', 'FileUploadResult',
 ]

--- a/sandbox/app/models/shell.py
+++ b/sandbox/app/models/shell.py
@@ -12,15 +12,6 @@ class ConsoleRecord(BaseModel):
     output: str = Field(default="", description="Command output")
 
 
-class ShellTask(BaseModel):
-    """Shell task model"""
-    id: str = Field(..., description="Task unique identifier")
-    command: str = Field(..., description="Executed command")
-    status: str = Field(..., description="Task status")
-    created_at: str = Field(..., description="Task creation time")
-    output: Optional[str] = Field(None, description="Task output")
-
-
 class ShellExecResult(BaseModel):
     """Shell command execution result model"""
     session_id: str = Field(..., description="Shell session ID")

--- a/sandbox/app/schemas/shell.py
+++ b/sandbox/app/schemas/shell.py
@@ -12,6 +12,7 @@ class ShellViewRequest(BaseModel):
     """Shell session content view request model"""
     id: str = Field(..., description="Unique identifier of the target shell session")
     console: Optional[bool] = Field(False, description="Whether to return console records")
+    max_length: Optional[int] = Field(10000, description="Maximum length of the output to return, the most recent part is kept")
 
 
 class ShellWaitRequest(BaseModel):

--- a/sandbox/app/schemas/supervisor.py
+++ b/sandbox/app/schemas/supervisor.py
@@ -1,0 +1,10 @@
+"""
+Supervisor request models
+"""
+from pydantic import BaseModel, Field
+from typing import Optional
+
+
+class TimeoutRequest(BaseModel):
+    """Timeout activation/extension request"""
+    minutes: Optional[int] = Field(None, description="Timeout duration in minutes, system default is used if not provided")

--- a/sandbox/app/services/file.py
+++ b/sandbox/app/services/file.py
@@ -1,13 +1,11 @@
 """
-File Operation Service Implementation - Async Version
+File Operation Service Implementation
 """
 import os
 import re
 import glob
 import asyncio
-import subprocess
-import mimetypes
-from typing import Optional, BinaryIO
+from typing import Optional
 from fastapi import UploadFile
 from app.models.file import (
     FileReadResult, FileWriteResult, FileReplaceResult,
@@ -15,79 +13,74 @@ from app.models.file import (
 )
 from app.core.exceptions import AppException, ResourceNotFoundException, BadRequestException
 
+# Chunk size for streaming file uploads
+UPLOAD_CHUNK_SIZE = 8192
+
 
 class FileService:
     """File Operation Service"""
 
-    async def read_file(self, file: str, start_line: Optional[int] = None, 
+    async def read_file(self, file: str, start_line: Optional[int] = None,
                  end_line: Optional[int] = None, sudo: bool = False, max_length: Optional[int] = 10000) -> FileReadResult:
         """
-        Asynchronously read file content
-        
+        Read file content
+
         Args:
             file: Absolute file path
             start_line: Starting line (0-based)
             end_line: Ending line (not included)
             sudo: Whether to use sudo privileges
+            max_length: Maximum content length to return, longer content is truncated
         """
-        # Check if file exists
         if not os.path.exists(file) and not sudo:
             raise ResourceNotFoundException(f"File does not exist: {file}")
-        
+
         try:
-            content = ""
-            
-            # Read with sudo
             if sudo:
-                command = f"sudo cat '{file}'"
                 process = await asyncio.create_subprocess_shell(
-                    command,
+                    f"sudo cat '{file}'",
                     stdout=asyncio.subprocess.PIPE,
                     stderr=asyncio.subprocess.PIPE
                 )
                 stdout, stderr = await process.communicate()
-                
+
                 if process.returncode != 0:
                     raise BadRequestException(f"Failed to read file: {stderr.decode()}")
-                
+
                 content = stdout.decode('utf-8')
             else:
-                # Asynchronously read file
-                def read_file_async():
-                    try:
-                        with open(file, 'r', encoding='utf-8') as f:
-                            return f.read()
-                    except Exception as e:
-                        raise AppException(message=f"Failed to read file: {str(e)}")
-                
+                def read_file_content() -> str:
+                    with open(file, 'r', encoding='utf-8') as f:
+                        return f.read()
+
                 # Execute IO operation in thread pool
-                content = await asyncio.to_thread(read_file_async)
-            
+                content = await asyncio.to_thread(read_file_content)
+
             # Process line range
             if start_line is not None or end_line is not None:
                 lines = content.splitlines()
                 start = start_line if start_line is not None else 0
                 end = end_line if end_line is not None else len(lines)
                 content = '\n'.join(lines[start:end])
-            
+
             if max_length is not None and max_length > 0 and len(content) > max_length:
                 content = content[:max_length] + "(truncated)"
-            
+
             return FileReadResult(
                 content=content,
                 file=file
             )
+        except (BadRequestException, ResourceNotFoundException):
+            raise
         except Exception as e:
-            if isinstance(e, BadRequestException) or isinstance(e, ResourceNotFoundException):
-                raise e
             raise AppException(message=f"Failed to read file: {str(e)}")
 
     async def write_file(self, file: str, content: str, append: bool = False,
                   leading_newline: bool = False, trailing_newline: bool = False,
                   sudo: bool = False) -> FileWriteResult:
         """
-        Asynchronously write file content
-        
+        Write file content
+
         Args:
             file: Absolute file path
             content: Content to write
@@ -97,28 +90,22 @@ class FileService:
             sudo: Whether to use sudo privileges
         """
         try:
-            # Prepare content
             if leading_newline:
                 content = '\n' + content
             if trailing_newline:
                 content = content + '\n'
-            
-            bytes_written = 0
-            
-            # Write with sudo
+
             if sudo:
                 mode = '>>' if append else '>'
-                # Create temporary file
                 temp_file = f"/tmp/file_write_{os.getpid()}.tmp"
-                
-                # Asynchronously write to temporary file
-                def write_temp_file():
+
+                def write_temp_file() -> int:
                     with open(temp_file, 'w', encoding='utf-8') as f:
                         f.write(content)
                     return len(content.encode('utf-8'))
-                
+
                 bytes_written = await asyncio.to_thread(write_temp_file)
-                
+
                 # Use sudo to write temporary file content to target file
                 command = f"sudo bash -c \"cat {temp_file} {mode} '{file}'\""
                 process = await asyncio.create_subprocess_shell(
@@ -127,102 +114,89 @@ class FileService:
                     stderr=asyncio.subprocess.PIPE
                 )
                 stdout, stderr = await process.communicate()
-                
+
                 if process.returncode != 0:
                     raise BadRequestException(f"Failed to write file: {stderr.decode()}")
-                
-                # Clean up temporary file
+
                 os.unlink(temp_file)
             else:
-                # Ensure directory exists
                 os.makedirs(os.path.dirname(file), exist_ok=True)
-                
-                # Asynchronously write file
-                def write_file_async():
+
+                def write_file_content() -> int:
                     mode = 'a' if append else 'w'
                     with open(file, mode, encoding='utf-8') as f:
                         return f.write(content)
-                
-                bytes_written = await asyncio.to_thread(write_file_async)
-            
+
+                bytes_written = await asyncio.to_thread(write_file_content)
+
             return FileWriteResult(
                 file=file,
                 bytes_written=bytes_written
             )
+        except BadRequestException:
+            raise
         except Exception as e:
-            if isinstance(e, BadRequestException):
-                raise e
             raise AppException(message=f"Failed to write file: {str(e)}")
 
-    async def str_replace(self, file: str, old_str: str, new_str: str, 
+    async def str_replace(self, file: str, old_str: str, new_str: str,
                    sudo: bool = False) -> FileReplaceResult:
         """
-        Asynchronously replace string in file
-        
+        Replace string in file
+
         Args:
             file: Absolute file path
             old_str: Original string to be replaced
             new_str: New replacement string
             sudo: Whether to use sudo privileges
         """
-        # First read file content
         file_result = await self.read_file(file, sudo=sudo)
         content = file_result.content
-        
-        # Calculate replacement count
+
         replaced_count = content.count(old_str)
         if replaced_count == 0:
             return FileReplaceResult(
                 file=file,
                 replaced_count=0
             )
-        
-        # Perform replacement
+
         new_content = content.replace(old_str, new_str)
-        
-        # Write back to file
         await self.write_file(file, new_content, sudo=sudo)
-        
+
         return FileReplaceResult(
             file=file,
             replaced_count=replaced_count
         )
 
-    async def find_in_content(self, file: str, regex: str, 
+    async def find_in_content(self, file: str, regex: str,
                        sudo: bool = False) -> FileSearchResult:
         """
-        Asynchronously search in file content
-        
+        Search in file content
+
         Args:
             file: Absolute file path
             regex: Regular expression pattern
             sudo: Whether to use sudo privileges
         """
-        # Read file
-        file_result = await self.read_file(file, sudo=sudo)
-        content = file_result.content
-        
-        # Process line by line
-        lines = content.splitlines()
-        matches = []
-        line_numbers = []
-        
-        # Compile regular expression
         try:
             pattern = re.compile(regex)
-        except Exception as e:
+        except re.error as e:
             raise BadRequestException(f"Invalid regular expression: {str(e)}")
-        
-        # Find matches (use async processing for possibly large files)
-        def process_lines():
-            nonlocal matches, line_numbers
+
+        file_result = await self.read_file(file, sudo=sudo)
+        lines = file_result.content.splitlines()
+
+        matches = []
+        line_numbers = []
+
+        # Process in a thread pool as the file may be large
+        def match_lines() -> None:
             for i, line in enumerate(lines):
                 if pattern.search(line):
                     matches.append(line)
                     line_numbers.append(i)
-        
-        await asyncio.to_thread(process_lines)
-        
+
+        await asyncio.to_thread(match_lines)
+
         return FileSearchResult(
             file=file,
             matches=matches,
@@ -231,23 +205,21 @@ class FileService:
 
     async def find_by_name(self, path: str, glob_pattern: str) -> FileFindResult:
         """
-        Asynchronously find files by name pattern
-        
+        Find files by name pattern
+
         Args:
             path: Directory path to search
             glob_pattern: File name pattern (glob syntax)
         """
-        # Check if path exists
         if not os.path.exists(path):
             raise ResourceNotFoundException(f"Directory does not exist: {path}")
-        
-        # Asynchronously find files
-        def glob_async():
+
+        def glob_files() -> list:
             search_pattern = os.path.join(path, glob_pattern)
             return glob.glob(search_pattern, recursive=True)
-        
-        files = await asyncio.to_thread(glob_async)
-        
+
+        files = await asyncio.to_thread(glob_files)
+
         return FileFindResult(
             path=path,
             files=files
@@ -256,31 +228,28 @@ class FileService:
     async def upload_file(self, path: str, file_stream: UploadFile) -> FileUploadResult:
         """
         Upload file using streaming for large files
-        
+
         Args:
             path: Target file path to save uploaded file
             file_stream: File stream from FastAPI UploadFile
         """
         try:
-            chunk_size = 8192  # 8KB chunks
             total_size = 0
-            
-            # Ensure directory exists
+
             os.makedirs(os.path.dirname(path), exist_ok=True)
-            
-            # Stream write directly to target file
-            def write_stream_direct():
+
+            def write_stream_to_file() -> None:
                 nonlocal total_size
                 with open(path, 'wb') as f:
                     while True:
-                        chunk = file_stream.file.read(chunk_size)
+                        chunk = file_stream.file.read(UPLOAD_CHUNK_SIZE)
                         if not chunk:
                             break
                         f.write(chunk)
                         total_size += len(chunk)
-            
-            await asyncio.to_thread(write_stream_direct)
-            
+
+            await asyncio.to_thread(write_stream_to_file)
+
             return FileUploadResult(
                 file_path=path,
                 file_size=total_size,
@@ -291,21 +260,13 @@ class FileService:
 
     def ensure_file(self, path: str) -> None:
         """
-        Ensure file exists
-        
+        Ensure file exists, raising ResourceNotFoundException otherwise
+
         Args:
             path: Path of the file to check
         """
-        try:
-            # Check if file exists
-            if not os.path.exists(path):
-                raise ResourceNotFoundException(f"File does not exist: {path}")
-                    
-        except Exception as e:
-            if isinstance(e, (BadRequestException, ResourceNotFoundException)):
-                raise e
-            raise AppException(message=f"Failed to ensure file: {str(e)}")
+        if not os.path.exists(path):
+            raise ResourceNotFoundException(f"File does not exist: {path}")
 
 
-# Service instance
 file_service = FileService()

--- a/sandbox/app/services/shell.py
+++ b/sandbox/app/services/shell.py
@@ -1,41 +1,68 @@
 """
-Shell Service Implementation - Async Version
+Shell Service Implementation
 """
 import os
-import subprocess
 import uuid
 import getpass
 import socket
 import logging
 import asyncio
 import re
-from typing import Dict, Any, Optional, List, Tuple
+from dataclasses import dataclass, field
+from typing import Dict, Optional, List
 from app.models.shell import (
     ShellExecResult, ShellViewResult, ShellWaitResult,
-    ShellWriteResult, ShellKillResult, ShellTask, ConsoleRecord
+    ShellWriteResult, ShellKillResult, ConsoleRecord
 )
 from app.core.exceptions import AppException, ResourceNotFoundException, BadRequestException
 
-# Set up logger
 logger = logging.getLogger(__name__)
 
+# Pattern to match ANSI escape sequences
+ANSI_ESCAPE_PATTERN = re.compile(r'\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])')
+
+# How long exec_command waits for a command before reporting it as still running
+EXEC_WAIT_SECONDS = 5
+# Default timeout for wait_for_process when none is given
+DEFAULT_WAIT_SECONDS = 60
+
+
+@dataclass
+class ShellSession:
+    """State of a single shell session"""
+    process: asyncio.subprocess.Process
+    exec_dir: str
+    output: str = ""
+    console: List[ConsoleRecord] = field(default_factory=list)
+
+
 class ShellService:
-    # Store active shell sessions
-    active_shells: Dict[str, Dict[str, Any]] = {}
-    
-    # Store shell tasks
-    shell_tasks: Dict[str, ShellTask] = {}
+    def __init__(self) -> None:
+        self.active_shells: Dict[str, ShellSession] = {}
 
-    def _remove_ansi_escape_codes(self, text: str) -> str:
+    def create_session_id(self) -> str:
+        """Create a new session ID"""
+        session_id = str(uuid.uuid4())
+        logger.debug(f"Created new session ID: {session_id}")
+        return session_id
+
+    def _get_session(self, session_id: str) -> ShellSession:
+        """Get an existing session or raise ResourceNotFoundException"""
+        session = self.active_shells.get(session_id)
+        if session is None:
+            logger.error(f"Session ID not found: {session_id}")
+            raise ResourceNotFoundException(f"Session ID does not exist: {session_id}")
+        return session
+
+    @staticmethod
+    def _remove_ansi_escape_codes(text: str) -> str:
         """Remove ANSI escape codes from text"""
-        # Pattern to match ANSI escape sequences
-        ansi_escape = re.compile(r'\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])')
-        return ansi_escape.sub('', text)
+        return ANSI_ESCAPE_PATTERN.sub('', text)
 
-    def _get_display_path(self, path: str) -> str:
+    @staticmethod
+    def _get_display_path(path: str) -> str:
         """Get the path for display, replacing user home directory with ~"""
         home_dir = os.path.expanduser("~")
-        logger.debug(f"Home directory: {home_dir} , path: {path}")
         if path.startswith(home_dir):
             return path.replace(home_dir, "~", 1)
         return path
@@ -57,128 +84,81 @@ class ShellService:
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.STDOUT,  # Redirect stderr to stdout
             stdin=asyncio.subprocess.PIPE,
-            limit=1024*1024  # Set buffer size to 1MB
+            limit=1024 * 1024  # Set buffer size to 1MB
         )
 
-    async def _start_output_reader(self, session_id: str, process: asyncio.subprocess.Process):
-        """Start a coroutine to continuously read process output and store it"""
+    async def _terminate_process(self, process: asyncio.subprocess.Process, timeout: float) -> None:
+        """Terminate a process gracefully, force killing it if it does not exit in time"""
+        if process.returncode is not None:
+            return
+        process.terminate()
+        try:
+            await asyncio.wait_for(process.wait(), timeout=timeout)
+        except (asyncio.TimeoutError, ProcessLookupError):
+            logger.warning("Graceful termination failed, force killing process")
+            process.kill()
+            await process.wait()
+
+    async def _read_output(self, session_id: str, process: asyncio.subprocess.Process) -> None:
+        """Continuously read process output and append it to the session state"""
         logger.debug(f"Starting output reader for session: {session_id}")
-        while True:
-            if process.stdout:
-                try:
-                    buffer = await process.stdout.read(128)
-                    if not buffer:
-                        # Process output ended
-                        break
-                    
-                    output = buffer.decode('utf-8')
-                    # Add output to shell session
-                    shell = self.active_shells.get(session_id)
-                    if shell:
-                        shell["output"] += output
-                        # Update the output of the latest console record
-                        if shell["console"]:
-                            shell["console"][-1].output += output
-                except Exception as e:
-                    logger.error(f"Error reading process output: {str(e)}", exc_info=True)
-                    break
-            else:
+        while process.stdout:
+            try:
+                buffer = await process.stdout.read(128)
+            except Exception as e:
+                logger.error(f"Error reading process output: {str(e)}", exc_info=True)
                 break
-        
+            if not buffer:
+                break  # Process output ended
+
+            output = buffer.decode('utf-8')
+            session = self.active_shells.get(session_id)
+            # Only record output if this process is still the session's current one
+            if session and session.process is process:
+                session.output += output
+                if session.console:
+                    session.console[-1].output += output
         logger.debug(f"Output reader for session {session_id} has finished")
 
     async def exec_command(self, session_id: str, exec_dir: Optional[str], command: str) -> ShellExecResult:
         """
-        Asynchronously execute a command in the specified shell session
+        Execute a command in the specified shell session.
+
+        Creates the session if it does not exist yet; if the session already has a
+        running process, that process is terminated first. Waits briefly for the
+        command to complete; returns a "running" result if it is still going.
         """
         logger.info(f"Executing command in session {session_id}: {command}")
         if not exec_dir:
             exec_dir = os.path.expanduser("~")
-        # Ensure directory exists
         if not os.path.exists(exec_dir):
             logger.error(f"Directory does not exist: {exec_dir}")
             raise BadRequestException(f"Directory does not exist: {exec_dir}")
-        
+
         try:
-            # Create PS1 format
-            ps1 = self._format_ps1(exec_dir)
-            
-            # If it's a new session, create a new process
-            if session_id not in self.active_shells:
+            session = self.active_shells.get(session_id)
+            if session is not None and session.process.returncode is None:
+                logger.debug(f"Terminating previous process in session: {session_id}")
+                await self._terminate_process(session.process, timeout=1)
+
+            process = await self._create_process(command, exec_dir)
+            record = ConsoleRecord(ps1=self._format_ps1(exec_dir), command=command, output="")
+
+            if session is None:
                 logger.debug(f"Creating new shell session: {session_id}")
-                process = await self._create_process(command, exec_dir)
-                self.active_shells[session_id] = {
-                    "process": process,
-                    "exec_dir": exec_dir,
-                    "output": "",
-                    "console": [ConsoleRecord(ps1=ps1, command=command, output="")]
-                }
-                # Start the output reader coroutine
-                asyncio.create_task(self._start_output_reader(session_id, process))
+                self.active_shells[session_id] = ShellSession(
+                    process=process,
+                    exec_dir=exec_dir,
+                    console=[record],
+                )
             else:
-                # Execute command in an existing session
-                logger.debug(f"Using existing shell session: {session_id}")
-                shell = self.active_shells[session_id]
-                old_process = shell["process"]
-                
-                # If the old process is still running, terminate it first
-                if old_process.returncode is None:
-                    logger.debug(f"Terminating previous process in session: {session_id}")
-                    try:
-                        old_process.terminate()
-                        await asyncio.wait_for(old_process.wait(), timeout=1)
-                    except:
-                        # If graceful termination fails, force kill
-                        logger.warning(f"Forcefully killing process in session: {session_id}")
-                        old_process.kill()
-                
-                # Create a new process
-                process = await self._create_process(command, exec_dir)
-                
-                # Update session information
-                self.active_shells[session_id]["process"] = process
-                self.active_shells[session_id]["exec_dir"] = exec_dir
-                self.active_shells[session_id]["output"] = ""  # Clear previous output
-                
-                # Record command console record, but output is initially empty, will be updated later
-                shell["console"].append(ConsoleRecord(ps1=ps1, command=command, output=""))
-                
-                # Start the output reader coroutine
-                asyncio.create_task(self._start_output_reader(session_id, process))
-            
-            # Try to wait for the process to complete (max 5 seconds)
-            try:
-                logger.debug(f"Waiting for process completion in session: {session_id}")
-                wait_result = await self.wait_for_process(session_id, seconds=5)
-                if wait_result.returncode is not None:
-                    # Process has completed, get the output
-                    logger.debug(f"Process completed with code: {wait_result.returncode}")
-                    view_result = await self.view_shell(session_id)
-                    
-                    return ShellExecResult(
-                        session_id=session_id,
-                        command=command,
-                        status="completed",
-                        returncode=wait_result.returncode,
-                        output=view_result.output,
-                    )
-            except BadRequestException:
-                # Wait timeout, process still running
-                logger.debug(f"Process still running after timeout in session: {session_id}")
-                pass
-            except Exception as e:
-                # Other exceptions, ignore and continue
-                logger.warning(f"Exception while waiting for process: {str(e)}")
-                pass
-            
-            # Get current console records
-            console = self.get_console_records(session_id)
-            
-            return ShellExecResult(
-                session_id=session_id,
-                command=command,
-                status="running",
-            )
+                logger.debug(f"Reusing existing shell session: {session_id}")
+                session.process = process
+                session.exec_dir = exec_dir
+                session.output = ""  # Clear previous output
+                session.console.append(record)
+
+            asyncio.create_task(self._read_output(session_id, process))
         except Exception as e:
             logger.error(f"Command execution failed: {str(e)}", exc_info=True)
             raise AppException(
@@ -186,77 +166,59 @@ class ShellService:
                 data={"session_id": session_id, "command": command}
             )
 
-    async def view_shell(self, session_id: str, console: bool = False) -> ShellViewResult:
-        """
-        Asynchronously view the content of the specified shell session
-        """
-        logger.debug(f"Viewing shell content for session: {session_id}")
-        if session_id not in self.active_shells:
-            logger.error(f"Session ID not found: {session_id}")
-            raise ResourceNotFoundException(f"Session ID does not exist: {session_id}")
-        
-        shell = self.active_shells[session_id]
-        
-        # Get raw output and filter ANSI escape codes
-        raw_output = shell["output"]
-        clean_output = self._remove_ansi_escape_codes(raw_output)
-        
-        # Get command console records with filtered output
-        if console:
-            console = self.get_console_records(session_id)
-        else:
-            console = None
-        
-        return ShellViewResult(
-            output=clean_output,
+        try:
+            wait_result = await self.wait_for_process(session_id, seconds=EXEC_WAIT_SECONDS)
+        except BadRequestException:
+            # Wait timeout, process still running
+            logger.debug(f"Process still running after timeout in session: {session_id}")
+            return ShellExecResult(
+                session_id=session_id,
+                command=command,
+                status="running",
+            )
+
+        logger.debug(f"Process completed with code: {wait_result.returncode}")
+        view_result = await self.view_shell(session_id)
+        return ShellExecResult(
             session_id=session_id,
-            console=console
+            command=command,
+            status="completed",
+            returncode=wait_result.returncode,
+            output=view_result.output,
+        )
+
+    async def view_shell(self, session_id: str, console: bool = False) -> ShellViewResult:
+        """View the output of the specified shell session"""
+        logger.debug(f"Viewing shell content for session: {session_id}")
+        session = self._get_session(session_id)
+        return ShellViewResult(
+            output=self._remove_ansi_escape_codes(session.output),
+            session_id=session_id,
+            console=self.get_console_records(session_id) if console else None,
         )
 
     def get_console_records(self, session_id: str) -> List[ConsoleRecord]:
-        """
-        Get command console records for the specified session (this method doesn't need to be async)
-        """
+        """Get console records for the specified session, with ANSI escape codes removed"""
         logger.debug(f"Getting console records for session: {session_id}")
-        if session_id not in self.active_shells:
-            logger.error(f"Session ID not found: {session_id}")
-            raise ResourceNotFoundException(f"Session ID does not exist: {session_id}")
-        
-        # Get raw console records and filter ANSI escape codes
-        raw_console = self.active_shells[session_id]["console"]
-        clean_console = []
-        for record in raw_console:
-            clean_record = ConsoleRecord(
+        session = self._get_session(session_id)
+        return [
+            ConsoleRecord(
                 ps1=record.ps1,
                 command=record.command,
-                output=self._remove_ansi_escape_codes(record.output)
+                output=self._remove_ansi_escape_codes(record.output),
             )
-            clean_console.append(clean_record)
-        
-        return clean_console
+            for record in session.console
+        ]
 
     async def wait_for_process(self, session_id: str, seconds: Optional[int] = None) -> ShellWaitResult:
-        """
-        Asynchronously wait for the process in the specified shell session to return
-        """
+        """Wait for the process in the specified shell session to return"""
         logger.debug(f"Waiting for process in session: {session_id}, timeout: {seconds}s")
-        if session_id not in self.active_shells:
-            logger.error(f"Session ID not found: {session_id}")
-            raise ResourceNotFoundException(f"Session ID does not exist: {session_id}")
-        
-        shell = self.active_shells[session_id]
-        process = shell["process"]
-        
+        session = self._get_session(session_id)
+        if seconds is None:
+            seconds = DEFAULT_WAIT_SECONDS
+
         try:
-            # Asynchronously wait for process to complete
-            if seconds is None:
-                seconds = 60
-            await asyncio.wait_for(process.wait(), timeout=seconds)
-            
-            logger.info(f"Process completed with return code: {process.returncode}")
-            return ShellWaitResult(
-                returncode=process.returncode
-            )
+            await asyncio.wait_for(session.process.wait(), timeout=seconds)
         except asyncio.TimeoutError:
             logger.warning(f"Process wait timeout expired: {seconds}s")
             raise BadRequestException(f"Wait timeout: {seconds} seconds")
@@ -264,96 +226,59 @@ class ShellService:
             logger.error(f"Failed to wait for process: {str(e)}", exc_info=True)
             raise AppException(message=f"Failed to wait for process: {str(e)}")
 
+        logger.info(f"Process completed with return code: {session.process.returncode}")
+        return ShellWaitResult(returncode=session.process.returncode)
+
     async def write_to_process(self, session_id: str, input_text: str, press_enter: bool) -> ShellWriteResult:
-        """
-        Asynchronously write input to the process in the specified shell session
-        """
+        """Write input to the process in the specified shell session"""
         logger.debug(f"Writing to process in session: {session_id}, press_enter: {press_enter}")
-        if session_id not in self.active_shells:
-            logger.error(f"Session ID not found: {session_id}")
-            raise ResourceNotFoundException(f"Session ID does not exist: {session_id}")
-        
-        shell = self.active_shells[session_id]
-        process = shell["process"]
-        
+        session = self._get_session(session_id)
+        process = session.process
+
+        if process.returncode is not None:
+            logger.error("Process has already terminated, cannot write input")
+            raise BadRequestException("Process has ended, cannot write input")
+
         try:
-            # Check if the process is still running
-            if process.returncode is not None:
-                logger.error(f"Process has already terminated, cannot write input")
-                raise BadRequestException("Process has ended, cannot write input")
-            
-            # Prepare input data
-            if press_enter:
-                input_data = f"{input_text}\n".encode()
-            else:
-                input_data = input_text.encode()
-            
-            # Add input to output and console records
-            input_str = input_data.decode('utf-8')
-            shell["output"] += input_str
-            if shell["console"]:
-                shell["console"][-1].output += input_str
-            
-            # Asynchronously write input
-            process.stdin.write(input_data)
+            input_str = f"{input_text}\n" if press_enter else input_text
+
+            # Echo the input into the session output and console records
+            session.output += input_str
+            if session.console:
+                session.console[-1].output += input_str
+
+            process.stdin.write(input_str.encode())
             await process.stdin.drain()
-            
-            logger.info(f"Successfully wrote input to process")
-            
-            return ShellWriteResult(
-                status="success"
-            )
+
+            logger.info("Successfully wrote input to process")
+            return ShellWriteResult(status="success")
         except Exception as e:
             logger.error(f"Failed to write input: {str(e)}", exc_info=True)
             raise AppException(message=f"Failed to write input: {str(e)}")
 
     async def kill_process(self, session_id: str) -> ShellKillResult:
-        """
-        Asynchronously terminate the process in the specified shell session
-        """
+        """Terminate the process in the specified shell session"""
         logger.info(f"Killing process in session: {session_id}")
-        if session_id not in self.active_shells:
-            logger.error(f"Session ID not found: {session_id}")
-            raise ResourceNotFoundException(f"Session ID does not exist: {session_id}")
-        
-        shell = self.active_shells[session_id]
-        process = shell["process"]
-        
+        session = self._get_session(session_id)
+        process = session.process
+
+        if process.returncode is not None:
+            logger.info(f"Process was already terminated with return code: {process.returncode}")
+            return ShellKillResult(
+                status="already_terminated",
+                returncode=process.returncode
+            )
+
         try:
-            # Check if the process is still running
-            if process.returncode is None:
-                # Try to terminate gracefully
-                logger.debug(f"Attempting to terminate process gracefully")
-                process.terminate()
-                try:
-                    await asyncio.wait_for(process.wait(), timeout=3)
-                except asyncio.TimeoutError:
-                    # If graceful termination fails, force kill
-                    logger.warning(f"Forcefully killing the process")
-                    process.kill()
-                    await process.wait()
-                
-                logger.info(f"Process terminated with return code: {process.returncode}")
-                return ShellKillResult(
-                    status="terminated",
-                    returncode=process.returncode
-                )
-            else:
-                logger.info(f"Process was already terminated with return code: {process.returncode}")
-                return ShellKillResult(
-                    status="already_terminated",
-                    returncode=process.returncode
-                )
+            await self._terminate_process(process, timeout=3)
+            logger.info(f"Process terminated with return code: {process.returncode}")
+            return ShellKillResult(
+                status="terminated",
+                returncode=process.returncode
+            )
         except Exception as e:
             logger.error(f"Failed to kill process: {str(e)}", exc_info=True)
             raise AppException(message=f"Failed to terminate process: {str(e)}")
 
-    def create_session_id(self) -> str:
-        """
-        Create a new session ID (this method doesn't need to be async)
-        """
-        session_id = str(uuid.uuid4())
-        logger.debug(f"Created new session ID: {session_id}")
-        return session_id
 
 shell_service = ShellService()

--- a/sandbox/app/services/shell.py
+++ b/sandbox/app/services/shell.py
@@ -25,6 +25,10 @@ ANSI_ESCAPE_PATTERN = re.compile(r'\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])')
 EXEC_WAIT_SECONDS = 5
 # Default timeout for wait_for_process when none is given
 DEFAULT_WAIT_SECONDS = 60
+# Default maximum length of output returned to clients, longer output is truncated
+DEFAULT_OUTPUT_MAX_LENGTH = 10000
+# Maximum output kept in memory per session, older output is discarded
+MAX_STORED_OUTPUT_LENGTH = 1024 * 1024
 
 
 @dataclass
@@ -58,6 +62,22 @@ class ShellService:
     def _remove_ansi_escape_codes(text: str) -> str:
         """Remove ANSI escape codes from text"""
         return ANSI_ESCAPE_PATTERN.sub('', text)
+
+    @staticmethod
+    def _truncate_output(text: str, max_length: Optional[int]) -> str:
+        """Truncate output to max_length, keeping the most recent (tail) part"""
+        if max_length is not None and max_length > 0 and len(text) > max_length:
+            return "(truncated)" + text[-max_length:]
+        return text
+
+    @staticmethod
+    def _append_bounded(stored: str, new_output: str) -> str:
+        """Append new output to stored output, discarding the oldest part beyond the memory cap"""
+        stored += new_output
+        # Allow some slack before trimming to avoid copying the string on every append
+        if len(stored) > MAX_STORED_OUTPUT_LENGTH + 64 * 1024:
+            stored = stored[-MAX_STORED_OUTPUT_LENGTH:]
+        return stored
 
     @staticmethod
     def _get_display_path(path: str) -> str:
@@ -115,9 +135,10 @@ class ShellService:
             session = self.active_shells.get(session_id)
             # Only record output if this process is still the session's current one
             if session and session.process is process:
-                session.output += output
+                session.output = self._append_bounded(session.output, output)
                 if session.console:
-                    session.console[-1].output += output
+                    record = session.console[-1]
+                    record.output = self._append_bounded(record.output, output)
         logger.debug(f"Output reader for session {session_id} has finished")
 
     async def exec_command(self, session_id: str, exec_dir: Optional[str], command: str) -> ShellExecResult:
@@ -187,25 +208,31 @@ class ShellService:
             output=view_result.output,
         )
 
-    async def view_shell(self, session_id: str, console: bool = False) -> ShellViewResult:
-        """View the output of the specified shell session"""
+    async def view_shell(self, session_id: str, console: bool = False,
+                         max_length: Optional[int] = DEFAULT_OUTPUT_MAX_LENGTH) -> ShellViewResult:
+        """
+        View the output of the specified shell session.
+
+        Output longer than max_length is truncated, keeping the most recent part.
+        """
         logger.debug(f"Viewing shell content for session: {session_id}")
         session = self._get_session(session_id)
         return ShellViewResult(
-            output=self._remove_ansi_escape_codes(session.output),
+            output=self._truncate_output(self._remove_ansi_escape_codes(session.output), max_length),
             session_id=session_id,
-            console=self.get_console_records(session_id) if console else None,
+            console=self.get_console_records(session_id, max_length) if console else None,
         )
 
-    def get_console_records(self, session_id: str) -> List[ConsoleRecord]:
-        """Get console records for the specified session, with ANSI escape codes removed"""
+    def get_console_records(self, session_id: str,
+                            max_length: Optional[int] = DEFAULT_OUTPUT_MAX_LENGTH) -> List[ConsoleRecord]:
+        """Get console records for the specified session, with ANSI escape codes removed and output truncated"""
         logger.debug(f"Getting console records for session: {session_id}")
         session = self._get_session(session_id)
         return [
             ConsoleRecord(
                 ps1=record.ps1,
                 command=record.command,
-                output=self._remove_ansi_escape_codes(record.output),
+                output=self._truncate_output(self._remove_ansi_escape_codes(record.output), max_length),
             )
             for record in session.console
         ]

--- a/sandbox/app/services/supervisor.py
+++ b/sandbox/app/services/supervisor.py
@@ -1,22 +1,28 @@
+"""
+Supervisor Service Implementation
+"""
 import threading
 import xmlrpc.client
 import socket
 import http.client
 import asyncio
 from datetime import datetime, timedelta
-from typing import List
+from typing import List, Optional
 
 from app.core.config import settings
 from app.core.exceptions import BadRequestException, ResourceNotFoundException
 from app.models.supervisor import (
-    ProcessInfo, 
-    SupervisorActionResult, 
+    ProcessInfo,
+    SupervisorActionResult,
     SupervisorTimeout
 )
 
+SUPERVISOR_SOCKET_PATH = "/tmp/supervisor.sock"
 
-# Add Unix socket support for xmlrpc client
+
 class UnixStreamHTTPConnection(http.client.HTTPConnection):
+    """HTTP connection over a Unix socket, for the supervisord XML-RPC API"""
+
     def __init__(self, host, socket_path, timeout=None):
         http.client.HTTPConnection.__init__(self, host, timeout=timeout)
         self.socket_path = socket_path
@@ -27,6 +33,8 @@ class UnixStreamHTTPConnection(http.client.HTTPConnection):
 
 
 class UnixStreamTransport(xmlrpc.client.Transport):
+    """xmlrpc transport that connects through a Unix socket"""
+
     def __init__(self, socket_path):
         xmlrpc.client.Transport.__init__(self)
         self.socket_path = socket_path
@@ -37,211 +45,175 @@ class UnixStreamTransport(xmlrpc.client.Transport):
 
 class SupervisorService:
     """
-    Supervisor service management class, used for managing service timeout and renewal functionality - Async version
+    Manages supervisord processes and the service auto-shutdown timeout.
     """
+
     def __init__(self):
-        self.rpc_url = "/tmp/supervisor.sock"
-        self._connect_rpc()
-        
+        # ServerProxy connects lazily, on the first RPC call
+        self.server = xmlrpc.client.ServerProxy(
+            'http://localhost',
+            transport=UnixStreamTransport(SUPERVISOR_SOCKET_PATH)
+        )
+
         # Timeout management - enabled based on configuration
         self.timeout_active = settings.SERVICE_TIMEOUT_MINUTES is not None
-        self.shutdown_task = None
-        self.shutdown_time = None
-        # Auto-expand functionality - disabled when user explicitly controls timeout
-        self._auto_expand_enabled = True
-        
-        # If timeout is configured, create scheduled task
+        self.shutdown_task: Optional[asyncio.Task] = None
+        self.shutdown_timer: Optional[threading.Timer] = None
+        self.shutdown_time: Optional[datetime] = None
+        # Auto-extend functionality - disabled when user explicitly controls timeout
+        self._auto_extend_enabled = True
+
         if settings.SERVICE_TIMEOUT_MINUTES is not None:
             self.shutdown_time = datetime.now() + timedelta(minutes=settings.SERVICE_TIMEOUT_MINUTES)
             self._setup_timer(settings.SERVICE_TIMEOUT_MINUTES)
-    
+
     @property
-    def auto_expand_enabled(self) -> bool:
-        """Get auto-expand status"""
-        return self._auto_expand_enabled
-    
-    def disable_auto_expand(self):
-        """Disable auto-expand functionality (called when user explicitly manages timeout)"""
-        self._auto_expand_enabled = False
-    
-    def enable_auto_expand(self):
-        """Enable auto-expand functionality"""
-        self._auto_expand_enabled = True
-    
-    def _connect_rpc(self):
-        """Connect to supervisord's RPC interface"""
-        try:
-            self.server = xmlrpc.client.ServerProxy(
-                'http://localhost',
-                transport=UnixStreamTransport(self.rpc_url)
-            )
-            # Test connection
-            self.server.supervisor.getState()
-        except Exception as e:
-            raise ResourceNotFoundException(f"Cannot connect to Supervisord: {str(e)}")
-    
-    def _setup_timer(self, minutes):
-        """Set up async timer"""
-        # Cancel existing scheduled task
+    def auto_extend_enabled(self) -> bool:
+        """Whether the timeout is automatically extended on API requests"""
+        return self._auto_extend_enabled
+
+    def disable_auto_extend(self):
+        """Disable auto-extend (called when user explicitly manages timeout)"""
+        self._auto_extend_enabled = False
+
+    def _cancel_timer(self):
+        """Cancel any pending shutdown timer"""
         if self.shutdown_task:
-            try:
-                self.shutdown_task.cancel()
-            except:
-                pass
-            
-        # Create scheduled task function
+            self.shutdown_task.cancel()
+            self.shutdown_task = None
+        if self.shutdown_timer:
+            self.shutdown_timer.cancel()
+            self.shutdown_timer = None
+
+    def _setup_timer(self, minutes):
+        """Schedule a shutdown after the given number of minutes"""
+        self._cancel_timer()
+
         async def shutdown_after_timeout():
             await asyncio.sleep(minutes * 60)
             await self.shutdown()
-        
-        # Create scheduled task
+
         try:
-            loop = asyncio.get_event_loop()
+            loop = asyncio.get_running_loop()
             self.shutdown_task = loop.create_task(shutdown_after_timeout())
-        except Exception as e:
-            # If async task creation fails, fall back to thread timer
-            if hasattr(self, 'shutdown_timer') and self.shutdown_timer:
-                self.shutdown_timer.cancel()
-            
+        except RuntimeError:
+            # No running event loop (e.g. during module import): use a thread timer
             self.shutdown_timer = threading.Timer(
-                minutes * 60, 
+                minutes * 60,
                 lambda: asyncio.run(self.shutdown())
             )
             self.shutdown_timer.daemon = True
             self.shutdown_timer.start()
-    
+
     async def _call_rpc(self, method, *args):
         """Execute RPC call asynchronously"""
         try:
             return await asyncio.to_thread(method, *args)
         except Exception as e:
             raise BadRequestException(f"RPC call failed: {str(e)}")
-    
+
     async def get_all_processes(self) -> List[ProcessInfo]:
-        """Asynchronously get all process statuses"""
+        """Get all process statuses"""
         try:
             processes = await self._call_rpc(self.server.supervisor.getAllProcessInfo)
             return [ProcessInfo(**process) for process in processes]
         except Exception as e:
             raise ResourceNotFoundException(f"Failed to get process status: {str(e)}")
-    
+
     async def stop_all_services(self) -> SupervisorActionResult:
-        """Asynchronously stop all services"""
+        """Stop all services"""
         try:
             result = await self._call_rpc(self.server.supervisor.stopAllProcesses)
             return SupervisorActionResult(status="stopped", result=result)
         except Exception as e:
             raise BadRequestException(f"Failed to stop all services: {str(e)}")
-    
+
     async def shutdown(self) -> SupervisorActionResult:
-        """Asynchronously shut down the supervisord service itself, without stopping processes"""
+        """Shut down the supervisord service itself, without stopping processes"""
         try:
             shutdown_result = await self._call_rpc(self.server.supervisor.shutdown)
             return SupervisorActionResult(status="shutdown", shutdown_result=shutdown_result)
         except Exception as e:
             raise BadRequestException(f"Failed to shut down supervisord service: {str(e)}")
-    
+
     async def restart_all_services(self) -> SupervisorActionResult:
-        """Asynchronously restart all services"""
+        """Restart all services"""
         try:
             stop_result = await self._call_rpc(self.server.supervisor.stopAllProcesses)
             start_result = await self._call_rpc(self.server.supervisor.startAllProcesses)
             return SupervisorActionResult(
-                status="restarted", 
+                status="restarted",
                 stop_result=stop_result,
                 start_result=start_result
             )
         except Exception as e:
             raise BadRequestException(f"Failed to restart services: {str(e)}")
-    
-    async def activate_timeout(self, minutes=None) -> SupervisorTimeout:
+
+    def _schedule_shutdown(self, minutes: Optional[int], status: str) -> SupervisorTimeout:
         """
-        Asynchronously activate timeout functionality, automatically shut down all services after the set time
-        
+        (Re)schedule the automatic shutdown.
+
+        Args:
+            minutes: Timeout in minutes, falls back to the configured default
+            status: Status string to report in the result
+        """
+        timeout_minutes = minutes or settings.SERVICE_TIMEOUT_MINUTES
+        if timeout_minutes is None:
+            raise BadRequestException("Timeout not specified, and system default is no timeout")
+
+        self.timeout_active = True
+        self.shutdown_time = datetime.now() + timedelta(minutes=timeout_minutes)
+        self._setup_timer(timeout_minutes)
+
+        return SupervisorTimeout(
+            status=status,
+            active=True,
+            shutdown_time=self.shutdown_time.isoformat(),
+            timeout_minutes=timeout_minutes
+        )
+
+    async def activate_timeout(self, minutes: Optional[int] = None) -> SupervisorTimeout:
+        """
+        Activate timeout functionality, automatically shutting down all services
+        after the given time
+
         Args:
             minutes: Timeout in minutes, if None then use the configured default value
         """
-        # Set timeout
-        timeout_minutes = minutes or settings.SERVICE_TIMEOUT_MINUTES
-        
-        # If no timeout is specified and no default in config, throw error
-        if timeout_minutes is None:
-            raise BadRequestException("Timeout not specified, and system default is no timeout")
-            
-        self.timeout_active = True
-        self.shutdown_time = datetime.now() + timedelta(minutes=timeout_minutes)
-        
-        # Set up timer
-        self._setup_timer(timeout_minutes)
-        
-        return SupervisorTimeout(
-            status="timeout_activated",
-            active=True,
-            shutdown_time=self.shutdown_time.isoformat(),
-            timeout_minutes=timeout_minutes
-        )
-    
-    async def extend_timeout(self, minutes=None) -> SupervisorTimeout:
+        return self._schedule_shutdown(minutes, status="timeout_activated")
+
+    async def extend_timeout(self, minutes: Optional[int] = None) -> SupervisorTimeout:
         """
-        Asynchronously extend timeout
-        
+        Extend the timeout
+
         Args:
             minutes: Number of minutes to extend, if None then use the configured default value
         """
-        # Set new timeout
-        timeout_minutes = minutes or settings.SERVICE_TIMEOUT_MINUTES
-        
-        # If no timeout is specified and no default in config, throw error
-        if timeout_minutes is None:
-            raise BadRequestException("Timeout not specified, and system default is no timeout")
-            
-        self.timeout_active = True
-        self.shutdown_time = datetime.now() + timedelta(minutes=timeout_minutes)
-        
-        # Set up timer
-        self._setup_timer(timeout_minutes)
-        
-        return SupervisorTimeout(
-            status="timeout_extended",
-            active=True,
-            shutdown_time=self.shutdown_time.isoformat(),
-            timeout_minutes=timeout_minutes
-        )
-    
+        return self._schedule_shutdown(minutes, status="timeout_extended")
+
     async def cancel_timeout(self) -> SupervisorTimeout:
-        """Asynchronously cancel timeout functionality"""
+        """Cancel timeout functionality"""
         if not self.timeout_active:
             return SupervisorTimeout(status="no_timeout_active", active=False)
-        
-        if self.shutdown_task:
-            try:
-                self.shutdown_task.cancel()
-                self.shutdown_task = None
-            except:
-                pass
-        
-        # Also check thread timer (for compatibility)
-        if hasattr(self, 'shutdown_timer') and self.shutdown_timer:
-            self.shutdown_timer.cancel()
-            self.shutdown_timer = None
-        
+
+        self._cancel_timer()
         self.timeout_active = False
         self.shutdown_time = None
-        # Re-enable auto-expand when timeout is cancelled
-        self._auto_expand_enabled = True
-        
+        # Re-enable auto-extend when timeout is cancelled
+        self._auto_extend_enabled = True
+
         return SupervisorTimeout(status="timeout_cancelled", active=False)
-    
+
     async def get_timeout_status(self) -> SupervisorTimeout:
-        """Asynchronously get current timeout status"""
+        """Get current timeout status"""
         if not self.timeout_active:
             return SupervisorTimeout(active=False)
-        
+
         remaining_seconds = 0
         if self.shutdown_time:
             remaining = self.shutdown_time - datetime.now()
             remaining_seconds = max(0, remaining.total_seconds())
-        
+
         return SupervisorTimeout(
             active=self.timeout_active,
             shutdown_time=self.shutdown_time.isoformat() if self.shutdown_time else None,
@@ -249,5 +221,4 @@ class SupervisorService:
         )
 
 
-# Global instance
-supervisor_service = SupervisorService() 
+supervisor_service = SupervisorService()

--- a/sandbox/resource/test_upload_unique.txt
+++ b/sandbox/resource/test_upload_unique.txt
@@ -1,1 +1,0 @@
-This is test upload content

--- a/sandbox/tests/conftest.py
+++ b/sandbox/tests/conftest.py
@@ -2,18 +2,17 @@
 Pytest configuration and fixtures
 """
 import sys
-import os
-import pytest
-import tempfile
 from pathlib import Path
 
 # Add the parent directory to Python path so we can import app modules
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
+import pytest
 import requests
 
 # Base URL for API testing
 BASE_URL = "http://localhost:8080"
+
 
 @pytest.fixture
 def client():
@@ -24,28 +23,23 @@ def client():
 
 
 @pytest.fixture
-def temp_test_file():
-    """Create temporary test file path for container"""
-    # Use container-accessible path
+def temp_test_file(client):
+    """Create temporary test file inside the sandbox via the file API"""
     temp_file = "/tmp/test_file.txt"
-    # Create content via API
-    import requests
-    session = requests.Session()
-    session.headers.update({"Content-Type": "application/json"})
-    
+
     content = "Line 1: Hello World\nLine 2: This is a test\nLine 3: Python testing"
-    session.post(f"{BASE_URL}/api/v1/file/write", json={
+    client.post(f"{BASE_URL}/api/v1/file/write", json={
         "file": temp_file,
         "content": content
     })
-    
+
     yield temp_file
-    
+
     # Cleanup via API
     try:
-        session.post(f"{BASE_URL}/api/v1/file/write", json={
+        client.post(f"{BASE_URL}/api/v1/file/write", json={
             "file": temp_file,
             "content": ""
         })
-    except:
-        pass 
+    except requests.RequestException:
+        pass

--- a/sandbox/tests/test_api_file.py
+++ b/sandbox/tests/test_api_file.py
@@ -1,10 +1,8 @@
-import pytest
-import tempfile
-import os
-from unittest.mock import patch, mock_open
-from conftest import BASE_URL
 import logging
 
+import pytest
+import requests
+from conftest import BASE_URL
 
 logger = logging.getLogger(__name__)
 
@@ -12,21 +10,18 @@ logger = logging.getLogger(__name__)
 @pytest.mark.file_api
 def test_upload_file_success(client):
     """Test successful file upload"""
-    temp_path = "resource/test_upload_unique.txt"  # Use unique filename
-    
-    # Create test file content
+    temp_path = "/tmp/test_upload_unique.txt"
     test_content = b"This is test upload content"
-    
+
     # For file upload, create a new requests session without JSON headers
-    import requests
     upload_client = requests.Session()
-    
+
     response = upload_client.post(
         f"{BASE_URL}/api/v1/file/upload",
         files={"file": ("test.txt", test_content, "text/plain")},
         data={"path": temp_path}
     )
-    
+
     assert response.status_code == 200
     data = response.json()
 
@@ -34,7 +29,7 @@ def test_upload_file_success(client):
 
     assert data["success"] is True
     assert "File uploaded successfully" in data["message"]
-    
+
     # Verify file was created via API
     read_response = client.post(f"{BASE_URL}/api/v1/file/read", json={
         "file": temp_path
@@ -49,7 +44,7 @@ def test_upload_file_success(client):
 def test_download_file_success(client, temp_test_file):
     """Test successful file download"""
     response = client.get(f"{BASE_URL}/api/v1/file/download", params={"path": temp_test_file})
-    
+
     assert response.status_code == 200
     assert response.headers["content-type"] == "application/octet-stream"
     assert "attachment" in response.headers.get("content-disposition", "")
@@ -58,8 +53,8 @@ def test_download_file_success(client, temp_test_file):
 @pytest.mark.file_api
 def test_download_nonexistent_file(client):
     """Test downloading non-existent file"""
-    response = client.get(f"{BASE_URL}/api/v1/file/download", params={"path": "1nonexistent.txt"})
+    response = client.get(f"{BASE_URL}/api/v1/file/download", params={"path": "/tmp/nonexistent.txt"})
 
     logger.info(f"Download response: {response.status_code}")
-    
-    assert response.status_code == 404 or response.status_code == 500
+
+    assert response.status_code == 404


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Cleans up the sandbox service without changing its API contract (verified against the routes the backend's `docker_sandbox.py` calls), and adds output truncation to the shell API.

### Shell output truncation (new)
- `shell/view` and console records now truncate output to `max_length` (default 10000 chars), keeping the most recent tail with a `(truncated)` prefix; `shell/exec` results get the same default
- New optional `max_length` field on the `shell/view` request, mirroring `file/read`
- Stored per-session output is capped at 1MB (with 64KB slack to avoid copying on every 128-byte append), discarding the oldest output — previously a chatty long-running process grew session memory without bound

### `app/services/shell.py`
- Replace the untyped `Dict[str, Dict[str, Any]]` session store with a typed `ShellSession` dataclass
- Extract `_get_session` (deduplicates 5 copies of the "session not found" check) and `_terminate_process` (deduplicates graceful-terminate/force-kill logic used by both `exec_command` and `kill_process`)
- Remove dead code: unused `ShellTask` model, `shell_tasks` store, unused `subprocess`/`Tuple` imports, and an unused `get_console_records` call in `exec_command`
- Fix the `console` parameter being shadowed by a local variable in `view_shell`
- Straighten out `exec_command` control flow (single create-process path, no nested try/except swallowing) and guard the output reader so a replaced process can't write into the new command's output
- Compile the ANSI-escape regex once at module level

### `app/services/supervisor.py`
- Connect to supervisord lazily (`ServerProxy` connects on first RPC call), so importing the app no longer requires a running supervisord
- Deduplicate `activate_timeout` / `extend_timeout` into a shared `_schedule_shutdown`
- Fix the import-time shutdown timer: it previously created an asyncio task on a never-running loop (silently doing nothing); now it uses `get_running_loop()` and falls back to `threading.Timer` when no loop is running
- Centralize timer cancellation in `_cancel_timer`, remove bare `except:` blocks, unify `auto_expand`/`auto_extend` naming

### `app/services/file.py`
- Remove unused imports (`subprocess`, `mimetypes`, `BinaryIO`), rename misleading `*_async` inner functions (they are sync functions run via `asyncio.to_thread`), simplify `ensure_file` and exception re-raising

### API layer
- Move `TimeoutRequest` out of the route file into `app/schemas/supervisor.py`
- Serialize all supervisor responses with `model_dump()` for consistency; add `response_model=Response` to the upload route
- Drop redundant empty-session-ID checks now handled by the service layer; use `os.path.basename` for the download filename

### Misc
- `main.py`: remove duplicated log-level setup
- `config.py`: migrate deprecated `class Config` to `SettingsConfigDict`
- Tests: upload to `/tmp` instead of the mounted repo directory — this removes `sandbox/resource/test_upload_unique.txt`, which a previous test run had accidentally committed into the repo; clean up unused imports and reuse the `client` fixture

## Testing

- ✅ `cd sandbox && uv run pytest` — 3 passed against the running dev sandbox container
- ✅ Manual curl verification of every endpoint against the dev container: `shell/exec` (fast + long-running + session reuse), `shell/view` (with console records), `shell/wait` (timeout 400), `shell/write` (interactive `cat`), `shell/kill`, `file/read|write|replace|search|find|upload|download` (incl. sudo read, invalid regex 400, missing file 404), `supervisor/status`, `supervisor/timeout/activate|extend|cancel|status`
- ✅ Truncation verified against the dev container: small output untouched; 200KB `seq` output returns 10011 chars starting with `(truncated)` and keeping the last line; `max_length=50` honored on `shell/view`; console records truncated too; 5MB `yes` output stored at ~1MB in memory with the tail (`DONE_MARKER`) preserved
- ✅ Full-stack end-to-end GUI test (frontend + backend + mockserver + refactored sandbox): sent a task in the web UI at `localhost:5173`; the mock-LLM-driven agent flow completed — plan, notify message, web search, three `file/write`s, `shell/exec` (`ls -a`), browser navigation, completion with attachments. Sandbox access logs show all `file/read`, `file/write`, `shell/exec`, `shell/view` calls returning 200, and the files exist in the sandbox with the expected content.

[e2e_agent_flow_shell_file_tools.mp4](https://cursor.com/agents/bc-019f380c-1df2-785e-82fb-b07293fca780/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fe2e_agent_flow_shell_file_tools.mp4)

[Shell tool view showing ls -a output with the created files](https://cursor.com/agents/bc-019f380c-1df2-785e-82fb-b07293fca780/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fe2e_shell_tool_view_ls_output.webp)
[Completed task with attachment cards](https://cursor.com/agents/bc-019f380c-1df2-785e-82fb-b07293fca780/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fe2e_final_completed_with_attachments.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f380c-1df2-785e-82fb-b07293fca780"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f380c-1df2-785e-82fb-b07293fca780"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

