### PR TITLE
feat: support non-Docker development environment

### DIFF
--- a/.cursor/skills/starter.md
+++ b/.cursor/skills/starter.md
@@ -54,6 +54,8 @@ Set `AUTH_PROVIDER=local`. Login at `http://localhost:5173/login` with `LOCAL_AU
 
 ## 2 · Running Services Individually (Without Docker)
 
+> Shortcut: `./dev-local.sh up` starts the whole non-Docker stack (mongodb, redis, mockserver, sandbox, backend, frontend) as host processes, reusing anything already listening on the standard ports. `./dev-local.sh status|logs <svc>|down` manage it; state lives in `.dev-local/`. The steps below are for running services one at a time.
+
 ### Backend
 
 ```bash
@@ -79,7 +81,13 @@ Opens on `http://localhost:5173`. The Vite config auto-creates a proxy for `/api
 
 ### Sandbox
 
-The sandbox is typically used inside Docker (it runs Xvfb, Chrome, VNC via supervisord). Running it standalone requires those system dependencies.
+```bash
+cd sandbox
+uv sync
+uv run uvicorn app.main:app --host 0.0.0.0 --port 8080 --reload
+```
+
+Without supervisord (outside Docker) the sandbox starts in **standalone mode**: shell/file APIs work against the host machine and supervisor status is synthesized as RUNNING, but browser/CDP/VNC features are unavailable (those need the Docker image with Xvfb/Chrome/supervisord).
 
 ### Mockserver
 

--- a/.env.example
+++ b/.env.example
@@ -19,18 +19,23 @@ MAX_TOKENS=2000
 #LLM_PROVIDER=langchain
 
 # MongoDB configuration
+# For non-Docker development use mongodb://localhost:27017 (or ./dev-local.sh,
+# which rewrites the hostname automatically)
 #MONGODB_URI=mongodb://mongodb:27017
 #MONGODB_DATABASE=manus
 #MONGODB_USERNAME=
 #MONGODB_PASSWORD=
 
 # Redis configuration
+# For non-Docker development use localhost (or ./dev-local.sh)
 #REDIS_HOST=redis
 #REDIS_PORT=6379
 #REDIS_DB=0
 #REDIS_PASSWORD=
 
 # Sandbox configuration
+# SANDBOX_ADDRESS: use a single fixed sandbox instead of creating Docker
+# containers per session (e.g. 127.0.0.1 for a sandbox running on the host)
 #SANDBOX_ADDRESS=
 SANDBOX_IMAGE=simpleyyt/manus-sandbox
 SANDBOX_NAME_PREFIX=sandbox

--- a/.gitignore
+++ b/.gitignore
@@ -125,3 +125,6 @@ mcp.json
 
 uv.lock
 specs
+
+# Non-Docker local dev stack (dev-local.sh) runtime state
+.dev-local/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,6 +40,7 @@ ai-manus/
 ├── docs/              # Docsify documentation site
 ├── .cursor/skills/    # Cursor agent skills
 ├── dev.sh             # Shortcut: docker compose -f docker-compose-development.yml ...
+├── dev-local.sh       # Non-Docker dev stack (host processes: mongodb/redis/mockserver/sandbox/backend/frontend)
 ├── run.sh             # Shortcut: docker compose -f docker-compose.yml ...
 ├── build.sh           # docker buildx bake
 ├── .env.example       # Environment variable template
@@ -79,6 +80,21 @@ This starts: frontend (5173), backend (8000), sandbox (8080), mockserver (8090),
 | `SANDBOX_ADDRESS` | `sandbox` | Use single dev sandbox container |
 | `LOG_LEVEL` | `DEBUG` | Verbose logging |
 
+### Non-Docker Development Stack (dev-local.sh)
+
+When Docker is unavailable, run the whole stack as host processes:
+
+```bash
+./dev-local.sh up          # mongodb, redis, mockserver, sandbox, backend, frontend
+./dev-local.sh status      # show service status
+./dev-local.sh logs backend
+./dev-local.sh down
+```
+
+Requires `uv`, Node.js/npm, and MongoDB + Redis (local `mongod`/`redis-server` binaries, or instances already listening on `localhost:27017`/`localhost:6379`). The script reads `.env` and rewrites compose hostnames (`mongodb`, `redis`, `mockserver`, `backend`) to `localhost`; it defaults to `AUTH_PROVIDER=none` and the mockserver LLM. Logs and PIDs live in `.dev-local/`.
+
+Limitations: the sandbox runs in **standalone mode** directly on the host (shell/file tools work, browser tools are unavailable — no Chrome/CDP/VNC); Claw is not started.
+
 ### Running Services Individually (Without Docker)
 
 **Backend:**
@@ -97,7 +113,13 @@ BACKEND_URL=http://localhost:8000 npm run dev
 ```
 The Vite config creates a proxy for `/api` when `BACKEND_URL` is set.
 
