### PR TITLE
fix(claw): honor container args in entrypoint so compose "exit 0" overrides work

### DIFF
--- a/claw/entrypoint.sh
+++ b/claw/entrypoint.sh
@@ -1,6 +1,14 @@
 #!/bin/bash
 set -e
 
+# If arguments are provided, run them instead of the gateway. This makes the
+# compose "prevent claw from starting" override (entrypoint/command:
+# /bin/sh -c "exit 0") work even with compose implementations that pass the
+# override as container args to the image entrypoint instead of replacing it.
+if [ "$#" -gt 0 ]; then
+    exec "$@"
+fi
+
 CONFIG_DIR="/home/node/.openclaw"
 CONFIG_FILE="${CONFIG_DIR}/openclaw.json"
 mkdir -p "${CONFIG_DIR}/workspace"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Users reported that the `claw` service in the image-pull-only compose configuration does not exit as expected:

```yaml
claw:
    image: simpleyyt/manus-claw
    entrypoint: /bin/sh -c "exit 0"  # prevent claw from starting, ensure image is pulled
    restart: "no"
```

```
ai-manus-service-claw-1   simpleyyt/manus-claw   "/entrypoint.sh /bin…"   Up 9 seconds (health: starting)
```

The `COMMAND` column (`/entrypoint.sh /bin…`) shows that the override ended up as container *args* rather than replacing the entrypoint (this happens with older downloaded compose files that still use `command:` from before a0cf379, and with some non-standard compose implementations). Since `claw/entrypoint.sh` ignored all arguments and unconditionally started the OpenClaw gateway, the container stayed up instead of exiting.

## Fix

`claw/entrypoint.sh` now `exec "$@"` when any arguments are passed, so both override styles work:

- `entrypoint: /bin/sh -c "exit 0"` — replaced entrypoint, exits 0 (unchanged behavior)
- `command: /bin/sh -c "exit 0"` — args passed to the entrypoint, now also exits 0

With no arguments (normal operation, including containers spawned by `DockerClawRuntime`), the gateway starts exactly as before.

## Verification

- Reproduced the reported bug with the published `simpleyyt/manus-claw` image + `command:` override: container stays `Up (healthy)`.
- Built the fixed image and ran both compose override styles: both containers exit 0 immediately.
- Ran the fixed image with no args: gateway boots normally and the container reports `Up (healthy)`.

[claw_exit0_override_test_results.log](https://cursor.com/agents/bc-5c3ba502-ef84-4476-ac16-4c390581716f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fclaw_exit0_override_test_results.log)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5c3ba502-ef84-4476-ac16-4c390581716f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5c3ba502-ef84-4476-ac16-4c390581716f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

