### PR TITLE
Redesign agent context engineering: native structured output, composable prompts, token-aware memory

### DIFF
--- a/backend/app/domain/models/agent_output.py
+++ b/backend/app/domain/models/agent_output.py
@@ -1,0 +1,86 @@
+"""Structured output contracts between agents and the LLM.
+
+Each model backs an :class:`app.domain.services.tools.base.OutputTool` that
+the model calls through native function calling to submit structured results
+(plans, step reports, final deliveries). Schemas are derived from these
+Pydantic models, and arguments are validated against them with self-repair on
+failure — no JSON format instructions live in prompts anymore.
+"""
+from typing import List
+
+from pydantic import BaseModel, Field
+
+
+class PlanStepDraft(BaseModel):
+    """A single step proposed by the planner."""
+
+    id: str = Field(description="Short sequential step identifier, e.g. '1', '2'")
+    description: str = Field(
+        description="Atomic, self-contained step description the executor can act on"
+    )
+
+
+class PlanOutput(BaseModel):
+    """Arguments of the ``create_plan`` output tool."""
+
+    message: str = Field(
+        description=(
+            "Reply to the user acknowledging the task and how you will approach"
+            " it, written in the user's language"
+        )
+    )
+    language: str = Field(
+        description="Working language inferred from the user's message, e.g. 'en', 'zh'"
+    )
+    title: str = Field(description="Short title for this task")
+    goal: str = Field(
+        description="Overall goal of the plan; empty string if the task is infeasible"
+    )
+    steps: List[PlanStepDraft] = Field(
+        description=(
+            "Ordered atomic steps to accomplish the goal; empty list if the"
+            " task is infeasible or needs no tool work"
+        )
+    )
+
+
+class PlanUpdateOutput(BaseModel):
+    """Arguments of the ``update_plan`` output tool."""
+
+    steps: List[PlanStepDraft] = Field(
+        description=(
+            "The remaining (not yet completed) steps after re-planning, starting"
+            " from the first uncompleted step; empty list if nothing is left to do"
+        )
+    )
+
+
+class StepReport(BaseModel):
+    """Arguments of the ``complete_step`` output tool."""
+
+    success: bool = Field(description="Whether the step was completed successfully")
+    result: str = Field(
+        description=(
+            "Concrete outcome of the step: what was done and what was produced,"
+            " in the working language"
+        )
+    )
+    attachments: List[str] = Field(
+        default_factory=list,
+        description="Absolute sandbox paths of files produced in this step",
+    )
+
+
+class FinalResult(BaseModel):
+    """Arguments of the ``deliver_result`` output tool."""
+
+    message: str = Field(
+        description=(
+            "Final answer delivered to the user, detailed and in the user's"
+            " language; reference produced files where relevant"
+        )
+    )
+    attachments: List[str] = Field(
+        default_factory=list,
+        description="Absolute sandbox paths of files to deliver to the user",
+    )

--- a/backend/app/domain/models/memory.py
+++ b/backend/app/domain/models/memory.py
@@ -1,14 +1,35 @@
+import json
 import logging
 from pydantic import BaseModel
 from typing import List, Optional
-from app.domain.models.tool_result import ToolResult
 from app.domain.models.message import LLMMessage, Role
 
 logger = logging.getLogger(__name__)
 