-**Sandbox:** Typically Docker-only (requires Xvfb, Chrome, VNC, supervisord).
+**Sandbox:**
+```bash
+cd sandbox
+uv sync
+uv run uvicorn app.main:app --host 0.0.0.0 --port 8080 --reload
+```
+Without supervisord (outside Docker) the sandbox starts in **standalone mode**: shell/file APIs work against the host, supervisor status is synthesized as RUNNING, browser/VNC features are unavailable. Full browser support requires the Docker image.
 
 **Mockserver:**
 ```bash
@@ -219,7 +241,7 @@ Single GitHub Actions workflow: `.github/workflows/docker-build-and-push.yml`
 
 When running in a Cloud Agent environment:
 
-1. Docker may not be available. If Docker commands fail, focus on running individual services or testing code changes without the full stack.
+1. Docker may not be available. If Docker commands fail, use `./dev-local.sh up` to run the stack as host processes (see "Non-Docker Development Stack"), or run individual services manually.
 2. For backend work, install dependencies with `cd backend && uv sync`.
 3. For frontend work, install dependencies with `cd frontend && npm install`.
 4. Set `AUTH_PROVIDER=none` and `API_KEY=test` in `.env` to bypass auth and LLM requirements.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,6 +58,8 @@ cd backend && uv sync && uv run uvicorn app.main:app --reload --port 8000   # ne
 cd frontend && npm install && BACKEND_URL=http://localhost:8000 npm run dev  # BACKEND_URL enables the /api proxy
 ```
 
