### PR TITLE
docs: example compose loads config from .env instead of inline environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,18 +116,10 @@ services:
       #- ./mcp.json:/etc/mcp.json # Mount MCP servers directory
     networks:
       - manus-network
-    environment:
-      # OpenAI API base URL
-      - API_BASE=https://api.openai.com/v1
-      # OpenAI API key, replace with your own
-      - API_KEY=sk-xxxx
-      # LLM model name
-      - MODEL_NAME=gpt-4o
-      # LLM temperature parameter, controls randomness
-      #- TEMPERATURE=0.7
-      # Maximum tokens for LLM response
-      #- MAX_TOKENS=2000
+    env_file:
+      # All configuration is loaded from the .env file, see .env.example
       # More configuration options: https://docs.ai-manus.com/#/configuration
+      - .env
 
   sandbox:
     image: simpleyyt/manus-sandbox
@@ -170,7 +162,15 @@ networks:
 ```
 <!-- /docker-compose-example.yml -->
 
-Save as `docker-compose.yml` file, and run:
+Save as `docker-compose.yml` file. All configuration is loaded from a `.env` file, so create one next to it based on [.env.example](https://github.com/simpleyyt/ai-manus/blob/main/.env.example). At minimum set `API_KEY`:
+
+```ini
+API_KEY=sk-xxxx
+API_BASE=https://api.openai.com/v1
+MODEL_NAME=gpt-4o
+```
+
+Then run:
 
 ```shell
 docker compose up -d

--- a/README_zh.md
+++ b/README_zh.md
@@ -98,18 +98,10 @@ services:
       #- ./mcp.json:/etc/mcp.json # Mount MCP servers directory
     networks:
       - manus-network
-    environment:
-      # OpenAI API base URL
-      - API_BASE=https://api.openai.com/v1
-      # OpenAI API key, replace with your own
-      - API_KEY=sk-xxxx
-      # LLM model name
-      - MODEL_NAME=gpt-4o
-      # LLM temperature parameter, controls randomness
-      #- TEMPERATURE=0.7
-      # Maximum tokens for LLM response
-      #- MAX_TOKENS=2000
+    env_file:
+      # All configuration is loaded from the .env file, see .env.example
       # More configuration options: https://docs.ai-manus.com/#/configuration
+      - .env
 
   sandbox:
     image: simpleyyt/manus-sandbox
@@ -152,7 +144,15 @@ networks:
 ```
 <!-- /docker-compose-example.yml -->
 
-保存成`docker-compose.yml`文件，并运行
+保存成`docker-compose.yml`文件。所有配置通过 `.env` 文件加载，在同级目录下参考 [.env.example](https://github.com/simpleyyt/ai-manus/blob/main/.env.example) 创建 `.env` 文件，至少需要设置 `API_KEY`：
+
+```ini
+API_KEY=sk-xxxx
+API_BASE=https://api.openai.com/v1
+MODEL_NAME=gpt-4o
+```
+
+然后运行：
 
 ```shell
 docker compose up -d

--- a/docker-compose-example.yml
+++ b/docker-compose-example.yml
@@ -22,18 +22,10 @@ services:
       #- ./mcp.json:/etc/mcp.json # Mount MCP servers directory
     networks:
       - manus-network
-    environment:
-      # OpenAI API base URL
-      - API_BASE=https://api.openai.com/v1
-      # OpenAI API key, replace with your own
-      - API_KEY=sk-xxxx
-      # LLM model name
-      - MODEL_NAME=gpt-4o
-      # LLM temperature parameter, controls randomness
-      #- TEMPERATURE=0.7
-      # Maximum tokens for LLM response
-      #- MAX_TOKENS=2000
+    env_file:
+      # All configuration is loaded from the .env file, see .env.example
       # More configuration options: https://docs.ai-manus.com/#/configuration
+      - .env
 
   sandbox:
     image: simpleyyt/manus-sandbox

--- a/docs/en/quick_start.md
+++ b/docs/en/quick_start.md
@@ -27,7 +27,7 @@ Install Docker Engine according to official requirements: https://docs.docker.co
 
 ## Deployment
 
