### PR TITLE
Security: Overly Permissive CORS Configuration

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -67,7 +67,7 @@ app = FastAPI(title="Manus AI Agent", lifespan=lifespan)
 # Configure CORS
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],
+    allow_origins=settings.cors_origins,
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],


### PR DESCRIPTION
## Summary

Security: Overly Permissive CORS Configuration

## Problem

**Severity**: `High` | **File**: `backend/app/main.py:L76`

The FastAPI application configures CORS middleware with `allow_origins=["*"]` combined with `allow_credentials=True`. According to CORS specifications, setting credentials to true while allowing all origins is invalid and can lead to unexpected behavior. If a browser strictly enforces the spec, it will reject the response; if it doesn't, it exposes the application to cross-origin attacks where malicious sites can make authenticated requests.

## Solution

Replace `allow_origins=["*"]` with a specific list of allowed frontend domains (e.g., `["https://yourdomain.com"]`). If credentials are not strictly required, set `allow_credentials=False`.

## Changes

- `backend/app/main.py` (modified)