+Or run the whole stack without Docker: `./dev-local.sh up` (host processes for mongodb/redis/mockserver/sandbox/backend/frontend; sandbox runs in standalone mode — shell/file tools work, browser tools don't). `./dev-local.sh down` stops everything; logs live in `.dev-local/logs/`.
+
 ## Backend architecture (the part worth understanding)
 
 The backend follows **Domain-Driven Design** with strict layer dependencies pointing inward: `interfaces/` → `application/` → `domain/` ← `infrastructure/`.

--- a/README.md
+++ b/README.md
@@ -244,6 +244,30 @@ All services will run in reload mode, and code changes will be automatically rel
 ./dev.sh up
 ```
 
+### Development without Docker
+
+If Docker is not available (or you prefer running services natively), use `dev-local.sh` to run the whole development stack as plain host processes:
+
+```bash
+# Start everything: mongodb, redis, mockserver, sandbox, backend, frontend
+./dev-local.sh up
+
+# Check status / tail logs / stop
+./dev-local.sh status
+./dev-local.sh logs backend
+./dev-local.sh down
+```
+
+Requirements: `uv` (Python package manager), Node.js + npm, and MongoDB & Redis (either installed locally — `mongod` / `redis-server` — or already listening on `localhost:27017` / `localhost:6379`; the script reuses running instances and only starts its own when the port is free).
+
+The script reads your `.env` and automatically rewrites Docker Compose hostnames (`mongodb`, `redis`, `mockserver`, `backend`) to `localhost`, so the same `.env` works for both `./dev.sh` and `./dev-local.sh`. It also defaults to `AUTH_PROVIDER=none` and the mockserver LLM.
+
+Notes and limitations of the non-Docker mode:
+- The sandbox runs **directly on your machine** in *standalone mode*: shell and file tools executed by the agent operate on the host (no isolation). Use only for development.
+- Browser tools are unavailable (no Chrome/CDP/VNC managed by supervisord). Agent browser tool calls will return errors; everything else works.
+- Claw is not started; keep `CLAW_ENABLED=false` (default), or run a Claw container yourself and set `CLAW_ADDRESS`.
+- You can also start any subset, e.g. `./dev-local.sh up mockserver backend frontend`, and run other services with Docker.
+
 ### Image Publishing
 
 ```bash

--- a/README_zh.md
+++ b/README_zh.md
@@ -245,6 +245,30 @@ MODEL_NAME=gpt-4o
 ./dev.sh up
 ```
 
+### 非 Docker 开发
+
+如果环境中没有 Docker(或者你更喜欢直接在本机运行服务),可以使用 `dev-local.sh` 以普通宿主机进程的方式运行整个开发栈:
+
+```bash
+# 启动全部服务:mongodb、redis、mockserver、sandbox、backend、frontend
+./dev-local.sh up
+
+# 查看状态 / 查看日志 / 停止
+./dev-local.sh status
+./dev-local.sh logs backend
+./dev-local.sh down
+```
+
+依赖要求:`uv`(Python 包管理器)、Node.js + npm,以及 MongoDB 和 Redis(本地安装 `mongod` / `redis-server`,或已有实例监听 `localhost:27017` / `localhost:6379`;脚本会优先复用已运行的实例,端口空闲时才自行启动)。
+
+脚本会读取 `.env`,并自动把 Docker Compose 的服务主机名(`mongodb`、`redis`、`mockserver`、`backend`)改写为 `localhost`,因此同一份 `.env` 可以同时用于 `./dev.sh` 和 `./dev-local.sh`。默认还会启用 `AUTH_PROVIDER=none` 和 mockserver 模拟 LLM。
+
+非 Docker 模式的注意事项与限制:
+- 沙盒以 *standalone 模式* **直接运行在你的机器上**:Agent 执行的 shell 和文件工具会直接操作宿主机(没有隔离),仅供开发使用。
+- 浏览器工具不可用(没有 supervisord 管理的 Chrome/CDP/VNC),Agent 的浏览器工具调用会返回错误,其余功能正常。
+- Claw 不会启动;保持 `CLAW_ENABLED=false`(默认),或自行运行 Claw 容器并设置 `CLAW_ADDRESS`。
+- 也可以只启动部分服务,例如 `./dev-local.sh up mockserver backend frontend`,其余服务用 Docker 运行。
+
 ### 镜像发布
 
 ```bash

--- a/dev-local.sh
+++ b/dev-local.sh
@@ -1,0 +1,305 @@
+#!/bin/bash
+#
+# dev-local.sh — Run the AI Manus development stack WITHOUT Docker.
+#
+# Starts (as plain host processes):
+#   - mockserver  (port 8090)  mock LLM server
+#   - sandbox     (port 8080)  sandbox API in standalone mode (no Chrome/VNC)
+#   - backend     (port 8000)  FastAPI backend
+#   - frontend    (port 5173)  Vite dev server
+#   - mongodb     (port 27017) only if `mongod` is installed and nothing is listening
+#   - redis       (port 6379)  only if `redis-server` is installed and nothing is listening
+#
+# MongoDB and Redis are required by the backend. If they are already running
+# (natively or otherwise) on localhost, they are reused as-is.
+#
+# Usage:
+#   ./dev-local.sh up [service...]      # start all (or selected) services
+#   ./dev-local.sh down [service...]    # stop all (or selected) services
+#   ./dev-local.sh status               # show service status
+#   ./dev-local.sh logs <service>       # tail logs of a service
+#
+# Configuration is read from .env (if present). Docker-compose hostnames
+# (mongodb / redis / mockserver / backend) are automatically rewritten to
+# localhost, so the same .env works for both ./dev.sh and ./dev-local.sh.
+#
+# NOTE: the sandbox runs directly on YOUR machine — shell/file tools executed
+# by the agent operate on the host. Browser tools are unavailable in this
+# mode (no Chrome/CDP); the corresponding tool calls will return errors.
+
+set -u
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RUN_DIR="$ROOT_DIR/.dev-local"
+LOG_DIR="$RUN_DIR/logs"
+DATA_DIR="$RUN_DIR/data"
+mkdir -p "$RUN_DIR" "$LOG_DIR" "$DATA_DIR"
+
+ALL_SERVICES=(mongodb redis mockserver sandbox backend frontend)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+log()  { echo "[dev-local] $*"; }
+warn() { echo "[dev-local] WARN: $*" >&2; }
+die()  { echo "[dev-local] ERROR: $*" >&2; exit 1; }
+
+port_in_use() {
+    # $1 = port
+    if command -v python3 &>/dev/null; then
+        python3 - "$1" <<'EOF'
+import socket, sys
+s = socket.socket()
+s.settimeout(0.5)
+sys.exit(0 if s.connect_ex(("127.0.0.1", int(sys.argv[1]))) == 0 else 1)
+EOF
+    else
+        (exec 3<>"/dev/tcp/127.0.0.1/$1") 2>/dev/null && { exec 3>&-; return 0; } || return 1
+    fi
+}
+
+pid_file() { echo "$RUN_DIR/$1.pid"; }
+
+service_pid() {
+    local f
+    f="$(pid_file "$1")"
+    [ -f "$f" ] && cat "$f" 2>/dev/null || true
+}
+
+service_running() {
+    local pid
+    pid="$(service_pid "$1")"
+    [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null
+}
+
+start_process() {
+    # $1 = service name, $2 = working dir, rest = command
+    local name="$1" dir="$2"
+    shift 2
+    if service_running "$name"; then
+        log "$name already running (pid $(service_pid "$name"))"
+        return 0
+    fi
+    log "starting $name ..."
+    # setsid (when available) makes the service a process-group leader so
+    # `down` can kill the whole tree (uv/npm spawn children).
+    local runner=()
+    command -v setsid &>/dev/null && runner=(setsid)
+    (cd "$dir" && nohup "${runner[@]}" "$@" >>"$LOG_DIR/$name.log" 2>&1 &
+     echo $! >"$(pid_file "$name")")
+    sleep 1
+    if service_running "$name"; then
+        log "$name started (pid $(service_pid "$name"), log: .dev-local/logs/$name.log)"
+    else
+        warn "$name failed to start — check .dev-local/logs/$name.log"
+        return 1
+    fi
+}
+
+stop_process() {
+    local name="$1" pid
+    pid="$(service_pid "$name")"
+    if [ -z "$pid" ] || ! kill -0 "$pid" 2>/dev/null; then
+        log "$name is not running"
+        rm -f "$(pid_file "$name")"
+        return 0
+    fi
+    log "stopping $name (pid $pid) ..."
+    # Kill the whole process group when possible (uv/npm spawn children)
+    kill -- -"$pid" 2>/dev/null || kill "$pid" 2>/dev/null
+    for _ in $(seq 1 20); do
+        kill -0 "$pid" 2>/dev/null || break
+        sleep 0.5
+    done
+    if kill -0 "$pid" 2>/dev/null; then
+        kill -9 -- -"$pid" 2>/dev/null || kill -9 "$pid" 2>/dev/null
+    fi
+    rm -f "$(pid_file "$name")"
+    log "$name stopped"
+}
+
+require_cmd() {
+    command -v "$1" &>/dev/null || die "'$1' is required but not installed. $2"
+}
+
+# ---------------------------------------------------------------------------
+# Environment
+# ---------------------------------------------------------------------------
+
+load_env() {
+    # Load .env then rewrite docker-compose hostnames for host networking.
+    if [ -f "$ROOT_DIR/.env" ]; then
+        set -a
+        # shellcheck disable=SC1091
+        source "$ROOT_DIR/.env"
+        set +a
+    fi
+
+    # Rewrite compose service hostnames to localhost
+    export MONGODB_URI="${MONGODB_URI:-mongodb://localhost:27017}"
+    MONGODB_URI="${MONGODB_URI/mongodb:\/\/mongodb/mongodb://localhost}"
+    export REDIS_HOST="${REDIS_HOST:-localhost}"
+    [ "$REDIS_HOST" = "redis" ] && export REDIS_HOST=localhost
+    export API_BASE="${API_BASE:-http://localhost:8090/v1}"
+    API_BASE="${API_BASE/\/\/mockserver/\/\/localhost}"
+    export API_KEY="${API_KEY:-local-dev-key}"
+
+    # Point the backend at the host sandbox / claw
+    export SANDBOX_ADDRESS="${SANDBOX_ADDRESS:-127.0.0.1}"
+    [ "$SANDBOX_ADDRESS" = "sandbox" ] && export SANDBOX_ADDRESS=127.0.0.1
+    export MANUS_API_BASE_URL="${MANUS_API_BASE_URL:-http://localhost:8000}"
+    MANUS_API_BASE_URL="${MANUS_API_BASE_URL/\/\/backend/\/\/localhost}"
+
+    # Development ergonomics
+    export AUTH_PROVIDER="${AUTH_PROVIDER:-none}"
+    export LOG_LEVEL="${LOG_LEVEL:-DEBUG}"
+    export MCP_CONFIG_PATH="${MCP_CONFIG_PATH:-$ROOT_DIR/mcp.json}"
+}
+
+# ---------------------------------------------------------------------------
+# Service definitions
+# ---------------------------------------------------------------------------
+
+start_mongodb() {
+    if port_in_use 27017; then
+        log "mongodb: something is already listening on 27017 — reusing it"
+        return 0
+    fi
+    if ! command -v mongod &>/dev/null; then
+        die "MongoDB is not reachable on localhost:27017 and 'mongod' is not installed.
+  Install MongoDB (https://www.mongodb.com/docs/manual/installation/) or start
+  one yourself, then re-run. Example (Debian/Ubuntu): sudo apt install mongodb-org"
+    fi
+    mkdir -p "$DATA_DIR/mongodb"
+    start_process mongodb "$ROOT_DIR" \
+        mongod --dbpath "$DATA_DIR/mongodb" --bind_ip 127.0.0.1 --port 27017
+}
+
+start_redis() {
+    if port_in_use 6379; then
+        log "redis: something is already listening on 6379 — reusing it"
+        return 0
+    fi
+    if ! command -v redis-server &>/dev/null; then
+        die "Redis is not reachable on localhost:6379 and 'redis-server' is not installed.
+  Install Redis (e.g. sudo apt install redis-server / brew install redis) or
+  start one yourself, then re-run."
+    fi
+    mkdir -p "$DATA_DIR/redis"
+    start_process redis "$ROOT_DIR" \
+        redis-server --port 6379 --bind 127.0.0.1 --dir "$DATA_DIR/redis" --save ''
+}
+
+start_mockserver() {
+    require_cmd uv "Install it from https://docs.astral.sh/uv/"
+    if [ ! -d "$ROOT_DIR/mockserver/.venv" ]; then
+        log "mockserver: creating virtualenv ..."
+        (cd "$ROOT_DIR/mockserver" && uv venv .venv -q \
+            && uv pip install -q --python .venv/bin/python -r requirements.txt) \
+            || die "failed to install mockserver dependencies"
+    fi
+    start_process mockserver "$ROOT_DIR/mockserver" \
+        .venv/bin/uvicorn main:app --host 0.0.0.0 --port 8090
+}
+
+start_sandbox() {
+    require_cmd uv "Install it from https://docs.astral.sh/uv/"
+    log "sandbox: syncing dependencies ..."
+    (cd "$ROOT_DIR/sandbox" && uv sync -q) || die "failed to sync sandbox dependencies"
+    # Standalone mode: no supervisord / Chrome / VNC. Shell & file tools work,
+    # browser tools are unavailable.
+    start_process sandbox "$ROOT_DIR/sandbox" \
+        env LOG_LEVEL="$LOG_LEVEL" \
+        uv run uvicorn app.main:app --host 0.0.0.0 --port 8080 --reload
+}
+
+start_backend() {
+    require_cmd uv "Install it from https://docs.astral.sh/uv/"
+    log "backend: syncing dependencies ..."
+    (cd "$ROOT_DIR/backend" && uv sync -q) || die "failed to sync backend dependencies"
+    start_process backend "$ROOT_DIR/backend" \
+        uv run uvicorn app.main:app --host 0.0.0.0 --port 8000 --reload \
+        --timeout-graceful-shutdown 0
+}
+
+start_frontend() {
+    require_cmd npm "Install Node.js (https://nodejs.org/)"
+    if [ ! -d "$ROOT_DIR/frontend/node_modules" ]; then
+        log "frontend: installing dependencies ..."
+        (cd "$ROOT_DIR/frontend" && npm install --no-audit --no-fund) \
+            || die "failed to install frontend dependencies"
+    fi
+    start_process frontend "$ROOT_DIR/frontend" \
+        env BACKEND_URL=http://localhost:8000 npm run dev -- --host 0.0.0.0
+}
+
+start_service() {
+    case "$1" in
+        mongodb)    start_mongodb ;;
+        redis)      start_redis ;;
+        mockserver) start_mockserver ;;
+        sandbox)    start_sandbox ;;
+        backend)    start_backend ;;
+        frontend)   start_frontend ;;
+        *) die "unknown service: $1 (available: ${ALL_SERVICES[*]})" ;;
+    esac
+}
+
+# ---------------------------------------------------------------------------
+# Commands
+# ---------------------------------------------------------------------------
+
+cmd_up() {
+    load_env
+    local services=("$@")
+    [ ${#services[@]} -eq 0 ] && services=("${ALL_SERVICES[@]}")
+    for s in "${services[@]}"; do
+        start_service "$s"
+    done
+    echo
+    log "stack is up:"
+    log "  frontend:   http://localhost:5173"
+    log "  backend:    http://localhost:8000  (docs: /docs)"
+    log "  sandbox:    http://localhost:8080  (standalone mode, no browser)"
+    log "  mockserver: http://localhost:8090"
+    log "logs: .dev-local/logs/  |  stop: ./dev-local.sh down"
+}
+
+cmd_down() {
+    local services=("$@")
+    [ ${#services[@]} -eq 0 ] && services=(frontend backend sandbox mockserver redis mongodb)
+    for s in "${services[@]}"; do
+        stop_process "$s"
+    done
+}
+
+cmd_status() {
+    for s in "${ALL_SERVICES[@]}"; do
+        if service_running "$s"; then
+            echo "  $s: running (pid $(service_pid "$s"))"
+        else
+            echo "  $s: stopped"
+        fi
+    done
+}
+
+cmd_logs() {
+    [ $# -ge 1 ] || die "usage: ./dev-local.sh logs <service>"
+    local f="$LOG_DIR/$1.log"
+    [ -f "$f" ] || die "no log file for '$1' ($f)"
+    tail -n 100 -f "$f"
+}
+
+usage() {
+    sed -n '2,30p' "$0" | sed 's/^# \{0,1\}//'
+}
+
+case "${1:-}" in
+    up)     shift; cmd_up "$@" ;;
+    down)   shift; cmd_down "$@" ;;
+    status) cmd_status ;;
+    logs)   shift; cmd_logs "$@" ;;
+    -h|--help|help|"") usage ;;
+    *) die "unknown command: $1 (use up / down / status / logs)" ;;
+esac