-Deploy using Docker Compose. All configuration is managed through a `.env` file (via `env_file`), so there is no need to pile environment variables into `docker-compose.yml`:
+Deploy using Docker Compose. All configuration is managed through a `.env` file (via `env_file`):
 
 <!-- docker-compose-example.yml -->
 ```yaml

--- a/docs/en/quick_start.md
+++ b/docs/en/quick_start.md
@@ -27,7 +27,7 @@ Install Docker Engine according to official requirements: https://docs.docker.co
 
 ## Deployment
 
-Deploy using Docker Compose: at minimum set `API_KEY`, and adjust `API_BASE` and `MODEL_PROVIDER` for your model service:
+Deploy using Docker Compose. All configuration is managed through a `.env` file (via `env_file`), so there is no need to pile environment variables into `docker-compose.yml`:
 
 <!-- docker-compose-example.yml -->
 ```yaml
@@ -55,18 +55,10 @@ services:
       #- ./mcp.json:/etc/mcp.json # Mount MCP servers directory
     networks:
       - manus-network
-    environment:
-      # OpenAI API base URL
-      - API_BASE=https://api.openai.com/v1
-      # OpenAI API key, replace with your own
-      - API_KEY=sk-xxxx
-      # LLM model name
-      - MODEL_NAME=gpt-4o
-      # LLM temperature parameter, controls randomness
-      #- TEMPERATURE=0.7
-      # Maximum tokens for LLM response
-      #- MAX_TOKENS=2000
+    env_file:
+      # All configuration is loaded from the .env file, see .env.example
       # More configuration options: https://docs.ai-manus.com/#/configuration
+      - .env
 
   sandbox:
     image: simpleyyt/manus-sandbox
@@ -111,11 +103,17 @@ networks:
 
 Save as `docker-compose.yml` file.
 
-### Managing Configuration with `.env` File
+### Create the `.env` Configuration File
 
