### PR TITLE
feat: Manus-aligned FilePreviewer, session menus, and pin

### DIFF
--- a/frontend/src/components/FilePreviewer.vue
+++ b/frontend/src/components/FilePreviewer.vue
@@ -29,10 +29,12 @@
     </div>
   </div>
 
-  <!-- Official portal: center mask + panel / fullscreen -->
+  <!-- Official portal: center mask + panel / fullscreen.
+       Keep center/fullscreen above Computer sidebar updates — do not dismiss
+       when EVENT_SHOW_COMPUTER_PANEL fires during a running task. -->
   <Teleport to="body">
     <div
-      v-if="visible && isShow && fileInfo && fileType && (viewMode === 'center' || viewMode === 'fullscreen')"
+      v-if="isShow && fileInfo && fileType && (viewMode === 'center' || viewMode === 'fullscreen')"
       class="fixed inset-0 pointer-events-none z-[1000]">
       <div
         v-if="viewMode === 'center'"
@@ -67,19 +69,16 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onMounted, onUnmounted, ref } from 'vue'
+import { computed, ref } from 'vue'
 import { useFilePreviewer } from '../composables/useFilePreviewer'
 import { getFileDownloadUrl } from '../api/file'
 import { getFileType } from '../utils/fileType'
 import { useResizeObserver } from '../composables/useResizeObserver'