--- a/dev-local.sh
+++ b/dev-local.sh
@@ -33,7 +33,10 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 RUN_DIR="$ROOT_DIR/.dev-local"
 LOG_DIR="$RUN_DIR/logs"
 DATA_DIR="$RUN_DIR/data"
-mkdir -p "$RUN_DIR" "$LOG_DIR" "$DATA_DIR"
+# Python virtualenvs live under .dev-local so they never clash with the
+# in-project .venv dirs used by the Docker dev stack (bind-mount artifacts).
+VENVS_DIR="$RUN_DIR/venvs"
+mkdir -p "$RUN_DIR" "$LOG_DIR" "$DATA_DIR" "$VENVS_DIR"
 
 ALL_SERVICES=(mongodb redis mockserver sandbox backend frontend)
 
@@ -82,12 +85,25 @@ start_process() {
         return 0
     fi
     log "starting $name ..."
-    # setsid (when available) makes the service a process-group leader so
-    # `down` can kill the whole tree (uv/npm spawn children).
+    # setsid (when available) makes the service a session/process-group leader
+    # so `down` can kill the whole tree (uv/npm spawn children). The wrapper
+    # writes its own pid (== the pgid after setsid) to the pid file.
     local runner=()
     command -v setsid &>/dev/null && runner=(setsid)
-    (cd "$dir" && nohup "${runner[@]}" "$@" >>"$LOG_DIR/$name.log" 2>&1 &
-     echo $! >"$(pid_file "$name")")
+    rm -f "$(pid_file "$name")"
+    (
+        cd "$dir" || exit 1
+        # The `&` must be a standalone statement (not `cd && nohup ... &`,
+        # which backgrounds the whole list and leaves a waiting subshell
+        # holding this script's stdout open).
+        nohup "${runner[@]}" bash -c 'echo $$ >"$0"; exec "$@"' \
+            "$(pid_file "$name")" "$@" >>"$LOG_DIR/$name.log" 2>&1 &
+    )
+    # Wait for the pid file to appear, then for the process to survive startup
+    for _ in $(seq 1 20); do
+        [ -s "$(pid_file "$name")" ] && break
+        sleep 0.2
+    done
     sleep 1
     if service_running "$name"; then
         log "$name started (pid $(service_pid "$name"), log: .dev-local/logs/$name.log)"
@@ -193,39 +209,50 @@ start_redis() {
 
 start_mockserver() {
     require_cmd uv "Install it from https://docs.astral.sh/uv/"
-    if [ ! -d "$ROOT_DIR/mockserver/.venv" ]; then
+    local venv="$VENVS_DIR/mockserver"
+    if [ ! -x "$venv/bin/uvicorn" ]; then
         log "mockserver: creating virtualenv ..."
-        (cd "$ROOT_DIR/mockserver" && uv venv .venv -q \
-            && uv pip install -q --python .venv/bin/python -r requirements.txt) \
+        (cd "$ROOT_DIR/mockserver" && uv venv "$venv" -q \
+            && uv pip install -q --python "$venv/bin/python" -r requirements.txt) \
             || die "failed to install mockserver dependencies"
     fi
     start_process mockserver "$ROOT_DIR/mockserver" \
-        .venv/bin/uvicorn main:app --host 0.0.0.0 --port 8090
+        "$venv/bin/uvicorn" main:app --host 0.0.0.0 --port 8090
 }
 
 start_sandbox() {
     require_cmd uv "Install it from https://docs.astral.sh/uv/"
     log "sandbox: syncing dependencies ..."
-    (cd "$ROOT_DIR/sandbox" && uv sync -q) || die "failed to sync sandbox dependencies"
+    (cd "$ROOT_DIR/sandbox" && UV_PROJECT_ENVIRONMENT="$VENVS_DIR/sandbox" uv sync -q) \
+        || die "failed to sync sandbox dependencies"
     # Standalone mode: no supervisord / Chrome / VNC. Shell & file tools work,
     # browser tools are unavailable.
     start_process sandbox "$ROOT_DIR/sandbox" \
-        env LOG_LEVEL="$LOG_LEVEL" \
+        env LOG_LEVEL="$LOG_LEVEL" UV_PROJECT_ENVIRONMENT="$VENVS_DIR/sandbox" \
         uv run uvicorn app.main:app --host 0.0.0.0 --port 8080 --reload
 }
 
 start_backend() {
     require_cmd uv "Install it from https://docs.astral.sh/uv/"
     log "backend: syncing dependencies ..."
-    (cd "$ROOT_DIR/backend" && uv sync -q) || die "failed to sync backend dependencies"
+    (cd "$ROOT_DIR/backend" && UV_PROJECT_ENVIRONMENT="$VENVS_DIR/backend" uv sync -q) \
+        || die "failed to sync backend dependencies"
     start_process backend "$ROOT_DIR/backend" \
+        env UV_PROJECT_ENVIRONMENT="$VENVS_DIR/backend" \
         uv run uvicorn app.main:app --host 0.0.0.0 --port 8000 --reload \
         --timeout-graceful-shutdown 0
 }
 
 start_frontend() {
     require_cmd npm "Install Node.js (https://nodejs.org/)"
-    if [ ! -d "$ROOT_DIR/frontend/node_modules" ]; then
+    # node_modules may exist but be empty (docker-compose bind-mount artifact),
+    # so check for an actual installed binary.
+    if [ ! -e "$ROOT_DIR/frontend/node_modules/.bin/vite" ]; then
+        if [ -d "$ROOT_DIR/frontend/node_modules" ] && [ ! -w "$ROOT_DIR/frontend/node_modules" ]; then
+            die "frontend/node_modules is not writable (likely a root-owned leftover
+  from the Docker dev stack). Remove it and retry:
+    sudo rm -rf frontend/node_modules"
+        fi
         log "frontend: installing dependencies ..."
         (cd "$ROOT_DIR/frontend" && npm install --no-audit --no-fund) \
             || die "failed to install frontend dependencies"

--- a/docs/en/quick_start.md
+++ b/docs/en/quick_start.md
@@ -140,18 +140,23 @@ MAX_TOKENS=2000
 #LLM_PROVIDER=langchain
 
 # MongoDB configuration
+# For non-Docker development use mongodb://localhost:27017 (or ./dev-local.sh,
+# which rewrites the hostname automatically)
 #MONGODB_URI=mongodb://mongodb:27017
 #MONGODB_DATABASE=manus
 #MONGODB_USERNAME=
 #MONGODB_PASSWORD=
 
 # Redis configuration
+# For non-Docker development use localhost (or ./dev-local.sh)
 #REDIS_HOST=redis
 #REDIS_PORT=6379
 #REDIS_DB=0
 #REDIS_PASSWORD=
 
 # Sandbox configuration
+# SANDBOX_ADDRESS: use a single fixed sandbox instead of creating Docker
+# containers per session (e.g. 127.0.0.1 for a sandbox running on the host)
 #SANDBOX_ADDRESS=
 SANDBOX_IMAGE=simpleyyt/manus-sandbox
 SANDBOX_NAME_PREFIX=sandbox

--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -141,18 +141,23 @@ MAX_TOKENS=2000
 #LLM_PROVIDER=langchain
 
 # MongoDB configuration
+# For non-Docker development use mongodb://localhost:27017 (or ./dev-local.sh,
+# which rewrites the hostname automatically)
 #MONGODB_URI=mongodb://mongodb:27017
 #MONGODB_DATABASE=manus
 #MONGODB_USERNAME=
 #MONGODB_PASSWORD=
 
 # Redis configuration
+# For non-Docker development use localhost (or ./dev-local.sh)
 #REDIS_HOST=redis
 #REDIS_PORT=6379
 #REDIS_DB=0
 #REDIS_PASSWORD=
 
 # Sandbox configuration
+# SANDBOX_ADDRESS: use a single fixed sandbox instead of creating Docker
+# containers per session (e.g. 127.0.0.1 for a sandbox running on the host)
 #SANDBOX_ADDRESS=
 SANDBOX_IMAGE=simpleyyt/manus-sandbox
 SANDBOX_NAME_PREFIX=sandbox

--- a/sandbox/README.md
+++ b/sandbox/README.md
@@ -66,6 +66,8 @@ uv sync --dev
 uv run uvicorn app.main:app --host 0.0.0.0 --port 8080 --reload
 ```
 
+> When supervisord is not running (i.e. outside the Docker container), the service starts in **standalone mode**: shell and file APIs work against the host machine, `GET /api/v1/supervisor/status` reports a synthetic RUNNING status, and supervisord-backed actions (stop/restart/shutdown) return an error. Browser/VNC features require the full Docker image.
+
 ### Docker Deployment
 
 ```bash

--- a/sandbox/README_zh.md
+++ b/sandbox/README_zh.md
@@ -67,6 +67,8 @@ uv sync --dev
 uv run uvicorn app.main:app --host 0.0.0.0 --port 8080 --reload
 ```
 
+> 当 supervisord 未运行时(即在 Docker 容器之外),服务会以 **standalone 模式**启动:shell 和文件 API 直接作用于宿主机,`GET /api/v1/supervisor/status` 返回合成的 RUNNING 状态,依赖 supervisord 的操作(stop/restart/shutdown)会返回错误。浏览器/VNC 功能仍需要完整的 Docker 镜像。
+
 ### Docker部署
 
 ```bash

--- a/sandbox/app/services/supervisor.py
+++ b/sandbox/app/services/supervisor.py
@@ -3,6 +3,8 @@ import xmlrpc.client
 import socket
 import http.client
 import asyncio
+import logging
+import os
 from datetime import datetime, timedelta
 from typing import List
 
@@ -13,6 +15,8 @@ from app.models.supervisor import (
     SupervisorActionResult, 
     SupervisorTimeout
 )
+
+logger = logging.getLogger(__name__)
 
 
 # Add Unix socket support for xmlrpc client
@@ -38,9 +42,17 @@ class UnixStreamTransport(xmlrpc.client.Transport):
 class SupervisorService:
     """
     Supervisor service management class, used for managing service timeout and renewal functionality - Async version
+
+    When supervisord is not available (e.g. running the API directly on the
+    host without Docker), the service falls back to *standalone mode*: process
+    status is synthesized so callers (like the backend readiness check) still
+    see a healthy sandbox, while supervisord-only actions return an error.
     """
     def __init__(self):
         self.rpc_url = "/tmp/supervisor.sock"
+        self.standalone = False
+        self.server = None
+        self._started_at = datetime.now()
         self._connect_rpc()
         
         # Timeout management - enabled based on configuration
@@ -69,7 +81,11 @@ class SupervisorService:
         self._auto_expand_enabled = True
     
     def _connect_rpc(self):
-        """Connect to supervisord's RPC interface"""
+        """Connect to supervisord's RPC interface
+
+        Falls back to standalone mode when supervisord is not running,
+        so the sandbox API can be started directly (non-Docker development).
+        """
         try:
             self.server = xmlrpc.client.ServerProxy(
                 'http://localhost',
@@ -78,7 +94,32 @@ class SupervisorService:
             # Test connection
             self.server.supervisor.getState()
         except Exception as e:
-            raise ResourceNotFoundException(f"Cannot connect to Supervisord: {str(e)}")
+            self.server = None
+            self.standalone = True
+            logger.warning(
+                "Cannot connect to Supervisord (%s); running in standalone mode "
+                "without process management", str(e)
+            )
+
+    def _synthetic_processes(self) -> List[ProcessInfo]:
+        """Synthesize process status for standalone mode (no supervisord)"""
+        now = datetime.now()
+        return [ProcessInfo(
+            name="app",
+            group="services",
+            description=f"pid {os.getpid()}, standalone mode",
+            start=int(self._started_at.timestamp()),
+            stop=0,
+            now=int(now.timestamp()),
+            state=20,  # RUNNING
+            statename="RUNNING",
+            spawnerr="",
+            exitstatus=0,
+            logfile="",
+            stdout_logfile="",
+            stderr_logfile="",
+            pid=os.getpid(),
+        )]
     
     def _setup_timer(self, minutes):
         """Set up async timer"""
@@ -119,6 +160,8 @@ class SupervisorService:
     
     async def get_all_processes(self) -> List[ProcessInfo]:
         """Asynchronously get all process statuses"""
+        if self.standalone:
+            return self._synthetic_processes()
         try:
             processes = await self._call_rpc(self.server.supervisor.getAllProcessInfo)
             return [ProcessInfo(**process) for process in processes]
@@ -127,6 +170,8 @@ class SupervisorService:
     
     async def stop_all_services(self) -> SupervisorActionResult:
         """Asynchronously stop all services"""
+        if self.standalone:
+            raise BadRequestException("Supervisord is not available (standalone mode)")
         try:
             result = await self._call_rpc(self.server.supervisor.stopAllProcesses)
             return SupervisorActionResult(status="stopped", result=result)
@@ -135,6 +180,8 @@ class SupervisorService:
     
     async def shutdown(self) -> SupervisorActionResult:
         """Asynchronously shut down the supervisord service itself, without stopping processes"""
+        if self.standalone:
+            raise BadRequestException("Supervisord is not available (standalone mode)")
         try:
             shutdown_result = await self._call_rpc(self.server.supervisor.shutdown)
             return SupervisorActionResult(status="shutdown", shutdown_result=shutdown_result)
@@ -143,6 +190,8 @@ class SupervisorService:
     
     async def restart_all_services(self) -> SupervisorActionResult:
         """Asynchronously restart all services"""
+        if self.standalone:
+            raise BadRequestException("Supervisord is not available (standalone mode)")
         try:
             stop_result = await self._call_rpc(self.server.supervisor.stopAllProcesses)
             start_result = await self._call_rpc(self.server.supervisor.startAllProcesses)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds first-class support for developing AI Manus without Docker.

- **`dev-local.sh`** — orchestrates the whole dev stack as plain host processes: `mongodb`, `redis`, `mockserver`, `sandbox`, `backend`, `frontend`. Supports `up [service...]`, `down`, `status`, `logs <service>`. Reads `.env` and automatically rewrites Docker Compose hostnames (`mongodb`/`redis`/`mockserver`/`backend`) to `localhost`, so the same `.env` works for both `./dev.sh` and `./dev-local.sh`. Reuses MongoDB/Redis instances already listening on standard ports. Runtime state (PIDs, logs, data, isolated Python venvs) lives in `.dev-local/` (gitignored), so it never clashes with root-owned `.venv`/`node_modules` leftovers from the Docker dev stack.
- **Sandbox standalone mode** — `SupervisorService` no longer crashes on import when supervisord is absent; it falls back to standalone mode: `GET /api/v1/supervisor/status` returns a synthetic RUNNING status (so the backend readiness check passes), shell/file APIs operate on the host, and supervisord-backed actions (stop/restart/shutdown) return a clear error.
- **Docs** — non-Docker development sections added to `README.md` / `README_zh.md`, `AGENTS.md`, `CLAUDE.md`, `.cursor/skills/starter.md`, sandbox READMEs, and `.env.example` (synced into `docs/*/quick_start.md` via `./update_doc.sh`).

Limitations of the non-Docker mode (documented): sandbox shell/file tools run directly on the host (no isolation); browser tools are unavailable (no Chrome/CDP/VNC); Claw is not started.

## Testing

Verified end-to-end on a machine without using Docker for any service:

- `./dev-local.sh up` started all six services; `status`/`logs`/`down` work, and `down` cleanly kills the full process trees.
- Full agent session via the frontend (mockserver LLM): plan → message → search → 3× file_write → shell_exec (`ls -a` terminal panel) → browser_navigate (fails as expected without Chrome, flow continues) → Task Completed with attachments. Files really appeared on the host (`/home/ubuntu/example.{txt,md,py}`).

[non_docker_stack_agent_session_demo.mp4](https://cursor.com/agents/bc-c206fb41-464a-4c68-ad1c-ef662d2af28c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fnon_docker_stack_agent_session_demo.mp4)

[Completed session with attachments](https://cursor.com/agents/bc-c206fb41-464a-4c68-ad1c-ef662d2af28c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcompleted_session_with_attachments.webp)

- `cd sandbox && uv run pytest` against the standalone sandbox: **3 passed**.
- `cd backend && uv run pytest` against the non-Docker backend: identical results to the Docker-compose baseline (auth-suite failures are pre-existing on `main` with `AUTH_PROVIDER=password`: 5 failed / 17 passed on both stacks).


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c206fb41-464a-4c68-ad1c-ef662d2af28c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c206fb41-464a-4c68-ad1c-ef662d2af28c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