-The example above only includes the essential AI model configuration. For additional settings (search engine, authentication, sandbox, Claw, etc.), it is recommended to use `env_file` to load a `.env` file, keeping your `docker-compose.yml` clean.
+Next to `docker-compose.yml`, create a `.env` file based on [`.env.example`](https://github.com/simpleyyt/ai-manus/blob/main/.env.example). At minimum set `API_KEY`, and adjust `API_BASE` and `MODEL_NAME` for your model service:
 
-**Step 1**: Create a `.env` file based on [`.env.example`](https://github.com/simpleyyt/ai-manus/blob/main/.env.example):
+```ini
+API_KEY=sk-xxxx
+API_BASE=https://api.openai.com/v1
+MODEL_NAME=gpt-4o
+```
+
+The full `.env.example` is shown below (search engine, authentication, sandbox, Claw, and more options):
 
 <!-- .env.example -->
 ```ini
@@ -310,16 +308,6 @@ JWT_REFRESH_TOKEN_EXPIRE_DAYS=7
 LOG_LEVEL=INFO
 ```
 <!-- /.env.example -->
-
-**Step 2**: In `docker-compose.yml`, replace the `environment` section of the `backend` service with `env_file`:
-
-```yaml
-  backend:
-    image: simpleyyt/manus-backend
-    # ...
-    env_file:
-      - .env
-```
 
 > **Tip**: `env_file` and `environment` can be used together — values in `environment` override those from `env_file`. See [Configuration](configuration.md) for a full list of available options.
 

--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -28,7 +28,7 @@
 
 ## 部署
 
-使用 Docker Compose 进行部署，至少需要修改 `API_KEY`，并根据模型服务调整 `API_BASE` 与 `MODEL_PROVIDER`：
+使用 Docker Compose 进行部署。所有配置均通过 `.env` 文件管理（`env_file`），无需在 `docker-compose.yml` 中堆积环境变量：
 
 <!-- docker-compose-example.yml -->
 ```yaml
@@ -56,18 +56,10 @@ services:
       #- ./mcp.json:/etc/mcp.json # Mount MCP servers directory
     networks:
       - manus-network
-    environment:
-      # OpenAI API base URL
-      - API_BASE=https://api.openai.com/v1
-      # OpenAI API key, replace with your own
-      - API_KEY=sk-xxxx
-      # LLM model name
-      - MODEL_NAME=gpt-4o
-      # LLM temperature parameter, controls randomness
-      #- TEMPERATURE=0.7
-      # Maximum tokens for LLM response
-      #- MAX_TOKENS=2000
+    env_file:
+      # All configuration is loaded from the .env file, see .env.example
       # More configuration options: https://docs.ai-manus.com/#/configuration
+      - .env
 
   sandbox:
     image: simpleyyt/manus-sandbox
@@ -112,11 +104,17 @@ networks:
 
 保存成 `docker-compose.yml` 文件。
 
-### 使用 `.env` 文件管理配置
+### 创建 `.env` 配置文件
 
-上述示例仅包含最基本的 AI 模型配置。如需自定义更多配置（搜索引擎、认证方式、沙箱、Claw 等），推荐使用 `env_file` 方式加载 `.env` 文件，避免在 `docker-compose.yml` 中堆积大量环境变量。
+在 `docker-compose.yml` 同级目录下，基于 [`.env.example`](https://github.com/simpleyyt/ai-manus/blob/main/.env.example) 创建 `.env` 文件，至少需要修改 `API_KEY`，并根据模型服务调整 `API_BASE` 与 `MODEL_NAME`：
 
-**步骤 1**：基于 [`.env.example`](https://github.com/simpleyyt/ai-manus/blob/main/.env.example) 创建 `.env` 文件：
+```ini
+API_KEY=sk-xxxx
+API_BASE=https://api.openai.com/v1
+MODEL_NAME=gpt-4o
+```
+
+完整的 `.env.example` 如下（搜索引擎、认证方式、沙箱、Claw 等更多配置项）：
 
 <!-- .env.example -->
 ```ini
@@ -311,16 +309,6 @@ JWT_REFRESH_TOKEN_EXPIRE_DAYS=7
 LOG_LEVEL=INFO
 ```
 <!-- /.env.example -->
-
-**步骤 2**：在 `docker-compose.yml` 的 `backend` 服务中，将 `environment` 替换为 `env_file`：
-
-```yaml
-  backend:
-    image: simpleyyt/manus-backend
-    # ...
-    env_file:
-      - .env
-```
 
 > **提示**：`env_file` 和 `environment` 可以同时使用，`environment` 中的值会覆盖 `env_file` 中的同名变量。完整的配置项说明请参阅[配置说明](configuration.md)。
 

--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -28,7 +28,7 @@
 
 ## 部署
 
-使用 Docker Compose 进行部署。所有配置均通过 `.env` 文件管理（`env_file`），无需在 `docker-compose.yml` 中堆积环境变量：
+使用 Docker Compose 进行部署，所有配置均通过 `.env` 文件（`env_file`）管理：
 
 <!-- docker-compose-example.yml -->
 ```yaml


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

配置项越来越多，示例 `docker-compose.yml` 不再内联 `environment` 变量，统一改为通过 `env_file` 加载 `.env`：

- `docker-compose-example.yml`：`backend` 服务的 `environment`（API_BASE / API_KEY / MODEL_NAME 等）替换为 `env_file: .env`，与生产 `docker-compose.yml` 的做法保持一致。
- `docs/quick_start.md` / `docs/en/quick_start.md`：部署流程调整为「保存 compose 文件 → 创建 `.env`（最小只需 `API_KEY` / `API_BASE` / `MODEL_NAME`）→ `docker compose up -d`」，删除原来"步骤 2：把 environment 替换为 env_file"的过渡说明。
- `README.md` / `README_zh.md`：部署指南同步补充创建 `.env` 的步骤。
- 所有 markdown 中的内嵌 compose 示例已通过 `./update_doc.sh` 重新同步。

## Testing

- ✅ `./update_doc.sh` 同步成功，各 md 内嵌代码块与源文件一致
- ✅ `docker compose config`（配合从 `.env.example` 复制的 `.env`）校验示例 compose 文件合法
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2a0ef7b5-6960-46ce-85f0-6213fe97c777"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2a0ef7b5-6960-46ce-85f0-6213fe97c777"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

