### PR TITLE
feat(frontend): replicate Manus home page suggestion chips structure

### DIFF
--- a/frontend/src/components/LeftPanel.vue
+++ b/frontend/src/components/LeftPanel.vue
@@ -105,6 +105,31 @@
         </div>
 
       </div>
+
+      <!-- 底部个人 Profile(结构复刻自 manus.im 侧边栏底部) -->
+      <div ref="profileRef" class="relative flex-shrink-0 px-[8px] pb-3 pt-1">
+        <div v-if="showUserMenu" class="absolute bottom-full start-2 mb-1 z-50">
+          <UserMenu />
+        </div>
+        <div
+          @click="showUserMenu = !showUserMenu"
+          class="flex items-center rounded-[10px] cursor-pointer transition-colors w-full gap-[8px] h-[48px] px-[8px]"
+          :class="showUserMenu ? 'bg-[var(--fill-tsp-white-main)]' : 'hover:bg-[var(--fill-tsp-white-light)]'">
+          <div
+            class="relative flex items-center justify-center font-bold flex-shrink-0 rounded-full overflow-hidden"
+            style="width: 32px; height: 32px; font-size: 16px; color: rgba(255, 255, 255, 0.9); background-color: rgb(59, 130, 246);">
+            {{ avatarLetter }}
+          </div>
+          <div class="flex flex-col flex-1 min-w-0">
+            <span class="text-[14px] leading-[18px] text-[var(--text-primary)] font-medium truncate">
+              {{ currentUser?.fullname || t('Unknown User') }}
+            </span>
+            <span class="text-[12px] leading-[16px] text-[var(--text-tertiary)] truncate">
+              {{ currentUser?.email || t('No email') }}
+            </span>
+          </div>
+        </div>
+      </div>
     </div>
   </div>
 </template>
@@ -112,8 +137,10 @@
 <script setup lang="ts">
 import { PanelLeft, SquarePen, Command, MessageSquareDashed, ChevronUp } from 'lucide-vue-next';
 import SessionItem from './SessionItem.vue';
+import UserMenu from './UserMenu.vue';
 import { useLeftPanel } from '../composables/useLeftPanel';
-import { ref, onMounted, watch, onUnmounted } from 'vue';
+import { useAuth } from '../composables/useAuth';
+import { ref, computed, onMounted, watch, onUnmounted } from 'vue';
 import { useRoute, useRouter } from 'vue-router';
 import { getSessionsSSE, getSessions } from '../api/agent';
 import { getCachedClientConfig } from '../api/config';
@@ -131,6 +158,21 @@ const isAllTasksCollapsed = ref(false)
 const isListScrolled = ref(false)
 const clawEnabled = ref(false)
 const scrollContainerRef = ref<HTMLElement | null>(null)