-import { eventBus } from '../utils/eventBus'
-import { EVENT_SHOW_COMPUTER_PANEL } from '../constants/event'
 import FilePreviewerChrome from './FilePreviewerChrome.vue'
 
 const {
   isShow,
   fileInfo,
-  visible,
   viewMode,
   showFilePreviewer,
   hideFilePreviewer,
@@ -121,16 +120,6 @@ const download = async () => {
   const url = await getFileDownloadUrl(fileInfo.value)
   window.open(url, '_blank')
 }
-
-onMounted(() => {
-  eventBus.on(EVENT_SHOW_COMPUTER_PANEL, () => {
-    visible.value = false
-  })
-})
-
-onUnmounted(() => {
-  eventBus.off(EVENT_SHOW_COMPUTER_PANEL)
-})
 
 defineExpose({
   showFilePreviewer,

--- a/frontend/src/components/SessionItem.vue
+++ b/frontend/src/components/SessionItem.vue
@@ -133,12 +133,12 @@
 </template>
 
 <script setup lang="ts">
-import { Ellipsis, FileText, Trash, Share2, Pencil, Star, ExternalLink, FolderPlus, Pin } from 'lucide-vue-next';
+import { Ellipsis, FileText, Trash, Share2, Pencil, Star, ExternalLink, FolderPlus, Folder, FolderSync, Pin } from 'lucide-vue-next';
 import { computed, ref } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { useRoute, useRouter } from 'vue-router';
 import { ListSessionItem, SessionStatus, ProjectItem } from '../types/response';
-import { useContextMenu, createDangerMenuItem, createMenuItem, createSeparator } from '../composables/useContextMenu';
+import { useContextMenu, createDangerMenuItem, createMenuItem, createSeparator, createSubmenuItem } from '../composables/useContextMenu';
 import { useDialog } from '../composables/useDialog';
 import {
   deleteSession,
@@ -149,8 +149,10 @@ import {
   pinSession,
   moveSessionProject,
 } from '../api/agent';
+import { createProject } from '../api/project';
 import { showSuccessToast, showErrorToast } from '../utils/toast';
 import { formatCustomTime } from '../utils/time';
+import { eventBus } from '../utils/eventBus';
 
 interface Props {
   session: ListSessionItem;
@@ -227,16 +229,22 @@ const handleSessionMenuClick = (event: MouseEvent) => {
     createMenuItem('open', t('Open in new tab'), { icon: ExternalLink }),
   ];
 
-  if (props.projects.length > 0) {
-    for (const project of props.projects) {
-      if (project.project_id !== props.session.project_id) {
-        items.push(createMenuItem(`move:${project.project_id}`, `${t('Move to project')}: ${project.name}`, { icon: FolderPlus }));
-      }
-    }
-  }
+  // Official: single「移动到项目」row → submenu (新项目 / projects)
+  const moveChildren = [
+    createMenuItem('new_project', t('New project'), { icon: FolderPlus }),
+    createSeparator(),
+    ...props.projects.map((project) =>
+      createMenuItem(`move:${project.project_id}`, project.name, {
+        icon: Folder,
+        checked: project.project_id === props.session.project_id,
+      }),
+    ),
+  ];
   if (props.session.project_id) {
-    items.push(createMenuItem('remove_project', t('Remove from project'), { icon: FolderPlus }));
+    moveChildren.push(createSeparator());
+    moveChildren.push(createMenuItem('remove_project', t('Remove from project'), { icon: Folder }));
   }
+  items.push(createSubmenuItem('move_project', t('Move to project'), moveChildren, { icon: FolderSync }));
 
   items.push(createSeparator());
   items.push(createMenuItem('pin', pinnedNow ? t('Unpin') : t('Pin'), { icon: Pin }));
@@ -295,8 +303,27 @@ const handleSessionMenuClick = (event: MouseEvent) => {
       }
     } else if (itemKey === 'open') {
       window.open(`/chat/${props.session.session_id}`, '_blank');
+    } else if (itemKey === 'new_project') {
+      showInputDialog({
+        title: t('New project'),
+        placeholder: t('Enter project name'),
+        confirmText: t('Create'),
+        onConfirm: async (value: string) => {
+          if (!value) return;
+          try {
+            const project = await createProject(value);
+            await moveSessionProject(props.session.session_id, project.project_id);
+            emit('moved', props.session.session_id, project.project_id);
+            eventBus.emit('projects:changed');
+            showSuccessToast(t('Moved to project'));
+          } catch {
+            showErrorToast(t('Failed to create project'));
+          }
+        },
+      });
     } else if (itemKey.startsWith('move:')) {
       const projectId = itemKey.slice(5);
+      if (projectId === props.session.project_id) return;
       try {
         await moveSessionProject(props.session.session_id, projectId);
         emit('moved', props.session.session_id, projectId);

--- a/frontend/src/components/SessionSidebar.vue
+++ b/frontend/src/components/SessionSidebar.vue
@@ -166,13 +166,21 @@
                         {{ project.name || t('Untitled') }}
                       </span>
                     </div>
-                    <div class="flex items-center flex-shrink-0">
+                    <div class="flex items-center flex-shrink-0 opacity-0 group-hover:opacity-100">
+                      <!-- Official: … menu (pin/edit/view/delete) + SquarePen shortcut -->
                       <button
                         type="button"
-                        class="hidden group-hover:flex size-[32px] rounded-[8px] items-center justify-center cursor-pointer hover:bg-[var(--fill-tsp-white-light)] text-[var(--icon-tertiary)]"
-                        :title="t('Unpin')"
-                        @click.stop="handlePinProject(project)">
-                        <Pin :size="14" />
+                        class="size-[32px] flex rounded-[8px] items-center justify-center cursor-pointer hover:bg-[var(--fill-tsp-white-light)] text-[var(--icon-tertiary)]"
+                        :title="t('More options')"
+                        @click.stop="handleProjectMenuClick($event, project)">
+                        <Ellipsis :size="18" />
+                      </button>
+                      <button
+                        type="button"
+                        class="size-[32px] flex rounded-[8px] items-center justify-center cursor-pointer hover:bg-[var(--fill-tsp-white-light)] text-[var(--icon-tertiary)]"
+                        :title="t('Edit')"
+                        @click.stop="handleEditProject(project)">
+                        <SquarePen :size="16" />
                       </button>
                     </div>
                   </div>
@@ -270,13 +278,21 @@
                         {{ project.name || t('Untitled') }}
                       </span>
                     </div>
-                    <div class="flex items-center flex-shrink-0">
+                    <div class="flex items-center flex-shrink-0 opacity-0 group-hover:opacity-100">
+                      <!-- Official: … menu (pin/edit/view/delete) + SquarePen shortcut -->
                       <button
                         type="button"
-                        class="hidden group-hover:flex size-[32px] rounded-[8px] items-center justify-center cursor-pointer hover:bg-[var(--fill-tsp-white-light)] text-[var(--icon-tertiary)]"
-                        :title="t('Pin')"
-                        @click.stop="handlePinProject(project)">
-                        <Pin :size="14" />
+                        class="size-[32px] flex rounded-[8px] items-center justify-center cursor-pointer hover:bg-[var(--fill-tsp-white-light)] text-[var(--icon-tertiary)]"
+                        :title="t('More options')"
+                        @click.stop="handleProjectMenuClick($event, project)">
+                        <Ellipsis :size="18" />
+                      </button>
+                      <button
+                        type="button"
+                        class="size-[32px] flex rounded-[8px] items-center justify-center cursor-pointer hover:bg-[var(--fill-tsp-white-light)] text-[var(--icon-tertiary)]"
+                        :title="t('Edit')"
+                        @click.stop="handleEditProject(project)">
+                        <SquarePen :size="16" />
                       </button>
                     </div>
                   </div>
@@ -420,7 +436,7 @@
 <script setup lang="ts">
 import {
   Bot, PanelLeft, SquarePen, MessageSquareDashed, ChevronUp, ChevronRight, Search, LibraryBig,
-  Plus, FolderPlus, Check, Pin, Folder, ListFilter,
+  Plus, FolderPlus, Check, Pin, PinOff, Folder, ListFilter, Ellipsis, Eye, Trash, Pencil,
 } from 'lucide-vue-next';
 import SessionItem from './SessionItem.vue';
 import UserMenu from './UserMenu.vue';
@@ -429,10 +445,11 @@ import ManusLogoTextIcon from './icons/ManusLogoTextIcon.vue';
 import { useSessionSidebar } from '../composables/useSessionSidebar';
 import { useAuth } from '../composables/useAuth';
 import { useDialog } from '../composables/useDialog';
+import { useContextMenu, createMenuItem, createDangerMenuItem } from '../composables/useContextMenu';
 import { ref, computed, onMounted, watch, onUnmounted } from 'vue';
 import { useRoute, useRouter } from 'vue-router';
 import { getSessionsSSE, getSessions } from '../api/agent';
-import { getProjects, createProject, pinProject } from '../api/project';
+import { getProjects, createProject, pinProject, updateProject, deleteProject } from '../api/project';
 import { getCachedClientConfig } from '../api/config';
 import { ListSessionItem, ProjectItem } from '../types/response';
 import { useI18n } from 'vue-i18n';
@@ -443,7 +460,8 @@ type TaskFilter = 'all' | 'favorites' | 'shared' | 'noProject'
 
 const { t } = useI18n()
 const { isSessionSidebarShow, toggleSessionSidebar } = useSessionSidebar()
-const { showInputDialog } = useDialog()
+const { showInputDialog, showConfirmDialog } = useDialog()
+const { showContextMenu } = useContextMenu()
 const route = useRoute()
 const router = useRouter()
 
@@ -631,6 +649,78 @@ const handlePinProject = async (project: ProjectItem) => {
   } catch {
     showErrorToast(t('Failed to update project'))
   }
+}
+
+const handleEditProject = (project: ProjectItem) => {
+  showInputDialog({
+    title: t('Edit project'),
+    initialValue: project.name,
+    placeholder: t('Enter project name'),
+    confirmText: t('Save'),
+    onConfirm: async (value: string) => {
+      if (!value) return
+      try {
+        const updated = await updateProject(project.project_id, { name: value })
+        projects.value = projects.value.map(p =>
+          p.project_id === updated.project_id ? updated : p,
+        )
+        eventBus.emit('projects:changed')
+        showSuccessToast(t('Project updated successfully'))
+      } catch {
+        showErrorToast(t('Failed to update project'))
+      }
+    },
+  })
+}
+
+const handleDeleteProject = (project: ProjectItem) => {
+  showConfirmDialog({
+    title: t('Delete project?'),
+    content: t('Tasks in this project will not be deleted, but they will be removed from the project.'),
+    confirmText: t('Delete'),
+    confirmType: 'danger',
+    onConfirm: async () => {
+      try {
+        await deleteProject(project.project_id)
+        projects.value = projects.value.filter(p => p.project_id !== project.project_id)
+        sessions.value = sessions.value.map(s =>
+          s.project_id === project.project_id ? { ...s, project_id: null } : s,
+        )
+        eventBus.emit('projects:changed')
+        eventBus.emit('sessions:changed')
+        showSuccessToast(t('Project deleted'))
+        if (route.path === `/project/${project.project_id}`) {
+          await router.push('/')
+        }
+      } catch {
+        showErrorToast(t('Failed to update project'))
+      }
+    },
+  })
+}
+
+/** Official project row … menu: Unpin|Pin / Edit / View project / Delete */
+const handleProjectMenuClick = (event: MouseEvent, project: ProjectItem) => {
+  event.stopPropagation()
+  const target = event.currentTarget as HTMLElement
+  const pinnedNow = !!project.is_pinned
+  const items = [
+    createMenuItem('pin', pinnedNow ? t('Unpin') : t('Pin'), { icon: pinnedNow ? PinOff : Pin }),
+    createMenuItem('edit', t('Edit'), { icon: Pencil }),
+    createMenuItem('view', t('View project'), { icon: Eye }),
+    createDangerMenuItem('delete', t('Delete'), { icon: Trash }),
+  ]
+  showContextMenu(project.project_id, target, items, async (key: string) => {
+    if (key === 'pin') {
+      await handlePinProject(project)
+    } else if (key === 'edit') {
+      handleEditProject(project)
+    } else if (key === 'view') {
+      openProject(project.project_id)
+    } else if (key === 'delete') {
+      handleDeleteProject(project)
+    }
+  })
 }
 
 const loadProjects = async () => {

--- a/frontend/src/components/ui/ContextMenu.vue
+++ b/frontend/src/components/ui/ContextMenu.vue
@@ -1,78 +1,153 @@
 <template>
   <!-- Official DropdownMenu portal chrome (session header … / sidebar row menu) -->
-  <div id="context-menu-portal" data-floating-ui-portal="">
-    <div
-      v-if="contextMenuVisible"
-      ref="menuRef"
-      data-bottom=""
-      class="min-w-max inline-block transition-[transform,opacity,scale] duration-150 data-[starting-style]:opacity-0 data-[ending-style]:opacity-0 data-[starting-style]:-translate-y-2 data-[ending-style]:-translate-y-2"
-      tabindex="-1"
-      data-floating-ui-focusable=""
-      role="dialog"
-      :style="{
-        position: 'absolute',
-        left: calculatedPosition.x + 'px',
-        top: calculatedPosition.y + 'px',
-        '--available-width': '554px',
-        '--available-height': '649px',
-        '--anchor-width': '22px',
-        '--anchor-height': '22px',
-      }">
-      <div class="bg-[var(--background-menu-white)] shadow-menu rounded-[12px] p-1 min-w-[172px]">
-        <template v-for="item in menuItems" :key="item.key">
-          <!-- Official divider: h-[1px] bg-[var(--border-main)] my-[2px] mx-[8px] -->
-          <div
-            v-if="item.key.startsWith('separator')"
-            class="h-[1px] bg-[var(--border-main)] my-[2px] mx-[8px]" />
-          <div
-            v-else
-            class="flex items-center gap-2 w-full p-2 rounded-[8px] hover:bg-[var(--fill-tsp-white-main)] cursor-pointer text-sm"
-            :class="[
-              item.variant === 'danger' ? 'text-[var(--function-error)]' : 'text-[var(--text-primary)]',
-              item.disabled ? 'opacity-50 cursor-not-allowed hover:bg-transparent' : '',
-            ]"
-            @click="handleMenuItemClick(item)">
-            <div class="size-5 flex items-center justify-center">
-              <component
-                v-if="item.icon"
-                :is="item.icon"
-                :size="16"
-                :stroke="item.variant === 'danger' ? 'var(--function-error)' : 'var(--icon-primary)'"
+  <Teleport to="body">
+    <div id="context-menu-portal" data-floating-ui-portal="" class="relative z-[1100]">
+      <div
+        v-if="contextMenuVisible"
+        ref="menuRef"
+        class="z-[1100] min-w-max inline-block transition-[transform,opacity,scale] duration-150 data-[starting-style]:opacity-0 data-[ending-style]:opacity-0 data-[starting-style]:-translate-y-2 data-[ending-style]:-translate-y-2"
+        tabindex="-1"
+        data-floating-ui-focusable=""
+        role="dialog"
+        :style="menuStyle">
+        <div class="bg-[var(--background-menu-white)] shadow-menu rounded-[12px] p-1 min-w-[172px]">
+          <template v-for="item in menuItems" :key="item.key">
+            <!-- Official divider: h-[1px] bg-[var(--border-main)] my-[2px] mx-[8px] -->
+            <div
+              v-if="item.key.startsWith('separator')"
+              class="h-[1px] bg-[var(--border-main)] my-[2px] mx-[8px]" />
+
+            <!-- Official Move-to-project style submenu (Popover + chevron) -->
+            <Popover
+              v-else-if="item.children"
+              :open="openSubmenuKey === item.key"
+              @update:open="(v: boolean) => { openSubmenuKey = v ? item.key : null }">
+              <PopoverTrigger as-child>
+                <div
+                  class="group"
+                  aria-haspopup="dialog"
+                  :aria-expanded="openSubmenuKey === item.key"
+                  :data-popover-trigger="openSubmenuKey === item.key ? 'true' : undefined"
+                  @mouseenter="openSubmenuKey = item.key"
+                  @click.prevent.stop="openSubmenuKey = item.key">
+                  <div
+                    class="flex items-center gap-2 w-full p-2 rounded-[8px] hover:bg-[var(--fill-tsp-white-main)] cursor-pointer text-[var(--text-primary)] text-sm group-data-[popover-trigger]:bg-[var(--fill-tsp-white-main)]">
+                    <div class="size-5 flex items-center justify-center">
+                      <component
+                        v-if="item.icon"
+                        :is="item.icon"
+                        :size="16"
+                        stroke="currentColor"
+                        stroke-width="2"
+                        stroke-linecap="round"
+                        stroke-linejoin="round" />
+                    </div>
+                    <div class="flex-1 flex items-center gap-2 min-w-0">
+                      <div class="flex items-center justify-between flex-1 gap-[8px]">
+                        <span>{{ item.label }}</span>
+                        <ChevronRight :size="16" color="var(--icon-secondary)" />
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </PopoverTrigger>
+              <!-- Official: shadow-menu rounded-[12px] min-w-[110px] p-1 max-h-[400px] overflow-y-auto w-[225px] -->
+              <PopoverContent
+                side="right"
+                align="start"
+                :side-offset="4"
+                class="z-[1100] w-[225px] min-w-[110px] max-h-[400px] overflow-y-auto rounded-[12px] border-0 bg-[var(--background-menu-white)] p-1 shadow-menu"
+                @mouseenter="openSubmenuKey = item.key">
+                <template v-for="child in item.children" :key="child.key">
+                  <div
+                    v-if="child.key.startsWith('separator')"
+                    class="h-[1px] bg-[var(--border-main)] my-[2px] mx-[8px]" />
+                  <div
+                    v-else
+                    class="flex items-center gap-2 w-full p-2 rounded-[8px] hover:bg-[var(--fill-tsp-white-main)] cursor-pointer text-[var(--text-primary)] text-sm"
+                    @click="handleMenuItemClick(child)">
+                    <div class="flex-1 flex items-center gap-2 min-w-0">
+                      <component
+                        v-if="child.icon"
+                        :is="child.icon"
+                        :size="16"
+                        stroke="currentColor"
+                        stroke-width="2"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        class="flex-shrink-0" />
+                      <span class="truncate" :title="child.label">{{ child.label }}</span>
+                    </div>
+                    <svg
+                      v-if="child.checked"
+                      xmlns="http://www.w3.org/2000/svg"
+                      width="16"
+                      height="16"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke="var(--icon-primary)"
+                      stroke-width="2"
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                      class="lucide lucide-check ms-auto flex-shrink-0">
+                      <path d="M20 6 9 17l-5-5" />
+                    </svg>
+                  </div>
+                </template>
+              </PopoverContent>
+            </Popover>
+
+            <div
+              v-else
+              class="flex items-center gap-2 w-full p-2 rounded-[8px] hover:bg-[var(--fill-tsp-white-main)] cursor-pointer text-sm"
+              :class="[
+                item.variant === 'danger' ? 'text-[var(--function-error)]' : 'text-[var(--text-primary)]',
+                item.disabled ? 'opacity-50 cursor-not-allowed hover:bg-transparent' : '',
+              ]"
+              @click="handleMenuItemClick(item)">
+              <div class="size-5 flex items-center justify-center">
+                <component
+                  v-if="item.icon"
+                  :is="item.icon"
+                  :size="16"
+                  :stroke="item.variant === 'danger' ? 'var(--function-error)' : 'var(--icon-primary)'"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                  stroke-linejoin="round" />
+              </div>
+              <div class="flex-1 flex items-center gap-2 min-w-0">
+                {{ item.label }}
+              </div>
+              <svg
+                v-if="item.checked"
+                xmlns="http://www.w3.org/2000/svg"
+                width="16"
+                height="16"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="var(--icon-primary)"
                 stroke-width="2"
                 stroke-linecap="round"
-                stroke-linejoin="round" />
+                stroke-linejoin="round"
+                class="lucide lucide-check ms-auto">
+                <path d="M20 6 9 17l-5-5" />
+              </svg>
             </div>
-            <div class="flex-1 flex items-center gap-2 min-w-0">
-              {{ item.label }}
-            </div>
-            <svg
-              v-if="item.checked"
-              xmlns="http://www.w3.org/2000/svg"
-              width="16"
-              height="16"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="var(--icon-primary)"
-              stroke-width="2"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              class="lucide lucide-check ms-auto">
-              <path d="M20 6 9 17l-5-5" />
-            </svg>
-          </div>
-        </template>
+          </template>
+        </div>
       </div>
     </div>
-  </div>
+  </Teleport>
 </template>
 
 <script setup lang="ts">
-import { ref, onMounted, onUnmounted, computed, watch } from 'vue';
+import { ref, onMounted, onUnmounted, computed, watch, nextTick } from 'vue';
+import { ChevronRight } from 'lucide-vue-next';
 import { useContextMenu } from '@/composables/useContextMenu';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 
 const {
   contextMenuVisible,
-  menuPosition,
   menuItems,
   targetElement,
   hideContextMenu,
@@ -80,45 +155,105 @@ const {
 } = useContextMenu();
 
 const menuRef = ref<HTMLElement>();
+const openSubmenuKey = ref<string | null>(null);
 
-const calculatedPosition = computed(() => {
-  if (!targetElement.value) {
-    return menuPosition.value;
-  }
-
-  const rect = targetElement.value.getBoundingClientRect();
-  const scrollLeft = window.scrollX || document.documentElement.scrollLeft;
-  const scrollTop = window.scrollY || document.documentElement.scrollTop;
-
-  const centerX = rect.left + scrollLeft + rect.width / 2;
-  const menuWidth = menuRef.value?.offsetWidth || 172;
-
-  return {
-    x: centerX - menuWidth / 2,
-    y: rect.bottom + scrollTop + 4,
-  };
+/**
+ * Official floating UI for session-header … menu (CDP dump):
+ *   position: fixed
+ *   left = trigger.right - menuWidth   // end / right-edge align
+ *   top  = trigger.bottom + 4
+ *   --available-width / --available-height / --anchor-width / --anchor-height
+ * Local used to center under the trigger → overflow past the right edge of the viewport.
+ */
+const floating = ref({
+  x: 0,
+  y: 0,
+  availableWidth: 0,
+  availableHeight: 0,
+  anchorWidth: 22,
+  anchorHeight: 22,
 });
 
-watch(targetElement, () => {
-  if (targetElement.value) {
-    menuPosition.value = calculatedPosition.value;
+const menuStyle = computed(() => ({
+  position: 'fixed' as const,
+  left: `${floating.value.x}px`,
+  top: `${floating.value.y}px`,
+  '--available-width': `${floating.value.availableWidth}px`,
+  '--available-height': `${floating.value.availableHeight}px`,
+  '--anchor-width': `${floating.value.anchorWidth}px`,
+  '--anchor-height': `${floating.value.anchorHeight}px`,
+}));
+
+const updateFloatingPosition = () => {
+  if (!targetElement.value) return;
+  const rect = targetElement.value.getBoundingClientRect();
+  const menuWidth = menuRef.value?.offsetWidth || 172;
+  const menuHeight = menuRef.value?.offsetHeight || 0;
+  const gap = 4;
+  const pad = 8;
+
+  // Official: align end (menu.right === trigger.right)
+  let x = rect.right - menuWidth;
+  let y = rect.bottom + gap;
+
+  // Keep inside viewport (floating-ui shift)
+  x = Math.min(Math.max(pad, x), window.innerWidth - menuWidth - pad);
+  if (menuHeight > 0) {
+    y = Math.min(Math.max(pad, y), window.innerHeight - menuHeight - pad);
   }
-}, { immediate: true });
+
+  floating.value = {
+    x,
+    y,
+    availableWidth: Math.max(0, window.innerWidth - x),
+    availableHeight: Math.max(0, window.innerHeight - y),
+    anchorWidth: rect.width,
+    anchorHeight: rect.height,
+  };
+};
+
+watch(contextMenuVisible, async (v) => {
+  if (!v) {
+    openSubmenuKey.value = null;
+    return;
+  }
+  await nextTick();
+  updateFloatingPosition();
+  // Re-measure after paint once real menu width is known
+  requestAnimationFrame(() => updateFloatingPosition());
+});
+
+watch(targetElement, async () => {
+  if (contextMenuVisible.value && targetElement.value) {
+    await nextTick();
+    updateFloatingPosition();
+  }
+});
 
 const handleClickOutside = (event: MouseEvent) => {
   if (!contextMenuVisible.value || !menuRef.value) return;
   const target = event.target as Node;
   if (targetElement.value?.contains(target)) return;
-  if (!menuRef.value.contains(target)) {
-    hideContextMenu();
-  }
+  if (menuRef.value.contains(target)) return;
+  // Nested PopoverContent is portaled — keep menu open while interacting with it
+  const el = target as HTMLElement;
+  if (el.closest?.('[data-slot="popover-content"]')) return;
+  hideContextMenu();
+};
+
+const handleViewportChange = () => {
+  if (contextMenuVisible.value) updateFloatingPosition();
 };
 
 onMounted(() => {
   document.addEventListener('click', handleClickOutside);
+  window.addEventListener('resize', handleViewportChange);
+  window.addEventListener('scroll', handleViewportChange, true);
 });
 
 onUnmounted(() => {
   document.removeEventListener('click', handleClickOutside);
+  window.removeEventListener('resize', handleViewportChange);
+  window.removeEventListener('scroll', handleViewportChange, true);
 });
 </script>

--- a/frontend/src/composables/useContextMenu.ts
+++ b/frontend/src/composables/useContextMenu.ts
@@ -7,6 +7,8 @@ export interface MenuItem {
     variant?: 'default' | 'danger';
     checked?: boolean;
     disabled?: boolean;
+    /** Official nested popover submenu (e.g. Move to project) */
+    children?: MenuItem[];
     action?: (itemId: string) => void;
 }
 
@@ -58,6 +60,8 @@ export function useContextMenu() {
   // Handle menu item click (called from ContextMenu component)
   const handleMenuItemClick = (item: MenuItem) => {
     if (item.disabled) return;
+    // Parent rows with children open a submenu — do not dismiss
+    if (item.children?.length) return;
     
     if (selectedItemId.value) {
       // Call the provided handler
@@ -89,33 +93,52 @@ export function useContextMenu() {
   }
 }
 
+function markIcons(item: MenuItem): MenuItem {
+  return {
+    ...item,
+    icon: item.icon ? markRaw(item.icon) : item.icon,
+    children: item.children?.map(markIcons),
+  }
+}
+
 // Utility functions for creating common menu items
 export const createMenuItem = (
   key: string,
   label: string,
   options: Partial<Omit<MenuItem, 'key' | 'label'>> = {}
-): MenuItem => ({
+): MenuItem => markIcons({
   key,
   label,
   variant: 'default',
   ...options,
-  icon: options.icon ? markRaw(options.icon) : options.icon
 })
 
 export const createDangerMenuItem = (
   key: string,
   label: string,
   options: Partial<Omit<MenuItem, 'key' | 'label' | 'variant'>> = {}
-): MenuItem => ({
+): MenuItem => markIcons({
   key,
   label,
   variant: 'danger',
   ...options,
-  icon: options.icon ? markRaw(options.icon) : options.icon
+})
+
+export const createSubmenuItem = (
+  key: string,
+  label: string,
+  children: MenuItem[],
+  options: Partial<Omit<MenuItem, 'key' | 'label' | 'children'>> = {}
+): MenuItem => markIcons({
+  key,
+  label,
+  variant: 'default',
+  children,
+  ...options,
 })
 
 export const createSeparator = (): MenuItem => ({
   key: `separator-${Math.random().toString(36).slice(2)}`,
   label: '',
   disabled: true,
-}) 
+})

--- a/frontend/src/composables/useFilePreviewer.ts
+++ b/frontend/src/composables/useFilePreviewer.ts
@@ -9,7 +9,6 @@ import { router } from '../router'
 export type FilePreviewViewMode = 'side' | 'center' | 'fullscreen'
 
 const isShow = ref(false)
-const visible = ref(true)
 const fileInfo = ref<FileInfo>()
 const viewMode = ref<FilePreviewViewMode>('center')
 const fullscreenReturnViewMode = ref<Exclude<FilePreviewViewMode, 'fullscreen'>>('center')
@@ -72,7 +71,6 @@ export function useFilePreviewer() {
 
   const showFilePreviewer = (file: FileInfo, mode?: FilePreviewViewMode) => {
     eventBus.emit(EVENT_SHOW_FILE_PREVIEWER)
-    visible.value = true
     fileInfo.value = file
     const canUseSide = canUseSideFilePreview.value
     if (mode) {
@@ -117,7 +115,6 @@ export function useFilePreviewer() {
   return {
     isShow,
     fileInfo,
-    visible,
     viewMode,
     fullscreenReturnViewMode,
     defaultViewMode,

--- a/frontend/src/locales/en.ts
+++ b/frontend/src/locales/en.ts
@@ -109,6 +109,7 @@ export default {
   'Project deleted': 'Project deleted',
   'Edit project': 'Edit project',
   'Edit instructions': 'Edit instructions',
+  'View project': 'View project',
   'Delete project': 'Delete project',
   'Delete project?': 'Delete project?',
   'Tasks in this project will not be deleted, but they will be removed from the project.':

--- a/frontend/src/locales/zh.ts
+++ b/frontend/src/locales/zh.ts
@@ -51,7 +51,7 @@ export default {
   'Desktop': '桌面端',
   'Notifications': '通知',
   'Coming soon': '即将推出',
-  'New project': '新建项目',
+  'New project': '新项目',
   'Favorites': '收藏',
   'Shared': '已分享',
   'Non-project tasks': '非项目任务',
@@ -109,6 +109,7 @@ export default {
   'Project deleted': '项目已删除',
   'Edit project': '编辑项目',
   'Edit instructions': '编辑指令',
+  'View project': '查看项目',
   'Delete project': '删除项目',
   'Delete project?': '删除项目？',
   'Tasks in this project will not be deleted, but they will be removed from the project.':

--- a/frontend/src/pages/ChatPage.vue
+++ b/frontend/src/pages/ChatPage.vue
@@ -2,9 +2,9 @@
   <SimpleBar ref="simpleBarRef" @scroll="handleScroll">
     <!-- Chat column: full-bleed header (Manus) + centered message column -->
     <div ref="chatContainerRef" class="relative flex flex-col h-full flex-1 min-w-0">
-      <!-- Official session chrome (scraped from manus.im/app/...): h-56 bar + brand left + actions right -->
+      <!-- Official session chrome header bar (CDP: manus.im/app/…) -->
       <div ref="observerRef"
-        class="flex h-[56px] w-full shrink-0 items-center justify-between py-[12px] ps-[14px] pe-[20px] md:px-[24px] gap-1 border-b sticky top-0 z-10 flex-shrink-0 bg-[var(--background-gray-main)] border-[var(--border-main)]">
+        class="flex h-[56px] w-full shrink-0 items-center justify-between py-[12px] md:px-[24px] ps-[16px] pe-[20px] md:ps-[16px] md:pe-[20px] gap-1 border-b sticky top-0 z-10 flex-shrink-0 [-webkit-app-region:drag] bg-[var(--background-gray-main)] border-[var(--border-main)]">
         <div class="flex min-w-0 flex-1 items-center gap-1">
           <div class="flex items-center pointer-events-auto overflow-hidden">
             <div class="flex h-8 pt-[7px] md:pr-[6px] pr-[4px] pb-[7px] md:pl-[8px] pl-[6px] justify-center items-center gap-1 rounded-[8px]">
@@ -154,7 +154,7 @@ import { Message, MessageContent, ToolContent, AttachmentsContent, StepContent, 
 import { PlanEventData, AgentSSEEvent } from '../types/event';
 import { useAgentEvents } from '../composables/useAgentEvents';
 import ComputerPanel from '../components/ComputerPanel.vue'
-import { ArrowDown, FileSearch, Lock, Globe, Link, Check, Ellipsis, Pencil, Star, Trash, FolderPlus, Pin } from 'lucide-vue-next';
+import { ArrowDown, FileSearch, Lock, Globe, Link, Check, Ellipsis, Pencil, Star, Trash, FolderPlus, Folder, FolderSync, Pin } from 'lucide-vue-next';
 import ShareIcon from '@/components/icons/ShareIcon.vue';
 import { showErrorToast, showSuccessToast } from '../utils/toast';
 import type { FileInfo } from '../api/file';
@@ -164,9 +164,10 @@ import { copyToClipboard } from '../utils/dom'
 import { SessionStatus, type ProjectItem } from '../types/response';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import LoadingIndicator from '@/components/ui/LoadingIndicator.vue';
-import { useContextMenu, createMenuItem, createDangerMenuItem, createSeparator } from '../composables/useContextMenu';
+import { useContextMenu, createMenuItem, createDangerMenuItem, createSeparator, createSubmenuItem } from '../composables/useContextMenu';
 import { useDialog } from '../composables/useDialog';
-import { getProjects } from '../api/project';
+import { getProjects, createProject } from '../api/project';
+import { eventBus } from '../utils/eventBus';
 
 const router = useRouter()
 const { t } = useI18n()
@@ -620,20 +621,22 @@ const handleMoreClick = async (event: MouseEvent | KeyboardEvent) => {
     createMenuItem('rename', t('Rename'), { icon: Pencil }),
   ];
 
-  if (projects.value.length > 0) {
-    for (const project of projects.value) {
-      if (project.project_id !== projectId.value) {
-        items.push(createMenuItem(
-          `move:${project.project_id}`,
-          `${t('Move to project')}: ${project.name}`,
-          { icon: FolderPlus },
-        ));
-      }
-    }
-  }
+  // Official:「移动到项目」+ chevron → submenu (新项目 / — / projects)
+  const moveChildren = [
+    createMenuItem('new_project', t('New project'), { icon: FolderPlus }),
+    createSeparator(),
+    ...projects.value.map((project) =>
+      createMenuItem(`move:${project.project_id}`, project.name, {
+        icon: Folder,
+        checked: project.project_id === projectId.value,
+      }),
+    ),
+  ];
   if (projectId.value) {
-    items.push(createMenuItem('remove_project', t('Remove from project'), { icon: FolderPlus }));
+    moveChildren.push(createSeparator());
+    moveChildren.push(createMenuItem('remove_project', t('Remove from project'), { icon: Folder }));
   }
+  items.push(createSubmenuItem('move_project', t('Move to project'), moveChildren, { icon: FolderSync }));
 
   items.push(createSeparator());
   items.push(createMenuItem('pin', pinnedNow ? t('Unpin') : t('Pin'), { icon: Pin }));
@@ -678,9 +681,30 @@ const handleMoreClick = async (event: MouseEvent | KeyboardEvent) => {
       } catch {
         showErrorToast(t('Failed to update favorite'));
       }
+    } else if (key === 'new_project') {
+      if (!sessionId.value) return;
+      showInputDialog({
+        title: t('New project'),
+        placeholder: t('Enter project name'),
+        confirmText: t('Create'),
+        onConfirm: async (value: string) => {
+          if (!value || !sessionId.value) return;
+          try {
+            const project = await createProject(value);
+            await agentApi.moveSessionProject(sessionId.value, project.project_id);
+            projectId.value = project.project_id;
+            projects.value = [project, ...projects.value];
+            eventBus.emit('projects:changed');
+            showSuccessToast(t('Moved to project'));
+          } catch {
+            showErrorToast(t('Failed to create project'));
+          }
+        },
+      });
     } else if (key.startsWith('move:')) {
       if (!sessionId.value) return;
       const nextProjectId = key.slice(5);
+      if (nextProjectId === projectId.value) return;
       try {
         await agentApi.moveSessionProject(sessionId.value, nextProjectId);
         projectId.value = nextProjectId;


### PR DESCRIPTION
## Summary
- Align FilePreviewer / Computer panel chrome with Manus (center / side / fullscreen modes, PDF/HTML previews).
- Align session `…` menus (header + sidebar) with nested「移动到项目」submenu, pin/favorite/delete; add session pin API; project-row `…` + edit actions.
- Fix ContextMenu layering (`Teleport` + `z-[1100]`) and keep center/fullscreen file preview open when Computer panel shows during a running task.

## Test plan
- [ ] Open a file in center/fullscreen preview while a task is running and Computer opens — preview should stay visible
- [ ] Session header `…`: rename, move-to-project submenu (new / list / remove), pin, favorite, delete
- [ ] Sidebar session row `…`: same move submenu + pin/favorite/delete
- [ ] Sidebar project row hover: `…` + edit; pin/unpin, edit, view, delete
- [ ] Confirm menus render above sidebar sticky headers and main content (no z-index clipping)
- [ ] `cd frontend && npm run type-check && npm run lint`


Made with [Cursor](https://cursor.com)