+# Rough chars-per-token ratio; conservative for mixed prose/code/JSON.
+_CHARS_PER_TOKEN = 4
+
+# Placeholder written over elided tool results. Kept as a ToolResult-shaped
+# JSON string so downstream consumers can still parse the content.
+_ELIDED_CONTENT = json.dumps(
+    {"success": True, "message": "(result elided to save context)", "data": None}
+)
+
+
+def estimate_tokens(text: str) -> int:
+    """Cheap, dependency-free token estimate for context budgeting."""
+    if not text:
+        return 0
+    return max(1, len(text) // _CHARS_PER_TOKEN)
+
+
 class Memory(BaseModel):
-    """
-    Memory class, defining the basic behavior of memory
+    """Agent conversation memory with token-aware compaction.
+
+    Messages are stored append-only; :meth:`compact` reclaims context budget
+    by eliding the *content* of old tool results (oldest first) while keeping
+    the message skeleton intact, so tool-call pairing required by LLM APIs is
+    never broken and recent working context is preserved.
     """
     messages: List[LLMMessage] = []
 
@@ -33,14 +54,39 @@ class Memory(BaseModel):
     def roll_back(self) -> None:
         """Roll back memory"""
         self.messages = self.messages[:-1]
-    
-    def compact(self) -> None:
-        """Compact memory"""
+
+    def estimate_tokens(self) -> int:
+        """Estimate the total token footprint of the stored messages."""
+        total = 0
         for message in self.messages:
-            if message.role == Role.TOOL:
-                if message.name in ["browser_view", "browser_navigate"]:
-                    message.content = ToolResult(success=True, data='(removed)').model_dump_json()
-                    logger.debug(f"Removed tool result from memory: {message.name}")
+            total += estimate_tokens(message.content)
+            for tool_call in message.tool_calls:
+                total += estimate_tokens(tool_call.name)
+                total += estimate_tokens(json.dumps(tool_call.args, default=str))
+        return total
+
+    def compact(self, max_tokens: int = 0, keep_recent: int = 10) -> None:
+        """Elide old tool results until the memory fits the token budget.
+
+        Args:
+            max_tokens: Target context budget. ``0`` means "compact all
+                eligible tool results" (unconditional cleanup between steps).
+            keep_recent: Number of most recent messages that are never
+                touched, so the model keeps its working context.
+        """
+        if max_tokens and self.estimate_tokens() <= max_tokens:
+            return
+
+        cutoff = max(0, len(self.messages) - keep_recent)
+        for message in self.messages[:cutoff]:
+            if message.role != Role.TOOL:
+                continue
+            if message.content == _ELIDED_CONTENT:
+                continue
+            message.content = _ELIDED_CONTENT
+            logger.debug(f"Elided old tool result from memory: {message.name}")
+            if max_tokens and self.estimate_tokens() <= max_tokens:
+                return
 
     @property
     def empty(self) -> bool:

--- a/backend/app/domain/services/agents/base.py
+++ b/backend/app/domain/services/agents/base.py
@@ -2,9 +2,9 @@ import logging
 import asyncio
 import uuid
 from abc import ABC
-from typing import List, Optional, AsyncGenerator
+from typing import Any, List, Literal, Optional, AsyncGenerator
 from app.domain.models.message import Message, LLMMessage, Role, ToolCall
-from app.domain.services.tools.base import BaseToolkit, Tool
+from app.domain.services.tools.base import BaseToolkit, OutputTool, Tool, ValidationError
 from app.domain.models.event import (
     BaseEvent,
     ToolEvent,
@@ -17,18 +17,34 @@ from app.domain.external.llm import LLM
 
 
 logger = logging.getLogger(__name__)
+
+
+class StructuredOutputEvent(BaseEvent):
+    """Internal event carrying validated structured output.
+
+    Emitted when the model submits its result through an :class:`OutputTool`.
+    Consumed by the concrete agents; never part of the public
+    ``AgentEvent`` union streamed to clients.
+    """
+
+    type: Literal["structured_output"] = "structured_output"
+    output: Any
+
+
 class BaseAgent(ABC):
     """
     Base agent class, defining the basic behavior of the agent
     """
 
     name: str = ""
-    system_prompt: str = ""
-    format: Optional[str] = None
     max_iterations: int = 100
     max_retries: int = 3
     retry_interval: float = 1.0
     tool_choice: Optional[str] = None
+    # Context engineering budgets: tool results are truncated at ingestion,
+    # and memory is compacted before each model call when over budget.
+    max_tool_result_chars: int = 16000
+    max_context_tokens: int = 100000
 
     def __init__(
         self,
@@ -42,11 +58,12 @@ class BaseAgent(ABC):
         self._llm = llm
         self.toolkits = tools
         self.memory = None
+        self._output_tool: Optional[OutputTool] = None
 
-    async def _parse_json(self, text: str) -> dict:
-        """Parse JSON from LLM output via the LLM gateway."""
-        return await self._llm.parse_json(text)
-    
+    def build_system_prompt(self) -> str:
+        """Assemble the system prompt for this agent; overridden by subclasses."""
+        return ""
+
     def get_tool(self, name: str) -> Optional[Tool]:
         """Get specified tool"""
         for toolkit in self.toolkits:
@@ -56,8 +73,25 @@ class BaseAgent(ABC):
         return None
 
     def get_tool_schemas(self) -> List[dict]:
-        """Get OpenAI function schemas for all available tools."""
-        return [schema for toolkit in self.toolkits for schema in toolkit.get_tool_schemas()]
+        """Get OpenAI function schemas for all available tools.
+
+        Includes the active output tool, if any, so the model can submit
+        structured results through native function calling.
+        """
+        schemas = [schema for toolkit in self.toolkits for schema in toolkit.get_tool_schemas()]
+        if self._output_tool:
+            schemas.append(self._output_tool.to_openai_schema())
+        return schemas
+
+    def _truncate_tool_result(self, content: str) -> str:
+        """Cap a tool result before it enters memory, to bound context growth."""
+        if len(content) <= self.max_tool_result_chars:
+            return content
+        omitted = len(content) - self.max_tool_result_chars
+        return (
+            content[: self.max_tool_result_chars]
+            + f"... [truncated {omitted} chars to save context]"
+        )
 
     async def invoke_tool(self, tool: Tool, tool_call: ToolCall) -> LLMMessage:
         """Invoke specified tool, with retry mechanism."""
@@ -74,7 +108,7 @@ class BaseAgent(ABC):
                 return LLMMessage.tool(
                     tool_call_id=tool_call.id,
                     name=tool.name,
-                    content=content,
+                    content=self._truncate_tool_result(content),
                     artifact=raw_result,
                 )
             except Exception as e:
@@ -87,55 +121,120 @@ class BaseAgent(ABC):
                     break
 
         return LLMMessage.tool(tool_call_id=tool_call.id, name=tool.name, content=last_error)
-    
-    async def execute(self, request: str, format: Optional[str] = None) -> AsyncGenerator[BaseEvent, None]:
-        format = format or self.format
-        message = await self.ask(request, format)
-        for _ in range(self.max_iterations):
-            if not message.tool_calls:
-                break
-            tool_responses = []
-            for tool_call in message.tool_calls:
-                function_name = tool_call.name
-                if not tool_call.id:
-                    tool_call.id = str(uuid.uuid4())
-                tool_call_id = tool_call.id
-                function_args = tool_call.args
-                
-                tool = self.get_tool(function_name)
-                if not tool:
-                    yield ErrorEvent(error=f"Unknown tool: {function_name}")
+
+    def _handle_output_call(self, tool_call: ToolCall) -> tuple[LLMMessage, Optional[Any]]:
+        """Validate a structured-output tool call.
+
+        Returns the tool response message to append to memory and, on
+        success, the validated output model. On validation failure the
+        response carries the error so the model can self-repair on the next
+        iteration.
+        """
+        try:
+            output = self._output_tool.validate(tool_call.args)
+            response = LLMMessage.tool(
+                tool_call_id=tool_call.id,
+                name=tool_call.name,
+                content='{"success": true}',
+            )
+            return response, output
+        except ValidationError as e:
+            logger.warning(f"Structured output validation failed for {tool_call.name}: {e}")
+            response = LLMMessage.tool(
+                tool_call_id=tool_call.id,
+                name=tool_call.name,
+                content=f"Invalid arguments, please correct and call {tool_call.name} again: {e}",
+            )
+            return response, None
+
+    async def execute(
+        self,
+        request: str,
+        output_tool: Optional[OutputTool] = None,
+    ) -> AsyncGenerator[BaseEvent, None]:
+        """Run the agent loop.
+
+        The model works with native tool calling. When ``output_tool`` is
+        provided, the loop finishes when the model calls it with valid
+        arguments, yielding a :class:`StructuredOutputEvent`. Otherwise a
+        plain assistant message ends the loop with a :class:`MessageEvent`.
+        """
+        self._output_tool = output_tool
+        try:
+            message = await self.ask(request)
+            for _ in range(self.max_iterations):
+                if not message.tool_calls:
+                    # Plain message: final answer for unstructured runs; for
+                    # structured runs, nudge the model to use the output tool.
+                    if not output_tool:
+                        break
+                    message = await self.ask(
+                        f"Submit your result by calling the `{output_tool.name}` tool."
+                    )
                     continue
 
-                # Generate event before tool call
-                yield ToolEvent(
-                    status=ToolStatus.CALLING,
-                    tool_call_id=tool_call_id,
-                    tool_name=tool.toolkit.name,
-                    function_name=function_name,
-                    function_args=function_args
-                )
+                tool_responses = []
+                structured_output: Optional[Any] = None
+                for tool_call in message.tool_calls:
+                    function_name = tool_call.name
+                    if not tool_call.id:
+                        tool_call.id = str(uuid.uuid4())
+                    tool_call_id = tool_call.id
+                    function_args = tool_call.args
 
-                tool_result = await self.invoke_tool(tool, tool_call)
+                    if output_tool and function_name == output_tool.name:
+                        response, structured_output = self._handle_output_call(tool_call)
+                        tool_responses.append(response)
+                        continue
 
-                # Generate event after tool call
-                yield ToolEvent(
-                    status=ToolStatus.CALLED,
-                    tool_call_id=tool_call_id,
-                    tool_name=tool.toolkit.name,
-                    function_name=function_name,
-                    function_args=function_args,
-                    function_result=tool_result.artifact
-                )
+                    tool = self.get_tool(function_name)
+                    if not tool:
+                        yield ErrorEvent(error=f"Unknown tool: {function_name}")
+                        tool_responses.append(LLMMessage.tool(
+                            tool_call_id=tool_call_id,
+                            name=function_name,
+                            content=f"Unknown tool: {function_name}",
+                        ))
+                        continue
 
-                tool_responses.append(tool_result)
+                    # Generate event before tool call
+                    yield ToolEvent(
+                        status=ToolStatus.CALLING,
+                        tool_call_id=tool_call_id,
+                        tool_name=tool.toolkit.name,
+                        function_name=function_name,
+                        function_args=function_args
+                    )
 
-            message = await self.ask_with_messages(tool_responses)
-        else:
-            yield ErrorEvent(error="Maximum iteration count reached, failed to complete the task")
-        
-        yield MessageEvent(message=message.content)
-    
+                    tool_result = await self.invoke_tool(tool, tool_call)
+
+                    # Generate event after tool call
+                    yield ToolEvent(
+                        status=ToolStatus.CALLED,
+                        tool_call_id=tool_call_id,
+                        tool_name=tool.toolkit.name,
+                        function_name=function_name,
+                        function_args=function_args,
+                        function_result=tool_result.artifact
+                    )
+
+                    tool_responses.append(tool_result)
+
+                if structured_output is not None:
+                    # Persist the tool responses so the tool-call pairing in
+                    # memory stays consistent, then finish.
+                    await self._add_to_memory(tool_responses)
+                    yield StructuredOutputEvent(output=structured_output)
+                    return
+
+                message = await self.ask_with_messages(tool_responses)
+            else:
+                yield ErrorEvent(error="Maximum iteration count reached, failed to complete the task")
+
+            yield MessageEvent(message=message.content)
+        finally:
+            self._output_tool = None
+
     async def _ensure_memory(self):
         if not self.memory:
             self.memory = await self._repository.get_memory(self._agent_id, self.name)
@@ -144,7 +243,7 @@ class BaseAgent(ABC):
         """Update memory and save to repository"""
         await self._ensure_memory()
         if self.memory.empty:
-            self.memory.add_message(LLMMessage.system(self.system_prompt))
+            self.memory.add_message(LLMMessage.system(self.build_system_prompt()))
         self.memory.add_messages(messages)
         await self._repository.save_memory(self._agent_id, self.name, self.memory)
     
@@ -153,14 +252,19 @@ class BaseAgent(ABC):
         self.memory.roll_back()
         await self._repository.save_memory(self._agent_id, self.name, self.memory)
 
-    async def ask_with_messages(self, messages: List[LLMMessage], format: Optional[str] = None) -> LLMMessage:
+    async def ask_with_messages(self, messages: List[LLMMessage]) -> LLMMessage:
         await self._add_to_memory(messages)
+
+        # Token-aware guard: reclaim budget from old tool results before the
+        # context is sent to the model.
+        if self.memory.estimate_tokens() > self.max_context_tokens:
+            self.memory.compact(max_tokens=self.max_context_tokens)
+            await self._repository.save_memory(self._agent_id, self.name, self.memory)
 
         context = list(self.memory.get_messages())
         message = await self._llm.ask(
             messages=context,
             tools=self.get_tool_schemas(),
-            response_format=format,
             tool_choice=self.tool_choice,
         )
         logger.debug(f"Response from model: {message}")
@@ -168,10 +272,10 @@ class BaseAgent(ABC):
         await self._add_to_memory([message])
         return message
 
-    async def ask(self, request: str, format: Optional[str] = None) -> LLMMessage:
+    async def ask(self, request: str) -> LLMMessage:
         return await self.ask_with_messages([
             LLMMessage.user(request)
-        ], format)
+        ])
     
     async def roll_back(self, message: Message):
         await self._ensure_memory()

--- a/backend/app/domain/services/agents/execution.py
+++ b/backend/app/domain/services/agents/execution.py
@@ -1,37 +1,50 @@
-from typing import AsyncGenerator, Optional, List
+from typing import AsyncGenerator, List
 from app.domain.models.plan import Plan, Step, ExecutionStatus
 from app.domain.models.file import FileInfo
 from app.domain.models.message import Message
-from app.domain.services.agents.base import BaseAgent
+from app.domain.models.agent_output import StepReport, FinalResult
+from app.domain.services.agents.base import BaseAgent, StructuredOutputEvent
 from app.domain.repositories.agent_repository import AgentRepository
-from app.domain.services.prompts.system import SYSTEM_PROMPT
-from app.domain.services.prompts.execution import EXECUTION_SYSTEM_PROMPT, EXECUTION_PROMPT, SUMMARIZE_PROMPT
+from app.domain.services.prompts.system import build_system_prompt
+from app.domain.services.prompts.execution import EXECUTION_ROLE_PROMPT, EXECUTION_PROMPT, SUMMARIZE_PROMPT
 from app.domain.models.event import (
     BaseEvent,
     StepEvent,
     StepStatus,
     ErrorEvent,
     MessageEvent,
-    DoneEvent,
     ToolEvent,
     ToolStatus,
     WaitEvent,
 )
-from app.domain.services.tools.base import BaseToolkit
+from app.domain.services.tools.base import BaseToolkit, OutputTool
 from app.domain.external.llm import LLM
 import logging
 
 logger = logging.getLogger(__name__)
 
+COMPLETE_STEP_TOOL = OutputTool(
+    name="complete_step",
+    description="Report the outcome of the current plan step when it is finished or cannot proceed.",
+    schema=StepReport,
+)
+
+DELIVER_RESULT_TOOL = OutputTool(
+    name="deliver_result",
+    description="Deliver the final task result and its files to the user.",
+    schema=FinalResult,
+)
+
 
 class ExecutionAgent(BaseAgent):
-    """
-    Execution agent class, defining the basic behavior of execution
+    """Execution agent: carries out plan steps with tools.
+
+    Uses native tool calling end-to-end: work tools during the step, and the
+    ``complete_step`` / ``deliver_result`` output tools to submit structured
+    results — no JSON-in-prompt protocol.
     """
 
     name: str = "execution"
-    system_prompt: str = SYSTEM_PROMPT + EXECUTION_SYSTEM_PROMPT
-    format: str = "json_object"
 
     def __init__(
         self,
@@ -46,31 +59,40 @@ class ExecutionAgent(BaseAgent):
             llm=llm,
             tools=tools
         )
-    
+
+    def build_system_prompt(self) -> str:
+        return build_system_prompt(
+            toolkits=self.toolkits,
+            role_prompt=EXECUTION_ROLE_PROMPT,
+        )
+
     async def execute_step(self, plan: Plan, step: Step, message: Message) -> AsyncGenerator[BaseEvent, None]:
-        message = EXECUTION_PROMPT.format(
-            step=step.description, 
+        request = EXECUTION_PROMPT.format(
+            step=step.description,
             message=message.message,
             attachments="\n".join(message.attachments),
             language=plan.language
         )
         step.status = ExecutionStatus.RUNNING
         yield StepEvent(status=StepStatus.STARTED, step=step)
-        async for event in self.execute(message):
+        async for event in self.execute(request, output_tool=COMPLETE_STEP_TOOL):
             if isinstance(event, ErrorEvent):
                 step.status = ExecutionStatus.FAILED
                 step.error = event.error
                 yield StepEvent(status=StepStatus.FAILED, step=step)
-            elif isinstance(event, MessageEvent):
+            elif isinstance(event, StructuredOutputEvent):
+                report: StepReport = event.output
                 step.status = ExecutionStatus.COMPLETED
-                parsed_response = await self._parse_json(event.message)
-                new_step = Step.model_validate(parsed_response)
-                step.success = new_step.success
-                step.result = new_step.result
-                step.attachments = new_step.attachments
+                step.success = report.success
+                step.result = report.result
+                step.attachments = report.attachments
                 yield StepEvent(status=StepStatus.COMPLETED, step=step)
                 if step.result:
                     yield MessageEvent(message=step.result)
+                continue
+            elif isinstance(event, MessageEvent):
+                # Plain assistant text without a step report: surface it but
+                # keep the step lifecycle driven by complete_step.
                 continue
             elif isinstance(event, ToolEvent):
                 if event.function_name == "message_ask_user":
@@ -84,13 +106,13 @@ class ExecutionAgent(BaseAgent):
         step.status = ExecutionStatus.COMPLETED
 
     async def summarize(self) -> AsyncGenerator[BaseEvent, None]:
-        message = SUMMARIZE_PROMPT
-        async for event in self.execute(message):
+        async for event in self.execute(SUMMARIZE_PROMPT, output_tool=DELIVER_RESULT_TOOL):
+            if isinstance(event, StructuredOutputEvent):
+                result: FinalResult = event.output
+                logger.debug(f"Execution agent summary: {result.message}")
+                attachments = [FileInfo(file_path=file_path) for file_path in result.attachments]
+                yield MessageEvent(message=result.message, attachments=attachments)
+                continue
             if isinstance(event, MessageEvent):
-                logger.debug(f"Execution agent summary: {event.message}")
-                parsed_response = await self._parse_json(event.message)
-                message = Message.model_validate(parsed_response)
-                attachments = [FileInfo(file_path=file_path) for file_path in message.attachments]
-                yield MessageEvent(message=message.message, attachments=attachments)
                 continue
             yield event

--- a/backend/app/domain/services/agents/planner.py
+++ b/backend/app/domain/services/agents/planner.py
@@ -1,88 +1,106 @@
-from typing import Dict, Any, List, AsyncGenerator, Optional
-import json
+from typing import AsyncGenerator, Optional
 import logging
 from app.domain.models.plan import Plan, Step
 from app.domain.models.message import Message
-from app.domain.services.agents.base import BaseAgent
-from app.domain.models.memory import Memory
-from app.domain.services.prompts.system import SYSTEM_PROMPT
+from app.domain.models.agent_output import PlanOutput, PlanUpdateOutput
+from app.domain.services.agents.base import BaseAgent, StructuredOutputEvent
+from app.domain.services.prompts.system import build_system_prompt
 from app.domain.services.prompts.planner import (
-    CREATE_PLAN_PROMPT, 
+    CREATE_PLAN_PROMPT,
     UPDATE_PLAN_PROMPT,
-    PLANNER_SYSTEM_PROMPT
+    PLANNER_ROLE_PROMPT,
 )
 from app.domain.models.event import (
     BaseEvent,
     PlanEvent,
     PlanStatus,
-    ErrorEvent,
-    MessageEvent,
-    DoneEvent,
 )
-from app.domain.external.sandbox import Sandbox
 from app.domain.external.llm import LLM
-from app.domain.services.tools.base import BaseToolkit
-from app.domain.services.tools.file import FileToolkit
-from app.domain.services.tools.shell import ShellToolkit
+from app.domain.services.tools.base import BaseToolkit, OutputTool, describe_toolkits
 from app.domain.repositories.agent_repository import AgentRepository
+from typing import List
 
 logger = logging.getLogger(__name__)
 
+CREATE_PLAN_TOOL = OutputTool(
+    name="create_plan",
+    description="Submit the plan for the user's request.",
+    schema=PlanOutput,
+)
+
+UPDATE_PLAN_TOOL = OutputTool(
+    name="update_plan",
+    description="Submit the re-planned remaining steps.",
+    schema=PlanUpdateOutput,
+)
+
+
 class PlannerAgent(BaseAgent):
-    """
-    Planner agent class, defining the basic behavior of planning
+    """Planner agent: creates and re-plans task plans.
+
+    Submits plans through native function calling (``create_plan`` /
+    ``update_plan`` output tools). It is not bound to any executor toolkits —
+    it only receives a compact capability overview, which keeps full function
+    schemas out of its context.
     """
 
     name: str = "planner"
-    system_prompt: str = SYSTEM_PROMPT + PLANNER_SYSTEM_PROMPT
-    format: Optional[str] = "json_object"
-    tool_choice: Optional[str] = "none"
+    tool_choice: Optional[str] = "required"
 
     def __init__(
         self,
         agent_id: str,
         agent_repository: AgentRepository,
         llm: LLM,
-        tools: List[BaseToolkit],
+        capability_toolkits: List[BaseToolkit] = [],
     ):
         super().__init__(
             agent_id=agent_id,
             agent_repository=agent_repository,
             llm=llm,
-            tools=tools,
+            tools=[],
+        )
+        # Kept as a reference so the overview is rendered lazily, after
+        # runtime-discovered tools (e.g. MCP) have been initialized.
+        self._capability_toolkits = capability_toolkits
+
+    def build_system_prompt(self) -> str:
+        return build_system_prompt(
+            toolkits=[],
+            role_prompt=PLANNER_ROLE_PROMPT.format(
+                capabilities=describe_toolkits(self._capability_toolkits)
+            ),
         )
 
-
     async def create_plan(self, message: Message) -> AsyncGenerator[BaseEvent, None]:
-        message = CREATE_PLAN_PROMPT.format(
+        request = CREATE_PLAN_PROMPT.format(
             message=message.message,
             attachments="\n".join(message.attachments)
         )
-        async for event in self.execute(message):
-            if isinstance(event, MessageEvent):
-                logger.info(event.message)
-                parsed_response = await self._parse_json(event.message)
-                plan = Plan.model_validate(parsed_response)
+        async for event in self.execute(request, output_tool=CREATE_PLAN_TOOL):
+            if isinstance(event, StructuredOutputEvent):
+                output: PlanOutput = event.output
+                logger.info(f"Planner created plan: {output.title}")
+                plan = Plan.model_validate(output.model_dump())
                 yield PlanEvent(status=PlanStatus.CREATED, plan=plan)
             else:
                 yield event
 
     async def update_plan(self, plan: Plan, step: Step) -> AsyncGenerator[BaseEvent, None]:
-        message = UPDATE_PLAN_PROMPT.format(plan=plan.dump_json(), step=step.model_dump_json())
-        async for event in self.execute(message):
-            if isinstance(event, MessageEvent):
-                logger.debug(f"Planner agent update plan: {event.message}")
-                parsed_response = await self._parse_json(event.message)
-                updated_plan = Plan.model_validate(parsed_response)
-                new_steps = [Step.model_validate(step) for step in updated_plan.steps]
-                
+        request = UPDATE_PLAN_PROMPT.format(plan=plan.dump_json(), step=step.model_dump_json())
+        async for event in self.execute(request, output_tool=UPDATE_PLAN_TOOL):
+            if isinstance(event, StructuredOutputEvent):
+                output: PlanUpdateOutput = event.output
+                logger.debug(f"Planner updated plan: {output}")
+                new_steps = [Step.model_validate(s.model_dump()) for s in output.steps]
+
                 # Find the index of the first pending step
                 first_pending_index = None
-                for i, step in enumerate(plan.steps):
-                    if not step.is_done():
+                for i, existing_step in enumerate(plan.steps):
+                    if not existing_step.is_done():
                         first_pending_index = i
                         break
-                
+
                 # If there are pending steps, replace all pending steps
                 if first_pending_index is not None:
                     # Keep completed steps
@@ -91,7 +109,7 @@ class PlannerAgent(BaseAgent):
                     updated_steps.extend(new_steps)
                     # Update steps in plan
                     plan.steps = updated_steps
-                
+
                 yield PlanEvent(status=PlanStatus.UPDATED, plan=plan)
             else:
                 yield event

--- a/backend/app/domain/services/flows/plan_act.py
+++ b/backend/app/domain/services/flows/plan_act.py
@@ -71,12 +71,13 @@ class PlanActFlow(BaseFlow):
         if search_engine:
             tools.append(SearchToolkit(search_engine))
 
-        # Create planner and execution agents
+        # Create planner and execution agents. The planner only receives a
+        # compact capability overview instead of full tool schemas.
         self.planner = PlannerAgent(
             agent_id=self._agent_id,
             agent_repository=self._repository,
             llm=self._llm,
-            tools=tools,
+            capability_toolkits=tools,
         )
         logger.debug(f"Created planner agent for Agent {self._agent_id}")
             

--- a/backend/app/domain/services/prompts/execution.py
+++ b/backend/app/domain/services/prompts/execution.py
@@ -1,107 +1,50 @@
-# Execution prompt
+"""Execution prompts.
 
-EXECUTION_SYSTEM_PROMPT = """
-You are a task execution agent, and you need to complete the following steps:
-1. Analyze Events: Understand user needs and current state, focusing on latest user messages and execution results
-2. Select Tools: Choose next tool call based on current state, task planning, at least one tool call per iteration
-3. Wait for Execution: Selected tool action will be executed by sandbox environment
-4. Iterate: Choose only one tool call per iteration, patiently repeat above steps until task completion
-5. Submit Results: Send the result to user, result must be detailed and specific
+Structured output is submitted through native function calling (the
+``complete_step`` / ``deliver_result`` output tools), so these prompts carry
+no JSON format specifications — only execution guidance.
+"""
+
+EXECUTION_ROLE_PROMPT = """
+<role>
+You are the executor. You complete one plan step at a time using the
+available tools.
+
+Execution loop:
+1. Understand the current step in the context of the user's request and what
+   previous steps already produced.
+2. Call the tools needed to make progress; observe each result before the
+   next call.
+3. Keep the user informed with brief `message_notify_user` updates (one
+   sentence) when starting significant work or finishing it.
+4. Use `message_ask_user` only when you are blocked without user input.
+5. When the step is done (or cannot be completed), call `complete_step` with
+   an honest report of the outcome.
+</role>
 """
 
 EXECUTION_PROMPT = """
-You are executing the task:
+Execute this step of the plan:
 {step}
 
-Note:
-- **It you that to do the task, not the user**
-- **You must use the language provided by user's message to execute the task**
-- You must use message_notify_user tool to notify users within one sentence:
-    - What tools you are going to use and what you are going to do with them
-    - What you have done by tools
-    - What you are going to do or have done within one sentence
-- If you need to ask user for input or take control of the browser, you must use message_ask_user tool to ask user for input
-- Don't tell how to do the task, determine by yourself.
-- Deliver the final result to user not the todo list, advice or plan
+Context:
+- Original user message: {message}
+- User attachments: {attachments}
+- Working language: {language}
 
-Return format requirements:
-- Must return JSON format that complies with the following TypeScript interface
-- Must include all required fields as specified
-
-
-TypeScript Interface Definition:
-```typescript
-interface Response {{
-  /** Whether the task is executed successfully **/
-  success: boolean;
-  /** Array of file paths in sandbox for generated files to be delivered to user **/
-  attachments: string[];
-
-  /** Task result, empty if no result to deliver **/
-  result: string;
-}}
-```
-
-EXAMPLE JSON OUTPUT:
-{{
-    "success": true,
-    "result": "We have finished the task",
-    "attachments": [
-        "/home/ubuntu/file1.md",
-        "/home/ubuntu/file2.md"
-    ],
-}}
-
-Input:
-- message: the user's message, use this language for all text output
-- attachments: the user's attachments
-- task: the task to execute
-
-Output:
-- the step execution result in json format
-
-User Message:
-{message}
-
-Attachments:
-{attachments}
-
-Working Language:
-{language}
-
-Task:
-{step}
+Rules:
+- You do the work yourself with tools; never tell the user how to do it.
+- Stay within the scope of this step; later steps will be handled separately.
+- When finished, call the `complete_step` tool with the step outcome. Report
+  success=false with what went wrong if the step could not be completed.
 """
 
 SUMMARIZE_PROMPT = """
-You are finished the task, and you need to deliver the final result to user.
+All plan steps are finished. Deliver the final result to the user by calling
+the `deliver_result` tool.
 
-Note:
-- You should explain the final result to user in detail.
-- Write a markdown content to deliver the final result to user if necessary.
-- Use file tools to deliver the files generated above to user if necessary.
-- Deliver the files generated above to user if necessary.
-
-Return format requirements:
-- Must return JSON format that complies with the following TypeScript interface
-- Must include all required fields as specified
-
-TypeScript Interface Definition:
-```typescript
-interface Response {
-  /** Response to user's message and thinking about the task, as detailed as possible */
-  message: string;
-  /** Array of file paths in sandbox for generated files to be delivered to user */
-  attachments: string[];
-}
-```
-
-EXAMPLE JSON OUTPUT:
-{{
-    "message": "Summary message",
-    "attachments": [
-        "/home/ubuntu/file1.md",
-        "/home/ubuntu/file2.md"
-    ]
-}}
+Rules:
+- Explain what was accomplished and the final outcome in detail, in the
+  working language.
+- Attach the files produced during the task that the user should receive.
 """

--- a/backend/app/domain/services/prompts/planner.py
+++ b/backend/app/domain/services/prompts/planner.py
@@ -1,69 +1,34 @@
-# Planner prompt
-PLANNER_SYSTEM_PROMPT = """
-You are a task planner agent, and you need to create or update a plan for the task:
-1. Analyze the user's message and understand the user's needs
-2. Determine what tools you need to use to complete the task
-3. Determine the working language based on the user's message
-4. Generate the plan's goal and steps
+"""Planner prompts.
+
+Structured output is submitted through native function calling (the
+``create_plan`` / ``update_plan`` output tools), so these prompts carry no
+JSON format specifications — only planning guidance.
+"""
+
+PLANNER_ROLE_PROMPT = """
+<role>
+You are the planner. You break the user's request into a short sequence of
+atomic steps that an executor agent will carry out one at a time with the
+capabilities listed below. You do not execute anything yourself.
+
+Planning rules:
+- Keep the plan simple: as few steps as the task genuinely needs. A trivial
+  task is a single step.
+- Each step must be atomic and self-contained so the executor can complete it
+  in one focused work session.
+- Determine the working language from the user's message and use it for all
+  user-facing text.
+- If the task is infeasible, return an empty step list and an empty goal.
+</role>
+
+<executor_capabilities>
+{capabilities}
+</executor_capabilities>
 """
 
 CREATE_PLAN_PROMPT = """
-You are now creating a plan based on the user's message:
-{message}
-
-Note:
-- **You must use the language provided by user's message to execute the task**
-- Your plan must be simple and concise, don't add any unnecessary details.
-- Your steps must be atomic and independent, and the next executor can execute them one by one use the tools.
-- You need to determine whether a task can be broken down into multiple steps. If it can, return multiple steps; otherwise, return a single step.
-
-Return format requirements:
-- Must return JSON format that complies with the following TypeScript interface
-- Must include all required fields as specified
-- If the task is determined to be unfeasible, return an empty array for steps and empty string for goal
-
-TypeScript Interface Definition:
-```typescript
-interface CreatePlanResponse {{
-  /** Response to user's message and thinking about the task, as detailed as possible, use the user's language */
-  message: string;
-  /** The working language according to the user's message */
-  language: string;
-  /** Array of steps, each step contains id and description */
-  steps: Array<{{
-    /** Step identifier */
-    id: string;
-    /** Step description */
-    description: string;
-  }}>;
-  /** Plan goal generated based on the context */
-  goal: string;
-  /** Plan title generated based on the context */
-  title: string;
-}}
-```
-
-EXAMPLE JSON OUTPUT:
-{{
-    "message": "User response message",
-    "goal": "Goal description",
-    "title": "Plan title",
-    "language": "en",
-    "steps": [
-        {{
-            "id": "1",
-            "description": "Step 1 description"
-        }}
-    ]
-}}
-
-Input:
-- message: the user's message
-- attachments: the user's attachments
-
-Output:
-- the plan in json format
-
+Create a plan for the user's request below, then submit it by calling the
+`create_plan` tool exactly once.
 
 User message:
 {message}
@@ -73,56 +38,20 @@ Attachments:
 """
 
 UPDATE_PLAN_PROMPT = """
-You are updating the plan, you need to update the plan based on the step execution result:
+A step has just finished. Review its result and re-plan the remaining steps,
+then submit them by calling the `update_plan` tool exactly once.
+
+Rules:
+- Do not change the plan goal or any completed steps.
+- Return only the remaining (uncompleted) steps, starting from the first
+  uncompleted step id. Return an empty list if nothing is left to do.
+- Read the step result carefully: if it failed, adjust the remaining steps to
+  recover; if it already covered later steps, drop them.
+- Keep step descriptions unchanged unless a real change is needed.
+
+Finished step:
 {step}
 
-Note:
-- You can delete, add or modify the plan steps, but don't change the plan goal
-- Don't change the description if the change is small
-- Only re-plan the following uncompleted steps, don't change the completed steps
-- Output the step id start with the id of first uncompleted step, re-plan the following steps
-- Delete the step if it is completed or not necessary
-- Carefully read the step result to determine if it is successful, if not, change the following steps
-- According to the step result, you need to update the plan steps accordingly
-
-Return format requirements:
-- Must return JSON format that complies with the following TypeScript interface
-- Must include all required fields as specified
-
-TypeScript Interface Definition:
-```typescript
-interface UpdatePlanResponse {{
-  /** Array of updated uncompleted steps */
-  steps: Array<{{
-    /** Step identifier */
-    id: string;
-    /** Step description */
-    description: string;
-  }}>;
-}}
-```
-
-EXAMPLE JSON OUTPUT:
-{{
-    "steps": [
-        {{
-            "id": "1",
-            "description": "Step 1 description"
-        }}
-    ]
-}}
-
-
-Input:
-- step: the current step
-- plan: the plan to update
-
-Output:
-- the updated plan uncompleted steps in json format
-
-Step:
-{step}
-
-Plan:
+Current plan:
 {plan}
 """

--- a/backend/app/domain/services/prompts/system.py
+++ b/backend/app/domain/services/prompts/system.py
@@ -1,100 +1,77 @@
-SYSTEM_PROMPT = """
-You are Manus, an AI agent created by the Manus team.
+"""Composable system prompt.
 
-<intro>
-You excel at the following tasks:
-1. Information gathering, fact-checking, and documentation
-2. Data processing, analysis, and visualization
-3. Writing multi-chapter articles and in-depth research reports、
-4. Using programming to solve various problems beyond development
-5. Various tasks that can be accomplished using computers and the internet
-</intro>
+The system prompt is assembled at agent-construction time from:
 
-<language_settings>
-- Default working language: **English**
-- Use the language specified by user in messages as the working language when explicitly provided
-- All thinking and responses must be in the working language
-- Natural language arguments in tool calls must be in the working language
-- Avoid using pure lists and bullet points format in any language
-</language_settings>
+* a core identity/policy section shared by all agents,
+* one usage section per toolkit actually bound to the agent (taken from
+  ``BaseToolkit.instructions``), so prompt guidance always matches the tools
+  the model can really call,
+* an optional role-specific section supplied by the concrete agent.
 
-<system_capability>
-- Access a Linux sandbox environment with internet connection
-- Use shell, text editor, browser, and other software
-- Write and run code in Python and various programming languages
-- Independently install required software packages and dependencies via shell
-- Access specialized external tools and professional services through MCP (Model Context Protocol) integration
-- Suggest users to temporarily take control of the browser for sensitive operations when necessary
-- Utilize various tools to complete user-assigned tasks step by step
-</system_capability>
+This replaces the previous monolithic hardcoded prompt, which shipped rules
+for tools that were not always available and could drift out of sync with the
+toolset.
+"""
+from typing import List, Optional
 
-<file_rules>
-- Use file tools for reading, writing, appending, and editing to avoid string escape issues in shell commands
-- Actively save intermediate results and store different types of reference information in separate files
-- When merging text files, must use append mode of file writing tool to concatenate content to target file
-- Strictly follow requirements in <writing_rules>, and avoid using list formats in any files except todo.md
-- Don't read files that are not a text file, code file or markdown file
-</file_rules>
+from app.domain.services.tools.base import BaseToolkit
 
-<search_rules>
-- You must access multiple URLs from search results for comprehensive information or cross-validation.
-- Information priority: authoritative data from web search > model's internal knowledge
-- Prefer dedicated search tools over browser access to search engine result pages
-- Snippets in search results are not valid sources; must access original pages via browser
-- Access multiple URLs from search results for comprehensive information or cross-validation
-- Conduct searches step by step: search multiple attributes of single entity separately, process multiple entities one by one
-</search_rules>
+CORE_PROMPT = """
+You are Manus, a general-purpose AI agent created by the Manus team.
 
-<browser_rules>
-- Must use browser tools to access and comprehend all URLs provided by users in messages
-- Must use browser tools to access URLs from search tool results
-- Actively explore valuable links for deeper information, either by clicking elements or accessing URLs directly
-- Browser tools only return elements in visible viewport by default
-- Visible elements are returned as `index[:]<tag>text</tag>`, where index is for interactive elements in subsequent browser actions
-- Due to technical limitations, not all interactive elements may be identified; use coordinates to interact with unlisted elements
-- Browser tools automatically attempt to extract page content, providing it in Markdown format if successful
-- Extracted Markdown includes text beyond viewport but omits links and images; completeness not guaranteed
-- If extracted Markdown is complete and sufficient for the task, no scrolling is needed; otherwise, must actively scroll to view the entire page
-</browser_rules>
+<capabilities>
+You operate a Linux sandbox with internet access to complete user tasks
+end-to-end: gathering and verifying information, processing and analyzing
+data, writing documents and reports, coding, and any other work achievable
+with a computer. You install what you need, run what you write, and verify
+what you produce.
+</capabilities>
 
-<shell_rules>
-- Avoid commands requiring confirmation; actively use -y or -f flags for automatic confirmation
-- Avoid commands with excessive output; save to files when necessary
-- Chain multiple commands with && operator to minimize interruptions
-- Use pipe operator to pass command outputs, simplifying operations
-- Use non-interactive `bc` for simple calculations, Python for complex math; never calculate mentally
-- Use `uptime` command when users explicitly request sandbox status check or wake-up
-</shell_rules>
+<language>
+- Default working language: English.
+- If the user's message is in another language, use that language for all
+  thinking, natural-language tool arguments, and responses.
+</language>
 
-<coding_rules>
-- Must save code to files before execution; direct code input to interpreter commands is forbidden
-- Write Python code for complex mathematical calculations and analysis
-- Use search tools to find solutions when encountering unfamiliar problems
-</coding_rules>
-
-<writing_rules>
-- Write content in continuous paragraphs using varied sentence lengths for engaging prose; avoid list formatting
-- Use prose and paragraphs by default; only employ lists when explicitly requested by users
-- All writing must be highly detailed with a minimum length of several thousand words, unless user explicitly specifies length or format requirements
-- When writing based on references, actively cite original text with sources and provide a reference list with URLs at the end
-- For lengthy documents, first save each section as separate draft files, then append them sequentially to create the final document
-- During final compilation, no content should be reduced or summarized; the final length must exceed the sum of all individual draft files
-</writing_rules>
+<operating_principles>
+- You execute the task yourself; never hand instructions back to the user to
+  perform. Deliver final results, not plans or advice about how to do it.
+- Work step by step; verify intermediate results before building on them.
+- Prefer primary sources and cross-validate important facts.
+- Save intermediate work to files so progress is never lost.
+- When writing prose deliverables, cite sources with URLs when the content is
+  based on references. Match the length and format to what the user asked
+  for; be thorough for research and writing tasks.
+- Code must be saved to a file before execution; never pipe code inline into
+  interpreters.
+</operating_principles>
 
 <sandbox_environment>
-System Environment:
-- Ubuntu 22.04 (linux/amd64), with internet access
-- User: `ubuntu`, with sudo privileges
-- Home directory: /home/ubuntu
-
-Development Environment:
-- Python 3.10.12 (commands: python3, pip3)
-- Node.js 20.18.0 (commands: node, npm)
-- Basic calculator (command: bc)
+- Ubuntu 22.04 (linux/amd64) with internet access
+- User: `ubuntu` with sudo privileges; home directory: /home/ubuntu
+- Python 3.10 (python3, pip3), Node.js 20 (node, npm), calculator (bc)
 </sandbox_environment>
+""".strip()
 
-<important_notes>
-- ** You must execute the task, not the user. **
-- ** Don't deliver the todo list, advice or plan to user, deliver the final result to user **
-</important_notes>
-""" 
+
+def build_system_prompt(
+    toolkits: Optional[List[BaseToolkit]] = None,
+    role_prompt: str = "",
+) -> str:
+    """Assemble the system prompt for an agent.
+
+    Args:
+        toolkits: Toolkits bound to the agent; each contributes its own usage
+            section only when it defines ``instructions``.
+        role_prompt: Role-specific guidance appended by the concrete agent.
+    """
+    sections = [CORE_PROMPT]
+    for toolkit in toolkits or []:
+        instructions = (toolkit.instructions or "").strip()
+        if instructions:
+            sections.append(
+                f"<{toolkit.name}_rules>\n{instructions}\n</{toolkit.name}_rules>"
+            )
+    if role_prompt.strip():
+        sections.append(role_prompt.strip())
+    return "\n\n".join(sections)

--- a/backend/app/domain/services/tools/base.py
+++ b/backend/app/domain/services/tools/base.py
@@ -1,16 +1,26 @@
 """Framework-agnostic tool abstraction for the domain layer.
 
-Replaces the previous LangChain ``BaseTool`` / ``@tool`` integration so the
-domain no longer depends on LangChain. A lightweight ``@tool`` decorator parses
-the method signature and its Google-style docstring into an OpenAI-compatible
-function schema, and ``Tool`` / ``BaseToolkit`` expose the tools for the agent
-loop and the LLM gateway.
+A lightweight ``@tool`` decorator parses the method signature and its
+Google-style docstring into an OpenAI-compatible function schema, and
+``Tool`` / ``BaseToolkit`` expose the tools for the agent loop and the LLM
+gateway.
+
+Two additional concepts support modern context engineering:
+
+* ``Tool.dynamic`` — build an invocable tool from a runtime schema and an
+  async invoker (used for MCP tools discovered at runtime), so every tool the
+  LLM sees is dispatchable through the same ``BaseToolkit.get_tool`` path.
+* ``OutputTool`` — a schema-only tool the model calls to submit structured
+  output (plans, step reports, final results). It is never executed; the agent
+  loop validates the arguments against a Pydantic model and feeds validation
+  errors back to the model for self-repair. This replaces the legacy
+  "JSON-in-prompt + repair parser" protocol with native function calling.
 """
 import inspect
 import re
-from typing import Any, Callable, Dict, List, Optional, get_type_hints
+from typing import Any, Awaitable, Callable, Dict, List, Optional, Type, get_type_hints
 
-from pydantic import Field, create_model
+from pydantic import BaseModel, Field, ValidationError, create_model
 
 
 def _parse_docstring(doc: Optional[str]) -> tuple[str, Dict[str, str]]:
@@ -57,6 +67,9 @@ def _clean_schema(schema: Dict[str, Any]) -> Dict[str, Any]:
     for definition in schema.get("$defs", {}).values():
         if isinstance(definition, dict):
             definition.pop("title", None)
+            for prop in definition.get("properties", {}).values():
+                if isinstance(prop, dict):
+                    prop.pop("title", None)
     return schema
 
 
@@ -115,16 +128,56 @@ def tool(func: Optional[Callable] = None, **_kwargs: Any):
 class Tool:
     """An invocable tool bound to its owning toolkit."""
 
-    def __init__(self, tool_function: ToolFunction, toolkit: "BaseToolkit"):
-        self._func = tool_function.func
-        self.name = tool_function.name
-        self.description = tool_function.description
-        self.parameters = tool_function.parameters
+    def __init__(
+        self,
+        name: str,
+        description: str,
+        parameters: Dict[str, Any],
+        invoker: Callable[[Dict[str, Any]], Awaitable[Any]],
+        toolkit: "BaseToolkit",
+    ):
+        self.name = name
+        self.description = description
+        self.parameters = parameters
         self.toolkit = toolkit
+        self._invoker = invoker
+
+    @classmethod
+    def from_function(cls, tool_function: ToolFunction, toolkit: "BaseToolkit") -> "Tool":
+        """Build a tool from a ``@tool``-decorated toolkit method."""
+
+        async def invoker(args: Dict[str, Any]) -> Any:
+            return await tool_function.func(toolkit, **(args or {}))
+
+        return cls(
+            name=tool_function.name,
+            description=tool_function.description,
+            parameters=tool_function.parameters,
+            invoker=invoker,
+            toolkit=toolkit,
+        )
+
+    @classmethod
+    def dynamic(
+        cls,
+        name: str,
+        description: str,
+        parameters: Dict[str, Any],
+        invoker: Callable[[Dict[str, Any]], Awaitable[Any]],
+        toolkit: "BaseToolkit",
+    ) -> "Tool":
+        """Build a tool from a runtime-discovered schema (e.g. an MCP tool)."""
+        return cls(
+            name=name,
+            description=description,
+            parameters=parameters,
+            invoker=invoker,
+            toolkit=toolkit,
+        )
 
     async def invoke(self, args: Dict[str, Any]) -> Any:
         """Invoke the underlying coroutine with the given arguments."""
-        return await self._func(self.toolkit, **(args or {}))
+        return await self._invoker(args or {})
 
     def to_openai_schema(self) -> Dict[str, Any]:
         """Render this tool as an OpenAI function-calling schema."""
@@ -138,17 +191,59 @@ class Tool:
         }
 
 
+class OutputTool:
+    """A schema-only tool the model calls to submit structured output.
+
+    The agent loop never executes it; instead the arguments are validated
+    against ``schema`` and returned as the structured result of the run.
+    Validation errors are sent back to the model as the tool response so it
+    can correct itself — native function calling replaces prompt-embedded
+    JSON format instructions.
+    """
+
+    def __init__(self, name: str, description: str, schema: Type[BaseModel]):
+        self.name = name
+        self.description = description
+        self.schema = schema
+        self.parameters = _clean_schema(schema.model_json_schema())
+
+    def validate(self, args: Dict[str, Any]) -> BaseModel:
+        """Validate raw tool-call arguments against the output schema.
+
+        Raises:
+            pydantic.ValidationError: when the arguments do not conform.
+        """
+        return self.schema.model_validate(args or {})
+
+    def to_openai_schema(self) -> Dict[str, Any]:
+        """Render this output tool as an OpenAI function-calling schema."""
+        return {
+            "type": "function",
+            "function": {
+                "name": self.name,
+                "description": self.description,
+                "parameters": self.parameters,
+            },
+        }
+
+
 class BaseToolkit:
-    """Base toolset class, providing common tool discovery and lookup."""
+    """Base toolset class, providing common tool discovery and lookup.
+
+    Subclasses may set ``instructions`` — usage guidance that is assembled
+    into the system prompt only when the toolkit is actually bound to the
+    agent, keeping prompt content and available tools in sync.
+    """
 
     name: str = ""
+    instructions: str = ""
 
     def __init__(self):
         self.tools: List[Tool] = []
         for _, member in inspect.getmembers(
             type(self), lambda x: isinstance(x, ToolFunction)
         ):
-            self.tools.append(Tool(member, toolkit=self))
+            self.tools.append(Tool.from_function(member, toolkit=self))
 
     def get_tools(self) -> List[Tool]:
         """Return all invocable tools in this toolkit."""
@@ -156,11 +251,37 @@ class BaseToolkit:
 
     def get_tool_schemas(self) -> List[Dict[str, Any]]:
         """Return OpenAI function schemas for all tools in this toolkit."""
-        return [t.to_openai_schema() for t in self.tools]
+        return [t.to_openai_schema() for t in self.get_tools()]
 
     def get_tool(self, tool_name: str) -> Optional[Tool]:
         """Return the tool with the given name, or ``None``."""
-        for t in self.tools:
+        for t in self.get_tools():
             if t.name == tool_name:
                 return t
         return None
+
+
+def describe_toolkits(toolkits: List[BaseToolkit]) -> str:
+    """Render a compact capability overview of the given toolkits.
+
+    Used to inform the planner about available capabilities without paying
+    the context cost of full function schemas.
+    """
+    lines: List[str] = []
+    for toolkit in toolkits:
+        tool_names = [t.name for t in toolkit.get_tools()]
+        if not tool_names:
+            continue
+        lines.append(f"- {toolkit.name}: {', '.join(tool_names)}")
+    return "\n".join(lines)
+
+
+__all__ = [
+    "tool",
+    "Tool",
+    "ToolFunction",
+    "OutputTool",
+    "BaseToolkit",
+    "describe_toolkits",
+    "ValidationError",
+]

--- a/backend/app/domain/services/tools/browser.py
+++ b/backend/app/domain/services/tools/browser.py
@@ -7,6 +7,14 @@ class BrowserToolkit(BaseToolkit):
     """Browser tool class, providing browser interaction functions"""
 
     name: str = "browser"
+    instructions: str = """
+- Use browser tools to open every URL provided by the user and URLs from search results
+- Actively explore valuable links for deeper information
+- Tools return elements in the visible viewport as `index[:]<tag>text</tag>`; use the index for subsequent interactions
+- Not all interactive elements are listed; use coordinates for unlisted elements
+- Pages are auto-extracted to Markdown when possible; the extraction may include off-screen text but omits links/images and is not guaranteed complete
+- If the extracted Markdown already covers what you need, don't scroll; otherwise scroll to view the full page
+"""
     
     def __init__(self, browser: Browser):
         """Initialize browser tool class

--- a/backend/app/domain/services/tools/file.py
+++ b/backend/app/domain/services/tools/file.py
@@ -7,6 +7,12 @@ class FileToolkit(BaseToolkit):
     """File tool class, providing file operation functions"""
 
     name: str = "file"
+    instructions: str = """
+- Prefer file tools over shell redirection to avoid escaping issues
+- Actively save intermediate results; keep different kinds of reference material in separate files
+- Use append mode to concatenate content onto an existing file
+- Only read text, code, or markdown files; never read binary files
+"""
     
     def __init__(self, sandbox: Sandbox):
         """Initialize file tool class

--- a/backend/app/domain/services/tools/mcp.py
+++ b/backend/app/domain/services/tools/mcp.py
@@ -9,7 +9,7 @@ from mcp.client.sse import sse_client
 from mcp.client.streamable_http import streamablehttp_client
 from mcp.types import Tool as MCPToolkit
 
-from app.domain.services.tools.base import BaseToolkit
+from app.domain.services.tools.base import BaseToolkit, Tool
 from app.domain.models.tool_result import ToolResult
 from app.domain.models.mcp_config import MCPConfig, MCPServerConfig
 
@@ -313,43 +313,49 @@ class MCPClientManager:
 
 
 class MCPToolkit(BaseToolkit):
-    """MCP 工具类"""
-    
+    """MCP 工具类
+
+    Tools discovered from MCP servers at runtime are wrapped as regular
+    invocable :class:`Tool` objects, so the agent loop dispatches them through
+    the same ``get_tool`` path as builtin tools.
+    """
+
     name: str = "mcp"
-    
+
     def __init__(self):
         super().__init__()
         self._initialized = False
-        self._tools = []
-    
+        self.manager: Optional[MCPClientManager] = None
+
     async def initialized(self, config: Optional[MCPConfig] = None):
         """确保管理器已初始化"""
         if not self._initialized:
             self.manager = MCPClientManager(config)
             await self.manager.initialize()
-            self._tools = await self.manager.get_all_tools()
+            self.tools = self._build_tools(await self.manager.get_all_tools())
             self._initialized = True
 
-    def get_tools(self) -> List[Any]:
-        """MCP tools are dynamic schemas, not invocable domain Tool objects."""
-        return []
+    def _build_tools(self, schemas: List[Dict[str, Any]]) -> List[Tool]:
+        """Wrap runtime-discovered MCP schemas as invocable domain tools."""
+        tools: List[Tool] = []
+        for schema in schemas:
+            function = schema.get("function", {})
+            tool_name = function.get("name", "")
+            if not tool_name:
+                continue
 
-    def get_tool_schemas(self) -> List[Dict[str, Any]]:
-        """Return OpenAI function schemas for the dynamic MCP tools."""
-        return self._tools
+            async def invoker(args: Dict[str, Any], _name: str = tool_name) -> ToolResult:
+                return await self.manager.call_tool(_name, args)
 
-    def has_function(self, function_name: str) -> bool:
-        """检查指定函数是否存在（包括动态 MCP 工具）"""
-        # 检查是否是 MCP 工具
-        for tool in self._tools:
-            if tool['function']['name'] == function_name:
-                return True
-        return False
-    
-    async def invoke_function(self, function_name: str, **kwargs) -> ToolResult:
-        """调用工具函数"""
-        return await self.manager.call_tool(function_name, kwargs)
-    
+            tools.append(Tool.dynamic(
+                name=tool_name,
+                description=function.get("description", ""),
+                parameters=function.get("parameters", {}) or {"type": "object", "properties": {}},
+                invoker=invoker,
+                toolkit=self,
+            ))
+        return tools
+
     async def cleanup(self):
         """清理资源"""
         if self.manager:

--- a/backend/app/domain/services/tools/message.py
+++ b/backend/app/domain/services/tools/message.py
@@ -7,6 +7,11 @@ class MessageToolkit(BaseToolkit):
     """Message tool class, providing message sending functions for user interaction"""
 
     name: str = "message"
+    instructions: str = """
+- Use message_notify_user for brief one-sentence progress updates; it needs no reply
+- Use message_ask_user only when blocked without user input (clarification, confirmation, credentials, or browser takeover)
+- Deliver final results and files to the user, not todo lists, advice, or plans
+"""
     
     def __init__(self):
         """Initialize message tool class"""

--- a/backend/app/domain/services/tools/search.py
+++ b/backend/app/domain/services/tools/search.py
@@ -7,6 +7,13 @@ class SearchToolkit(BaseToolkit):
     """Search tool class, providing search engine interaction functions"""
 
     name: str = "search"
+    instructions: str = """
+- Prefer the dedicated search tool over browsing to a search engine results page
+- Snippets are not valid sources; open the original pages via browser before citing
+- Visit multiple result URLs for comprehensive information or cross-validation
+- Search step by step: query attributes of a single entity separately, handle entities one by one
+- Authoritative web information takes priority over internal model knowledge
+"""
     
     def __init__(self, search_engine: SearchEngine):
         """Initialize search tool class

--- a/backend/app/domain/services/tools/shell.py
+++ b/backend/app/domain/services/tools/shell.py
@@ -7,6 +7,13 @@ class ShellToolkit(BaseToolkit):
     """Shell tool class, providing Shell interaction related functions"""
 
     name: str = "shell"
+    instructions: str = """
+- Avoid commands requiring interactive confirmation; use -y or -f flags
+- Avoid commands with excessive output; redirect to files when necessary
+- Chain related commands with && to minimize round-trips
+- Use non-interactive `bc` for simple math, Python for anything complex; never compute mentally
+- Save code to files before execution; never pipe code inline into interpreters
+"""
     
     def __init__(self, sandbox: Sandbox):
         """Initialize Shell tool class

--- a/backend/tests/test_context_engineering.py
+++ b/backend/tests/test_context_engineering.py
@@ -1,0 +1,328 @@
+"""Unit tests for the redesigned context engineering.
+
+Covers the composable system prompt, structured output via native function
+calling (OutputTool + self-repair), token-aware memory compaction, tool
+result truncation, and the dynamic MCP tool bridge. Pure unit tests — no
+running backend required.
+"""
+import json
+from typing import List, Optional
+
+from pydantic import BaseModel
+
+from app.domain.models.agent_output import PlanOutput, StepReport
+from app.domain.models.memory import Memory, estimate_tokens
+from app.domain.models.message import LLMMessage, Role, ToolCall
+from app.domain.models.tool_result import ToolResult
+from app.domain.services.agents.base import BaseAgent, StructuredOutputEvent
+from app.domain.services.prompts.system import build_system_prompt
+from app.domain.services.tools.base import (
+    BaseToolkit,
+    OutputTool,
+    Tool,
+    describe_toolkits,
+    tool,
+)
+
+
+class EchoToolkit(BaseToolkit):
+    name = "echo"
+    instructions = "- Echo things back verbatim"
+
+    @tool(parse_docstring=True)
+    async def echo(self, text: str) -> ToolResult:
+        """Echo the given text back.
+
+        Args:
+            text: Text to echo
+        """
+        return ToolResult(success=True, data=text)
+
+
+class SilentToolkit(BaseToolkit):
+    """Toolkit without instructions — must not add a prompt section."""
+
+    name = "silent"
+
+    @tool(parse_docstring=True)
+    async def noop(self) -> ToolResult:
+        """Do nothing."""
+        return ToolResult(success=True)
+
+
+class TestSystemPromptBuilder:
+    def test_core_prompt_always_present(self):
+        prompt = build_system_prompt()
+        assert "You are Manus" in prompt
+        assert "<sandbox_environment>" in prompt
+
+    def test_bound_toolkit_contributes_section(self):
+        prompt = build_system_prompt(toolkits=[EchoToolkit()])
+        assert "<echo_rules>" in prompt
+        assert "Echo things back verbatim" in prompt
+
+    def test_toolkit_without_instructions_adds_no_section(self):
+        prompt = build_system_prompt(toolkits=[SilentToolkit()])
+        assert "<silent_rules>" not in prompt
+
+    def test_role_prompt_appended(self):
+        prompt = build_system_prompt(role_prompt="<role>planner</role>")
+        assert prompt.endswith("<role>planner</role>")
+
+    def test_describe_toolkits_compact_overview(self):
+        overview = describe_toolkits([EchoToolkit(), SilentToolkit()])
+        assert overview == "- echo: echo\n- silent: noop"
+
+
+class TestOutputTool:
+    def test_schema_shape(self):
+        out = OutputTool("create_plan", "Submit the plan.", PlanOutput)
+        schema = out.to_openai_schema()
+        assert schema["type"] == "function"
+        assert schema["function"]["name"] == "create_plan"
+        props = schema["function"]["parameters"]["properties"]
+        assert set(props) == {"message", "language", "title", "goal", "steps"}
+
+    def test_validate_success_and_failure(self):
+        out = OutputTool("complete_step", "Report step.", StepReport)
+        report = out.validate({"success": True, "result": "done"})
+        assert report.success is True and report.attachments == []
+
+        import pytest
+        from pydantic import ValidationError
+        with pytest.raises(ValidationError):
+            out.validate({"result": "missing success"})
+
+
+class TestMemoryCompaction:
+    def _memory_with_tool_results(self, n: int, size: int = 400) -> Memory:
+        m = Memory()
+        m.add_message(LLMMessage.system("sys"))
+        for i in range(n):
+            m.add_message(LLMMessage.assistant(
+                "", tool_calls=[ToolCall(id=f"c{i}", name="echo", args={})]
+            ))
+            m.add_message(LLMMessage.tool(
+                tool_call_id=f"c{i}", name="echo", content="x" * size
+            ))
+        return m
+
+    def test_estimate_tokens_counts_content_and_calls(self):
+        assert estimate_tokens("") == 0
+        assert estimate_tokens("abcd" * 100) == 100
+        m = self._memory_with_tool_results(2)
+        assert m.estimate_tokens() > 0
+
+    def test_unconditional_compact_elides_old_tool_results(self):
+        m = self._memory_with_tool_results(10)
+        m.compact(keep_recent=4)
+        elided = [msg for msg in m.messages if "elided" in msg.content]
+        assert elided, "old tool results should be elided"
+        # The most recent messages are untouched.
+        assert m.messages[-1].content == "x" * 400
+
+    def test_budgeted_compact_stops_at_budget(self):
+        m = self._memory_with_tool_results(10)
+        before = m.estimate_tokens()
+        m.compact(max_tokens=before + 1)  # already under budget: no-op
+        assert all("elided" not in msg.content for msg in m.messages if msg.role == Role.TOOL)
+
+        m.compact(max_tokens=before // 2, keep_recent=2)
+        assert m.estimate_tokens() <= before // 2
+
+    def test_compact_preserves_message_skeleton(self):
+        m = self._memory_with_tool_results(5)
+        count = len(m.messages)
+        m.compact(keep_recent=0)
+        assert len(m.messages) == count
+        assert all(msg.role in (Role.SYSTEM, Role.ASSISTANT, Role.TOOL) for msg in m.messages)
+
+
+class _FakeRepository:
+    def __init__(self):
+        self.memory = Memory()
+
+    async def get_memory(self, agent_id: str, name: str) -> Memory:
+        return self.memory
+
+    async def save_memory(self, agent_id: str, name: str, memory: Memory) -> None:
+        self.memory = memory
+
+
+class _ScriptedLLM:
+    """LLM stub returning scripted assistant messages in order."""
+
+    def __init__(self, responses: List[LLMMessage]):
+        self._responses = list(responses)
+        self.requests = []
+
+    async def ask(self, messages, tools=None, response_format=None, tool_choice=None):
+        self.requests.append({"messages": list(messages), "tools": tools, "tool_choice": tool_choice})
+        return self._responses.pop(0)
+
+    async def parse_json(self, text: str):
+        raise AssertionError("parse_json must not be used by the agent loop anymore")
+
+
+class _TestAgent(BaseAgent):
+    name = "test"
+
+    def build_system_prompt(self) -> str:
+        return "test system prompt"
+
+
+def _agent(llm: _ScriptedLLM, toolkits: Optional[list] = None) -> _TestAgent:
+    return _TestAgent(
+        agent_id="a1",
+        agent_repository=_FakeRepository(),
+        llm=llm,
+        tools=toolkits or [],
+    )
+
+
+REPORT_TOOL = OutputTool("complete_step", "Report the step outcome.", StepReport)
+
+
+async def _collect(gen):
+    return [event async for event in gen]
+
+
+class TestAgentLoopStructuredOutput:
+    async def test_output_tool_call_yields_structured_output(self):
+        llm = _ScriptedLLM([
+            LLMMessage.assistant("", tool_calls=[
+                ToolCall(id="c1", name="complete_step",
+                         args={"success": True, "result": "done", "attachments": []}),
+            ]),
+        ])
+        agent = _agent(llm)
+        events = await _collect(agent.execute("do it", output_tool=REPORT_TOOL))
+
+        outputs = [e for e in events if isinstance(e, StructuredOutputEvent)]
+        assert len(outputs) == 1
+        assert outputs[0].output.result == "done"
+
+        # Output tool schema was offered to the model.
+        offered = [t["function"]["name"] for t in llm.requests[0]["tools"]]
+        assert "complete_step" in offered
+
+        # Memory stays consistent: the output call received a tool response.
+        last = agent.memory.get_last_message()
+        assert last.role == Role.TOOL and last.tool_call_id == "c1"
+
+    async def test_invalid_output_args_trigger_self_repair(self):
+        llm = _ScriptedLLM([
+            # First attempt: missing required fields.
+            LLMMessage.assistant("", tool_calls=[
+                ToolCall(id="c1", name="complete_step", args={"success": True}),
+            ]),
+            # Second attempt: valid.
+            LLMMessage.assistant("", tool_calls=[
+                ToolCall(id="c2", name="complete_step",
+                         args={"success": True, "result": "fixed"}),
+            ]),
+        ])
+        agent = _agent(llm)
+        events = await _collect(agent.execute("do it", output_tool=REPORT_TOOL))
+
+        outputs = [e for e in events if isinstance(e, StructuredOutputEvent)]
+        assert len(outputs) == 1 and outputs[0].output.result == "fixed"
+
+        # The validation error was fed back as the tool response.
+        error_feedback = [
+            m for m in agent.memory.get_messages()
+            if m.role == Role.TOOL and "Invalid arguments" in m.content
+        ]
+        assert len(error_feedback) == 1
+
+    async def test_plain_message_is_nudged_to_output_tool(self):
+        llm = _ScriptedLLM([
+            LLMMessage.assistant("I think I'm done."),
+            LLMMessage.assistant("", tool_calls=[
+                ToolCall(id="c1", name="complete_step",
+                         args={"success": True, "result": "ok"}),
+            ]),
+        ])
+        agent = _agent(llm)
+        events = await _collect(agent.execute("do it", output_tool=REPORT_TOOL))
+        assert any(isinstance(e, StructuredOutputEvent) for e in events)
+        # The nudge mentions the output tool by name.
+        nudge = llm.requests[1]["messages"][-1]
+        assert "complete_step" in nudge.content
+
+    async def test_regular_tools_still_execute(self):
+        llm = _ScriptedLLM([
+            LLMMessage.assistant("", tool_calls=[
+                ToolCall(id="c1", name="echo", args={"text": "hello"}),
+            ]),
+            LLMMessage.assistant("", tool_calls=[
+                ToolCall(id="c2", name="complete_step",
+                         args={"success": True, "result": "echoed"}),
+            ]),
+        ])
+        agent = _agent(llm, toolkits=[EchoToolkit()])
+        events = await _collect(agent.execute("echo hello", output_tool=REPORT_TOOL))
+        assert any(isinstance(e, StructuredOutputEvent) for e in events)
+        tool_msgs = [m for m in agent.memory.get_messages() if m.role == Role.TOOL and m.name == "echo"]
+        assert len(tool_msgs) == 1
+        assert json.loads(tool_msgs[0].content)["data"] == "hello"
+
+    async def test_unknown_tool_gets_error_response(self):
+        llm = _ScriptedLLM([
+            LLMMessage.assistant("", tool_calls=[
+                ToolCall(id="c1", name="not_a_tool", args={}),
+            ]),
+            LLMMessage.assistant("all done"),
+        ])
+        agent = _agent(llm)
+        events = await _collect(agent.execute("do it"))
+        # The dangling tool call was answered so the history stays valid.
+        unknown = [
+            m for m in agent.memory.get_messages()
+            if m.role == Role.TOOL and "Unknown tool" in m.content
+        ]
+        assert len(unknown) == 1
+
+
+class TestToolResultTruncation:
+    async def test_oversized_tool_result_truncated(self):
+        class BigToolkit(BaseToolkit):
+            name = "big"
+
+            @tool(parse_docstring=True)
+            async def big(self) -> ToolResult:
+                """Return something huge."""
+                return ToolResult(success=True, data="y" * 100000)
+
+        llm = _ScriptedLLM([
+            LLMMessage.assistant("", tool_calls=[ToolCall(id="c1", name="big", args={})]),
+            LLMMessage.assistant("done"),
+        ])
+        agent = _agent(llm, toolkits=[BigToolkit()])
+        await _collect(agent.execute("go"))
+
+        tool_msg = [m for m in agent.memory.get_messages() if m.role == Role.TOOL][0]
+        assert len(tool_msg.content) <= agent.max_tool_result_chars + 100
+        assert "truncated" in tool_msg.content
+
+
+class TestDynamicMcpTools:
+    def test_mcp_schemas_become_invocable_tools(self):
+        from app.domain.services.tools.mcp import MCPToolkit
+
+        toolkit = MCPToolkit()
+        tools = toolkit._build_tools([
+            {
+                "type": "function",
+                "function": {
+                    "name": "mcp_server_lookup",
+                    "description": "[server] Look something up",
+                    "parameters": {"type": "object", "properties": {"q": {"type": "string"}}},
+                },
+            }
+        ])
+        toolkit.tools = tools
+        found = toolkit.get_tool("mcp_server_lookup")
+        assert isinstance(found, Tool)
+        assert found.toolkit is toolkit
+        assert toolkit.get_tool_schemas()[0]["function"]["name"] == "mcp_server_lookup"

--- a/backend/tests/test_llm_message.py
+++ b/backend/tests/test_llm_message.py
@@ -51,9 +51,14 @@ class TestMemoryOperations:
         m.roll_back()
         assert len(m.messages) == n - 1
 
-    def test_compact_strips_browser_tool_output(self):
+    def test_compact_elides_old_tool_output(self):
         m = self._memory()
-        m.compact()
+        m.compact(keep_recent=0)
         tool_msg = m.messages[-1]
         assert "huge page content" not in tool_msg.content
-        assert "(removed)" in tool_msg.content
+        assert "elided" in tool_msg.content
+
+    def test_compact_keeps_recent_tool_output(self):
+        m = self._memory()
+        m.compact()  # default keep_recent window covers all 4 messages
+        assert m.messages[-1].content == "huge page content"

--- a/mockserver/mock_datas/browser_tools.yaml
+++ b/mockserver/mock_datas/browser_tools.yaml
@@ -2,18 +2,24 @@
     - index: 0
       message:
         role: assistant
-        content: |
-          {
-            "message": "This is a test",
-            "goal": "test goal",
-            "title": "test title",
-            "steps": [
-              {
-                "id": "1",
-                "description": "test browser tools"
-              }
-            ]
-          }
+        content: null
+        tool_calls:
+          - type: function
+            function:
+              name: create_plan
+              arguments: |
+                {
+                  "message": "This is a test",
+                  "language": "en",
+                  "goal": "test goal",
+                  "title": "test title",
+                  "steps": [
+                    {
+                      "id": "1",
+                      "description": "test browser tools"
+                    }
+                  ]
+                }
 
 - choices:
     - index: 0
@@ -175,14 +181,43 @@
     - index: 0
       message:
         role: assistant
-        content: |
-          test file end
+        content: null
+        tool_calls:
+          - type: function
+            function:
+              name: complete_step
+              arguments: |
+                {
+                  "success": true,
+                  "result": "test browser end",
+                  "attachments": []
+                }
 
 - choices:
     - index: 0
       message:
         role: assistant
-        content: |
-          {
-            "steps": []
-          }
+        content: null
+        tool_calls:
+          - type: function
+            function:
+              name: update_plan
+              arguments: |
+                {
+                  "steps": []
+                }
+
+- choices:
+    - index: 0
+      message:
+        role: assistant
+        content: null
+        tool_calls:
+          - type: function
+            function:
+              name: deliver_result
+              arguments: |
+                {
+                  "message": "Browser tool test finished.",
+                  "attachments": []
+                }

--- a/mockserver/mock_datas/default.yaml
+++ b/mockserver/mock_datas/default.yaml
@@ -1,19 +1,28 @@
+# Canned responses follow the native tool-calling protocol:
+# planner submits plans via create_plan/update_plan output tools, and the
+# executor finishes steps via complete_step and delivers via deliver_result.
 - choices:
     - index: 0
       message:
         role: assistant
-        content: |
-          {
-            "message": "This is a test",
-            "goal": "test goal",
-            "title": "test title",
-            "steps": [
-              {
-                "id": "1",
-                "description": "test step"
-              }
-            ]
-          }
+        content: null
+        tool_calls:
+          - type: function
+            function:
+              name: create_plan
+              arguments: |
+                {
+                  "message": "This is a test",
+                  "language": "en",
+                  "goal": "test goal",
+                  "title": "test title",
+                  "steps": [
+                    {
+                      "id": "1",
+                      "description": "test step"
+                    }
+                  ]
+                }
 
 - choices:
     - index: 0
@@ -127,37 +136,52 @@
     - index: 0
       message:
         role: assistant
-        content: |
-          {
-            "success": true,
-            "result": "test end",
-            "attachments": [
-              "/home/ubuntu/example.txt",
-              "/home/ubuntu/example.md",
-              "/home/ubuntu/example.py"
-            ]
-          }
+        content: null
+        tool_calls:
+          - type: function
+            function:
+              name: complete_step
+              arguments: |
+                {
+                  "success": true,
+                  "result": "test end",
+                  "attachments": [
+                    "/home/ubuntu/example.txt",
+                    "/home/ubuntu/example.md",
+                    "/home/ubuntu/example.py"
+                  ]
+                }
 
 - choices:
     - index: 0
       message:
         role: assistant
-        content: |
-          {
-            "steps": []
-          }
+        content: null
+        tool_calls:
+          - type: function
+            function:
+              name: update_plan
+              arguments: |
+                {
+                  "steps": []
+                }
       finish_reason: stop
 
 - choices:
     - index: 0
       message:
         role: assistant
-        content: |
-          {
-            "message": "This is a test",
-            "attachments": [
-              "/home/ubuntu/example.txt",
-              "/home/ubuntu/example.md",
-              "/home/ubuntu/example.py"
-            ]
-          }
+        content: null
+        tool_calls:
+          - type: function
+            function:
+              name: deliver_result
+              arguments: |
+                {
+                  "message": "This is a test",
+                  "attachments": [
+                    "/home/ubuntu/example.txt",
+                    "/home/ubuntu/example.md",
+                    "/home/ubuntu/example.py"
+                  ]
+                }

--- a/mockserver/mock_datas/file_tools.yaml
+++ b/mockserver/mock_datas/file_tools.yaml
@@ -2,18 +2,24 @@
     - index: 0
       message:
         role: assistant
-        content: |
-          {
-            "message": "This is a test",
-            "goal": "test goal",
-            "title": "test title",
-            "steps": [
-              {
-                "id": "1",
-                "description": "test file tools"
-              }
-            ]
-          }
+        content: null
+        tool_calls:
+          - type: function
+            function:
+              name: create_plan
+              arguments: |
+                {
+                  "message": "This is a test",
+                  "language": "en",
+                  "goal": "test goal",
+                  "title": "test title",
+                  "steps": [
+                    {
+                      "id": "1",
+                      "description": "test file tools"
+                    }
+                  ]
+                }
 
 - choices:
     - index: 0
@@ -100,14 +106,43 @@
     - index: 0
       message:
         role: assistant
-        content: |
-          test file end
+        content: null
+        tool_calls:
+          - type: function
+            function:
+              name: complete_step
+              arguments: |
+                {
+                  "success": true,
+                  "result": "test file end",
+                  "attachments": ["/home/ubuntu/example.txt"]
+                }
 
 - choices:
     - index: 0
       message:
         role: assistant
-        content: |
-          {
-            "steps": []
-          }
+        content: null
+        tool_calls:
+          - type: function
+            function:
+              name: update_plan
+              arguments: |
+                {
+                  "steps": []
+                }
+
+- choices:
+    - index: 0
+      message:
+        role: assistant
+        content: null
+        tool_calls:
+          - type: function
+            function:
+              name: deliver_result
+              arguments: |
+                {
+                  "message": "File tool test finished.",
+                  "attachments": ["/home/ubuntu/example.txt"]
+                }

--- a/mockserver/mock_datas/message_tools.yaml
+++ b/mockserver/mock_datas/message_tools.yaml
@@ -2,18 +2,24 @@
     - index: 0
       message:
         role: assistant
-        content: |
-          {
-            "message": "This is a test",
-            "goal": "test goal",
-            "title": "test title",
-            "steps": [
-              {
-                "id": "1",
-                "description": "test message tools"
-              }
-            ]
-          }
+        content: null
+        tool_calls:
+          - type: function
+            function:
+              name: create_plan
+              arguments: |
+                {
+                  "message": "This is a test",
+                  "language": "en",
+                  "goal": "test goal",
+                  "title": "test title",
+                  "steps": [
+                    {
+                      "id": "1",
+                      "description": "test message tools"
+                    }
+                  ]
+                }
 
 - choices:
     - index: 0
@@ -33,14 +39,43 @@
     - index: 0
       message:
         role: assistant
-        content: |
-          test message end
+        content: null
+        tool_calls:
+          - type: function
+            function:
+              name: complete_step
+              arguments: |
+                {
+                  "success": true,
+                  "result": "test message end",
+                  "attachments": []
+                }
 
 - choices:
     - index: 0
       message:
         role: assistant
-        content: |
-          {
-            "steps": []
-          }
+        content: null
+        tool_calls:
+          - type: function
+            function:
+              name: update_plan
+              arguments: |
+                {
+                  "steps": []
+                }
+
+- choices:
+    - index: 0
+      message:
+        role: assistant
+        content: null
+        tool_calls:
+          - type: function
+            function:
+              name: deliver_result
+              arguments: |
+                {
+                  "message": "Message tool test finished.",
+                  "attachments": []
+                }

--- a/mockserver/mock_datas/search_tools.yaml
+++ b/mockserver/mock_datas/search_tools.yaml
@@ -2,18 +2,24 @@
     - index: 0
       message:
         role: assistant
-        content: |
-          {
-            "message": "This is a test",
-            "goal": "test goal",
-            "title": "test title",
-            "steps": [
-              {
-                "id": "1",
-                "description": "test search tools"
-              }
-            ]
-          }
+        content: null
+        tool_calls:
+          - type: function
+            function:
+              name: create_plan
+              arguments: |
+                {
+                  "message": "This is a test",
+                  "language": "en",
+                  "goal": "test goal",
+                  "title": "test title",
+                  "steps": [
+                    {
+                      "id": "1",
+                      "description": "test search tools"
+                    }
+                  ]
+                }
 
 - choices:
     - index: 0
@@ -35,14 +41,43 @@
     - index: 0
       message:
         role: assistant
-        content: |
-          test message end
+        content: null
+        tool_calls:
+          - type: function
+            function:
+              name: complete_step
+              arguments: |
+                {
+                  "success": true,
+                  "result": "test search end",
+                  "attachments": []
+                }
 
 - choices:
     - index: 0
       message:
         role: assistant
-        content: |
-          {
-            "steps": []
-          }
+        content: null
+        tool_calls:
+          - type: function
+            function:
+              name: update_plan
+              arguments: |
+                {
+                  "steps": []
+                }
+
+- choices:
+    - index: 0
+      message:
+        role: assistant
+        content: null
+        tool_calls:
+          - type: function
+            function:
+              name: deliver_result
+              arguments: |
+                {
+                  "message": "Search tool test finished.",
+                  "attachments": []
+                }

--- a/mockserver/mock_datas/shell_tools.yaml
+++ b/mockserver/mock_datas/shell_tools.yaml
@@ -2,18 +2,24 @@
     - index: 0
       message:
         role: assistant
-        content: |
-          {
-            "message": "This is a test",
-            "goal": "test goal",
-            "title": "test title",
-            "steps": [
-              {
-                "id": "1",
-                "description": "test shell tools"
-              }
-            ]
-          }
+        content: null
+        tool_calls:
+          - type: function
+            function:
+              name: create_plan
+              arguments: |
+                {
+                  "message": "This is a test",
+                  "language": "en",
+                  "goal": "test goal",
+                  "title": "test title",
+                  "steps": [
+                    {
+                      "id": "1",
+                      "description": "test shell tools"
+                    }
+                  ]
+                }
 
 - choices:
     - index: 0
@@ -93,14 +99,43 @@
     - index: 0
       message:
         role: assistant
-        content: |
-          test file end
+        content: null
+        tool_calls:
+          - type: function
+            function:
+              name: complete_step
+              arguments: |
+                {
+                  "success": true,
+                  "result": "test shell end",
+                  "attachments": []
+                }
 
 - choices:
     - index: 0
       message:
         role: assistant
-        content: |
-          {
-            "steps": []
-          }
+        content: null
+        tool_calls:
+          - type: function
+            function:
+              name: update_plan
+              arguments: |
+                {
+                  "steps": []
+                }
+
+- choices:
+    - index: 0
+      message:
+        role: assistant
+        content: null
+        tool_calls:
+          - type: function
+            function:
+              name: deliver_result
+              arguments: |
+                {
+                  "message": "Shell tool test finished.",
+                  "attachments": []
+                }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Modernizes the agent-side "context engineering" (prompts, tools, agents), replacing the legacy 2023-style scaffolding:

### Structured output via native function calling
- Removed the JSON-in-prompt protocol (TypeScript interfaces + `response_format=json_object` + `parse_json` repair chain).
- Added `OutputTool` (`tools/base.py`): the model submits structured results through native tool calls — `create_plan` / `update_plan` (planner), `complete_step` / `deliver_result` (executor). Arguments are validated against Pydantic schemas (`domain/models/agent_output.py`); validation errors are fed back as the tool response so the model self-repairs.
- The agent loop nudges the model to the output tool if it replies with plain text, and answers unknown/dangling tool calls so conversation history always stays API-valid.

### Composable prompts
- `build_system_prompt()` assembles: core identity + one usage section per toolkit actually bound to the agent (from the new `BaseToolkit.instructions`) + a role-specific section. Prompt guidance can no longer drift out of sync with the toolset.
- Dropped stale rules (e.g. mandatory multi-thousand-word prose) and all JSON format specs from prompts.

### Leaner planner context
- The planner no longer binds the full tool schemas with `tool_choice="none"`; it receives a compact capability overview (`describe_toolkits`) and only the plan output tools, with `tool_choice="required"`.

### Token-aware memory
- `Memory.compact()` is now budget-aware: elides old tool-result content (oldest first, keeping a recent window and the message skeleton so tool-call pairing is never broken) instead of only wiping two hardcoded browser tools.
- Tool results are truncated at ingestion (`max_tool_result_chars`) and memory is compacted before each model call when over `max_context_tokens`.

### MCP execution path fixed
- MCP tools discovered at runtime are now wrapped as invocable domain `Tool` objects, dispatched through the same `get_tool` path as builtin tools. Previously their schemas were exposed to the LLM but calls failed with "Unknown tool".

### Mockserver
- All canned datasets updated to the new tool-calling protocol (`create_plan` / `complete_step` / `update_plan` / `deliver_result`).

## Testing
- New unit suite `backend/tests/test_context_engineering.py` (prompt builder, output tools, agent loop incl. self-repair, compaction, truncation, MCP bridge): 17 tests pass.
- Full offline unit suites pass (58 tests): domain tools, LLM message, memory serialization, LangChain + OpenAI gateways.
- Full-stack E2E via `./dev.sh up -d` with mockserver: plan creation → tool events (message/search/file/shell/browser) → step completion → plan update → final delivery with attachments, verified through the web UI.
- Pre-existing `test_auth_routes.py` / `test_api_file.py` failures reproduce identically on `main` (they require `AUTH_PROVIDER=password`; dev env runs `none`) — unrelated to this change.

## Demo

[e2e_demo_native_tool_calling_flow.mp4](https://cursor.com/agents/bc-4f5593c4-5b7f-4018-a838-684dd974e3a3/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fe2e_demo_native_tool_calling_flow.mp4)

[Final state with completed plan and attachments](https://cursor.com/agents/bc-4f5593c4-5b7f-4018-a838-684dd974e3a3/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ffinal_state_completed_plan_attachments.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4f5593c4-5b7f-4018-a838-684dd974e3a3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4f5593c4-5b7f-4018-a838-684dd974e3a3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