+
+// Bottom profile entry
+const { currentUser } = useAuth()
+const showUserMenu = ref(false)
+const profileRef = ref<HTMLElement | null>(null)
+
+const avatarLetter = computed(() => {
+  return currentUser.value?.fullname?.charAt(0)?.toUpperCase() || 'M'
+})
+
+const handleClickOutside = (event: MouseEvent) => {
+  if (showUserMenu.value && profileRef.value && !profileRef.value.contains(event.target as Node)) {
+    showUserMenu.value = false
+  }
+}
 
 const handleListScroll = () => {
   if (scrollContainerRef.value) {
@@ -199,6 +241,7 @@ onMounted(async () => {
 
   // Add keyboard event listener
   window.addEventListener('keydown', handleKeydown)
+  window.addEventListener('mousedown', handleClickOutside)
 })
 
 onUnmounted(() => {
@@ -209,6 +252,7 @@ onUnmounted(() => {
 
   // Remove keyboard event listener
   window.removeEventListener('keydown', handleKeydown)
+  window.removeEventListener('mousedown', handleClickOutside)
 })
 
 watch(() => route.path, async () => {

--- a/frontend/src/locales/en.ts
+++ b/frontend/src/locales/en.ts
@@ -1,6 +1,16 @@
 export default {
   'Hello': 'Hello',
   'What can I do for you?': 'What can I do for you?',
+  // Home suggestion chips
+  'Create slides': 'Create slides',
+  'Build website': 'Build website',
+  'Design': 'Design',
+  'Create games': 'Create games',
+  'Deep research': 'Deep research',
+  'Analyze data': 'Analyze data',
+  'Generate image': 'Generate image',
+  'Write report': 'Write report',
+  'More': 'More',
   'Failed to create agent, please try again later': 'Failed to create agent, please try again later',
   'New Chat': 'New Chat',
   'New Task': 'New Task',

--- a/frontend/src/locales/zh.ts
+++ b/frontend/src/locales/zh.ts
@@ -1,6 +1,16 @@
 export default {
   'Hello': '你好',
   'What can I do for you?': '我能为你做什么？',
+  // Home suggestion chips
+  'Create slides': '创建幻灯片',
+  'Build website': '构建网站',
+  'Design': '设计',
+  'Create games': '创建游戏',
+  'Deep research': '深入研究',
+  'Analyze data': '分析数据',
+  'Generate image': '生成图片',
+  'Write report': '撰写报告',
+  'More': '更多',
   'Failed to create agent, please try again later': '创建Agent失败，请稍后重试',
   'New Chat': '新对话',
   'New Task': '新建任务',

--- a/frontend/src/pages/HomePage.vue
+++ b/frontend/src/pages/HomePage.vue
@@ -44,7 +44,7 @@
         </div>
         <div class="h-8"></div>
       </div>
-      <div class="w-full max-w-full sm:max-w-[768px] sm:min-w-[390px] mx-auto mt-[180px] mb-auto">
+      <div class="max-md:px-[16px] w-full max-w-full sm:max-w-[768px] sm:min-w-[390px] mx-auto mt-[20vh] mb-auto">
         <div class="w-full flex pl-4 items-center justify-start pb-4">
           <span class="text-[var(--text-primary)] text-start font-serif text-[32px] leading-[40px]" :style="{
             fontFamily:
@@ -65,6 +65,28 @@
               :isRunning="false" />
           </div>
         </div>
+        <!-- Suggestion chips (structure replicated from manus.im home) -->
+        <div class="relative w-full">
+          <div class="w-full transition-transform duration-300 ease-out relative mt-[20px]">
+            <div class="w-full flex flex-col justify-center items-center gap-4">
+              <div class="flex flex-wrap justify-center items-center gap-2">
+                <div v-for="suggestion in visibleSuggestions" :key="suggestion.label" role="button" tabindex="0"
+                  class="h-10 px-[14px] py-[7px] rounded-full border border-[var(--border-main)] flex justify-center items-center gap-2 clickable cursor-pointer hover:bg-[var(--fill-tsp-white-light)] flex-shrink-0"
+                  @click="handleSuggestionClick(suggestion)">
+                  <component :is="suggestion.icon" :size="18" color="var(--icon-tertiary)" />
+                  <div class="flex justify-start items-center gap-1">
+                    <span class="text-[var(--text-primary)] text-[14px] font-normal">{{ $t(suggestion.label) }}</span>
+                  </div>
+                </div>
+                <div v-if="!showMoreSuggestions" role="button" tabindex="0"
+                  class="h-10 px-[14px] text-sm py-[7px] rounded-full border border-[var(--border-main)] flex justify-center items-center gap-2 clickable cursor-pointer hover:bg-[var(--fill-tsp-white-light)] flex-shrink-0 text-[var(--text-primary)]"
+                  @click="showMoreSuggestions = true">
+                  {{ $t('More') }}
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
       </div>
     </div>
   </SimpleBar>
@@ -78,7 +100,11 @@ import { useI18n } from 'vue-i18n';
 import ChatBox from '../components/ChatBox.vue';
 import { createSession } from '../api/agent';
 import { showErrorToast } from '../utils/toast';
-import { Bot, PanelLeft, Github } from 'lucide-vue-next';
+import {
+  Bot, PanelLeft, Github, Presentation, Globe, Palette, Gamepad2,
+  Telescope, ChartColumn, Image, FileText
+} from 'lucide-vue-next';
+import type { Component } from 'vue';
 import ManusLogoTextIcon from '../components/icons/ManusLogoTextIcon.vue';
 import type { FileInfo } from '../api/file';
 import { useLeftPanel } from '../composables/useLeftPanel';
@@ -97,6 +123,36 @@ const { hideFilePanel } = useFilePanel();
 const { currentUser } = useAuth();
 const showGithubButton = ref(false);
 const githubRepositoryUrl = ref('https://github.com/simpleyyt/ai-manus');
+
+// Suggestion chips, structure replicated from the manus.im home page
+interface Suggestion {
+  label: string;
+  icon: Component;
+}
+
+const primarySuggestions: Suggestion[] = [
+  { label: 'Create slides', icon: Presentation },
+  { label: 'Build website', icon: Globe },
+  { label: 'Design', icon: Palette },
+  { label: 'Create games', icon: Gamepad2 },
+];
+
+const moreSuggestions: Suggestion[] = [
+  { label: 'Deep research', icon: Telescope },
+  { label: 'Analyze data', icon: ChartColumn },
+  { label: 'Generate image', icon: Image },
+  { label: 'Write report', icon: FileText },
+];
+
+const showMoreSuggestions = ref(false);
+
+const visibleSuggestions = computed(() =>
+  showMoreSuggestions.value ? [...primarySuggestions, ...moreSuggestions] : primarySuggestions
+);
+
+const handleSuggestionClick = (suggestion: Suggestion) => {
+  message.value = t(suggestion.label);
+};
 
 // Get first letter of user's fullname for avatar display
 const avatarLetter = computed(() => {

--- a/frontend/src/pages/HomePage.vue
+++ b/frontend/src/pages/HomePage.vue
@@ -26,7 +26,7 @@
               <Github class="size-[18px]" />
               GitHub
             </a>
-            <div class="relative flex items-center" aria-expanded="false" aria-haspopup="dialog"
+            <div v-if="!isLeftPanelShow" class="relative flex items-center" aria-expanded="false" aria-haspopup="dialog"
               @mouseenter="handleUserMenuEnter" @mouseleave="handleUserMenuLeave">
               <div class="relative flex items-center justify-center font-bold cursor-pointer flex-shrink-0">
                 <div


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

按照 manus.im 官方页面的结构，复刻首页(HomePage)、侧边栏、顶部标题区，并把对应区块的标记(代码)结构与字体对齐官方(侧边栏与首页头部依据用户提供的官方真实 HTML)。图标保留项目自己的 Bot 机器人图标。

### 图标
- 各头部(侧边栏、登录页、分享页、设置页)恢复使用项目自有的 Bot 机器人图标 + "manus" 字标；删除此前引入的官方手形 logo 组件 `ManusLogoIcon.vue`。

### 字体对齐官方
- 正文字体与官方相同(系统栈，项目原本已一致)；衬线字体通过 `@fontsource/libre-baskerville`(SIL OFL)自托管加载，`font-serif` 栈覆盖为官方顺序，问候语与官方一样以 Libre Baskerville 渲染。

### 首页头部(标记结构对齐官方 HTML)
- 容器 `sticky top-0 ps-[14px] pe-[20px] py-[12px] border-b border-transparent` + `flex justify-between`；左侧静态标题 `Manus`(18px/500，无下拉)；右侧 GitHub 按钮采用官方 `h-8 rounded-[8px] border ps-2 pe-3` 样式。

### 侧边栏(标记结构对齐官方 HTML)
- 顶部 `h-[56px] px-[8px] py-[12px]`，图标 28×28 于 `size-[32px]` 包裹层；收起态悬停变展开按钮。
- 条目行 `w-full gap-[8px] h-[36px] p-[9px] rounded-[10px]`；收起态约 52px 图标窄栏 + `w-[28px]` 居中分隔线。
- 底部 Profile `p-[8px]` + 收起态 `flex-col-reverse`、28×28 头像；菜单展开态上方弹出、收起态右侧弹出。

### 输入框与首页(标记结构对齐官方)
- `ChatBox.vue`：容器 `bg-[var(--background-menu-white)]` + `focus-within` 边框态、`px-3` 占位层、页脚 `flex gap-2 px-3 items-center` + `ml-auto` 发送按钮组。
- `HomePage.vue`：hero 容器 `sm:min-w-[360px]`、`mt-[20vh]`；建议胶囊行按官方结构实现(+中英文 i18n)。

## Walkthrough

### 端到端对话(所有改动后的完整验证)
[e2e_conversation_after_all_changes.mp4](https://cursor.com/agents/bc-92d80d17-bd19-42af-9796-070607463ad9/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fe2e_conversation_after_all_changes.mp4)

[端到端完成:计划 + 6 个工具调用 + 附件 + Task Completed + Manus Computer 面板](https://cursor.com/agents/bc-92d80d17-bd19-42af-9796-070607463ad9/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fe2e_task_completed_final.webp)

### 项目自有 Bot 图标
[展开态:侧边栏顶部为 Bot 机器人图标 + manus 字标](https://cursor.com/agents/bc-92d80d17-bd19-42af-9796-070607463ad9/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsidebar_bot_icon_expanded.webp)
[收起态:窄栏顶部同为 Bot 图标](https://cursor.com/agents/bc-92d80d17-bd19-42af-9796-070607463ad9/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsidebar_bot_icon_rail.webp)

### 衬线字体(Libre Baskerville)
[问候语以 Libre Baskerville 渲染(150% 缩放)](https://cursor.com/agents/bc-92d80d17-bd19-42af-9796-070607463ad9/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fgreeting_libre_baskerville_150.webp)

### 侧边栏(官方结构)
[sidebar_official_structure_final_demo.mp4](https://cursor.com/agents/bc-92d80d17-bd19-42af-9796-070607463ad9/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsidebar_official_structure_final_demo.mp4)

### 输入框官方结构
[chatbox_official_structure_demo.mp4](https://cursor.com/agents/bc-92d80d17-bd19-42af-9796-070607463ad9/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fchatbox_official_structure_demo.mp4)

### 建议胶囊
[manus_home_suggestion_chips_demo.mp4](https://cursor.com/agents/bc-92d80d17-bd19-42af-9796-070607463ad9/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmanus_home_suggestion_chips_demo.mp4)

## Testing

- ✅ `npm run test` — 36 个单元测试通过
- ✅ `npm run type-check` — vue-tsc 无错误
- ✅ `npm run lint` — 0 错误(40 个既有 warning，均与本次改动无关)
- ✅ `npm run build` — 构建成功
- ✅ GUI 端到端测试(`./dev.sh` 全栈 + computerUse)：胶囊填入 → 输入发送 → 会话创建 → agent loop(计划/消息/搜索/写文件×3/Shell/浏览器)→ Manus Computer 面板 → 附件 + Task Completed，全程无报错(见视频)
- ⚠️ `uv run pytest`(backend)— 在本环境中挂起未完成(集成测试需长连接 SSE，与本 PR 改动无关；本 PR 未改后端代码)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-92d80d17-bd19-42af-9796-070607463ad9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-92d80d17-bd19-42af-9796-070607463ad9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

