### PR TITLE
feat: align chat WS control plane with Manus protocol

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -171,11 +171,15 @@ Auth: browser Cookie (`session_id`) or App `Authorization: Bearer` (no `?token=`
 | Path | Description |
 |---|---|
 | WebSocket | `/ws/sessions` | Session list channel (`snapshot` / `upsert` / `remove` / `ping`) |
-| WebSocket | `/ws/chat` | Chat channel — one connection per tab; switch with `join_session` / `leave_session`; send with `chat`; stop with `stop_session` |
+| WebSocket | `/ws/chat` | Chat channel (protocol `version: 2`) — one connection per tab; `join_session` / `leave_session` / `chat` / `stop_session` with envelope `id`+`timestamp`; awaitable ack via `request_id` |
 | WebSocket | `/ws/claw` | Claw chat channel (`chat` / `text` / `file` / `done` / `heartbeat`) |
 | WebSocket | `/ws/vnc/{session_id}` | Sandbox VNC proxy (binary subprotocol; Cookie/Bearer) |
 
-Chat server→client event envelope: `{ type: "event", session_id, event, data }` where `event` is one of `message`, `title`, `plan`, `step`, `tool`, `wait`, `error`, `done`.
+Chat client→server envelope: `{ id, timestamp, version: 2, type, session_id, ... }`.
+
+Chat server→client: `{ type: "joined"|"left"|"stopped"|"ack"|"stream_end"|"ping"|"error"|"event", ... }`. Control replies echo `request_id`. Errors include `code` (`4000` bad version, `4002` bad request, `4004` not found, `4009` not joined, `5000` internal).
+
+Event envelope: `{ type: "event", session_id, event, data }` where `event` is one of `message`, `title`, `plan`, `step`, `tool`, `wait`, `error`, `done`, `status_update`, `terminal_update`, `file_update`. `status_update.data.agent_status` is `pending|running|waiting|completed|error` (authoritative loading/state signal). `terminal_update` / `file_update` push live Computer-panel shell console and file content (official `terminalUpdate` / text_editor).
 
 ### File Endpoints (`/api/v1/files`)
 

--- a/backend/README_zh.md
+++ b/backend/README_zh.md
@@ -171,11 +171,15 @@ docker run -p 8000:8000 --env-file .env -v /var/run/docker.sock:/var/run/docker.
 | 路径 | 描述 |
 |---|---|
 | WebSocket | `/ws/sessions` | 会话列表通道（`snapshot` / `upsert` / `remove` / `ping`） |
-| WebSocket | `/ws/chat` | 聊天通道 — 每标签页一条连接；用 `join_session` / `leave_session` 切换；`chat` 发消息；`stop_session` 停止 |
+| WebSocket | `/ws/chat` | 聊天通道（协议 `version: 2`）— 每标签页一条连接；`join_session` / `leave_session` / `chat` / `stop_session`；信封含 `id`+`timestamp`；通过 `request_id` 可等待 ack |
 | WebSocket | `/ws/claw` | Claw 聊天通道（`chat` / `text` / `file` / `done` / `heartbeat`） |
 | WebSocket | `/ws/vnc/{session_id}` | 沙盒 VNC 代理（binary 子协议；Cookie/Bearer） |
 
-聊天服务端→客户端事件信封：`{ type: "event", session_id, event, data }`，其中 `event` 为 `message`、`title`、`plan`、`step`、`tool`、`wait`、`error`、`done` 之一。
+客户端→服务端信封：`{ id, timestamp, version: 2, type, session_id, ... }`。
+
+服务端→客户端：`{ type: "joined"|"left"|"stopped"|"ack"|"stream_end"|"ping"|"error"|"event", ... }`。控制面回包带 `request_id`。错误含 `code`（`4000` 版本错误、`4002` 坏请求、`4004` 未找到、`4009` 未加入、`5000` 内部错误）。
+
+事件信封：`{ type: "event", session_id, event, data }`，其中 `event` 为 `message`、`title`、`plan`、`step`、`tool`、`wait`、`error`、`done`、`status_update`、`terminal_update`、`file_update`。`status_update.data.agent_status` 为 `pending|running|waiting|completed|error`（权威加载/状态信号）。`terminal_update` / `file_update` 推送 Computer 面板终端输出与文件内容（对齐官方 `terminalUpdate` / text_editor）。
 
 ### 文件接口（`/api/v1/files`）
 

--- a/backend/app/domain/models/event.py
+++ b/backend/app/domain/models/event.py
@@ -114,6 +114,28 @@ class WaitEvent(BaseEvent):
     """Wait event"""
     type: Literal["wait"] = "wait"
 
+
+class TerminalUpdateEvent(BaseEvent):
+    """Live shell/terminal output (official Manus ``terminalUpdate``).
+
+    Streamed while a shell tool runs and once more with final console.
+    Not required for history — ToolEvent already carries final content.
+    """
+    type: Literal["terminal_update"] = "terminal_update"
+    shell_id: str
+    output: Any = None
+    description: Optional[str] = None
+
+
+class FileUpdateEvent(BaseEvent):
+    """Live file editor content (official text_editor / file panel updates)."""
+    type: Literal["file_update"] = "file_update"
+    path: str
+    content: str = ""
+    old_content: Optional[str] = None
+    file: Optional[FileInfo] = None
+
+
 AgentEvent = Union[
     ErrorEvent,
     PlanEvent, 
@@ -123,4 +145,6 @@ AgentEvent = Union[
     DoneEvent,
     TitleEvent,
     WaitEvent,
+    TerminalUpdateEvent,
+    FileUpdateEvent,
 ]

--- a/backend/app/domain/services/agent_task_runner.py
+++ b/backend/app/domain/services/agent_task_runner.py
@@ -20,6 +20,8 @@ from app.domain.models.event import (
     ToolStatus,
     AgentEvent,
     McpToolContent,
+    TerminalUpdateEvent,
+    FileUpdateEvent,
 )
 from app.domain.services.flows.plan_act import PlanActFlow
 from app.domain.external.sandbox import Sandbox
@@ -98,6 +100,9 @@ class AgentTaskRunner(TaskRunner):
     async def _put_and_add_event(self, task: Task, event: AgentEvent) -> None:
         event_id = await task.output_stream.put(event.model_dump_json())
         event.id = event_id
+        # Live computer-panel updates — stream only (avoid bloating session.events)
+        if isinstance(event, (TerminalUpdateEvent, FileUpdateEvent)):
+            return
         await self._session_repository.add_event(self._session_id, event)
     
     async def _pop_event(self, task: Task) -> AgentEvent:
@@ -362,9 +367,41 @@ class AgentTaskRunner(TaskRunner):
             if isinstance(event, ToolEvent):
                 # TODO: move to tool function
                 await self._handle_tool_event(event)
+                yield event
+                # Official: terminalUpdate / text_editor file panel push after tool settles
+                if event.status == ToolStatus.CALLED:
+                    if event.tool_name == "shell" and event.function_args.get("id"):
+                        console = None
+                        if isinstance(event.tool_content, ShellToolContent):
+                            console = event.tool_content.console
+                        yield TerminalUpdateEvent(
+                            shell_id=event.function_args["id"],
+                            output=console if console is not None else [],
+                        )
+                    elif event.tool_name == "file" and event.function_args.get("file"):
+                        path = event.function_args["file"]
+                        content = ""
+                        old_content = None
+                        if isinstance(event.tool_content, FileToolContent):
+                            content = event.tool_content.content or ""
+                            old_content = event.tool_content.old_content
+                        file_info = await self._session_repository.get_file_by_path(
+                            self._session_id, path
+                        )
+                        yield FileUpdateEvent(
+                            path=path,
+                            content=content,
+                            old_content=old_content,
+                            file=file_info,
+                        )
             elif isinstance(event, MessageEvent):
                 await self._sync_message_attachments_to_storage(event)
-            yield event
+                yield event
+            elif isinstance(event, TerminalUpdateEvent):
+                # Already emitted from BaseAgent live poll
+                yield event
+            else:
+                yield event
 
         logger.info(f"Agent {self._agent_id} completed processing one message")
 

--- a/backend/app/domain/services/agents/base.py
+++ b/backend/app/domain/services/agents/base.py
@@ -235,6 +235,24 @@ class BaseAgent(ABC):
                     if shell_id and hasattr(tool.toolkit, "sandbox"):
                         invoke_task = asyncio.create_task(self.invoke_tool(tool, tool_call))
                         last_fingerprint: Optional[str] = None
+
+                        def _console_fingerprint(console: Any) -> str:
+                            """Cheap change detector — avoid repr() on large consoles."""
+                            if console is None:
+                                return "0:"
+                            if isinstance(console, str):
+                                return f"s:{len(console)}:{console[-80:]}"
+                            if isinstance(console, list):
+                                if not console:
+                                    return "0:"
+                                last = console[-1]
+                                if isinstance(last, dict):
+                                    tail = f"{last.get('command', '')}|{str(last.get('output', ''))[-60:]}"
+                                else:
+                                    tail = str(last)[-80:]
+                                return f"l:{len(console)}:{tail}"
+                            return f"o:{type(console).__name__}:{str(console)[-80:]}"
+
                         while not invoke_task.done():
                             done, _ = await asyncio.wait({invoke_task}, timeout=1.0)
                             if done:
@@ -248,11 +266,7 @@ class BaseAgent(ABC):
                                     if view and getattr(view, "data", None)
                                     else []
                                 )
-                                fingerprint = (
-                                    console
-                                    if isinstance(console, str)
-                                    else repr(console)
-                                )
+                                fingerprint = _console_fingerprint(console)
                                 if fingerprint != last_fingerprint:
                                     last_fingerprint = fingerprint
                                     yield TerminalUpdateEvent(

--- a/backend/app/domain/services/agents/base.py
+++ b/backend/app/domain/services/agents/base.py
@@ -11,6 +11,7 @@ from app.domain.models.event import (
     ToolStatus,
     ErrorEvent,
     MessageEvent,
+    TerminalUpdateEvent,
 )
 from app.domain.repositories.agent_repository import AgentRepository
 from app.domain.external.llm import LLM
@@ -225,7 +226,48 @@ class BaseAgent(ABC):
                         function_args=function_args
                     )
 
-                    tool_result = await self.invoke_tool(tool, tool_call)
+                    # Official terminalUpdate: poll shell console while the tool runs
+                    shell_id = (
+                        function_args.get("id")
+                        if tool.toolkit.name == "shell" and isinstance(function_args, dict)
+                        else None
+                    )
+                    if shell_id and hasattr(tool.toolkit, "sandbox"):
+                        invoke_task = asyncio.create_task(self.invoke_tool(tool, tool_call))
+                        last_fingerprint: Optional[str] = None
+                        while not invoke_task.done():
+                            done, _ = await asyncio.wait({invoke_task}, timeout=1.0)
+                            if done:
+                                break
+                            try:
+                                view = await tool.toolkit.sandbox.view_shell(
+                                    shell_id, console=True
+                                )
+                                console = (
+                                    view.data.get("console", [])
+                                    if view and getattr(view, "data", None)
+                                    else []
+                                )
+                                fingerprint = (
+                                    console
+                                    if isinstance(console, str)
+                                    else repr(console)
+                                )
+                                if fingerprint != last_fingerprint:
+                                    last_fingerprint = fingerprint
+                                    yield TerminalUpdateEvent(
+                                        shell_id=shell_id,
+                                        output=console,
+                                    )
+                            except Exception:
+                                logger.debug(
+                                    "Shell live poll failed for %s",
+                                    shell_id,
+                                    exc_info=True,
+                                )
+                        tool_result = await invoke_task
+                    else:
+                        tool_result = await self.invoke_tool(tool, tool_call)
 
                     # Generate event after tool call
                     yield ToolEvent(

--- a/backend/app/interfaces/api/ws_routes.py
+++ b/backend/app/interfaces/api/ws_routes.py
@@ -311,7 +311,8 @@ async def chat_ws(websocket: WebSocket):
             session_id = raw.get("session_id")
             request_id = raw.get("id")
 
-            # leave_session: allow without version (fire-and-forget on tab close)
+            # leave_session: still accept missing version (tab-close races), but
+            # clients should send version: 2 like other control frames.
             if msg_type != "leave_session" and raw.get("version") != CHAT_WS_PROTOCOL_VERSION:
                 await send_error(
                     f"Unsupported protocol version (require {CHAT_WS_PROTOCOL_VERSION})",

--- a/backend/app/interfaces/api/ws_routes.py
+++ b/backend/app/interfaces/api/ws_routes.py
@@ -35,6 +35,38 @@ SESSION_LIST_KEEPALIVE_SECONDS = 20.0
 CHAT_WS_PING_SECONDS = 20.0
 CLAW_HEARTBEAT_INTERVAL = 15
 
+# Chat WS protocol (aligned with official Manus control-plane contract).
+CHAT_WS_PROTOCOL_VERSION = 2
+ERR_BAD_VERSION = 4000
+ERR_BAD_REQUEST = 4002
+ERR_NOT_FOUND = 4004
+ERR_NOT_JOINED = 4009
+ERR_INTERNAL = 5000
+
+
+def _session_status_value(status: Any) -> str:
+    return getattr(status, "value", status) if status is not None else "pending"
+
+
+def _agent_status_from_session(status: Any) -> str:
+    """Map SessionStatus → wire agent_status (pending|running|waiting|completed|error)."""
+    value = _session_status_value(status)
+    if value in ("pending", "running", "waiting", "completed"):
+        return value
+    return "completed"
+
+
+def _events_after(events: list[Any], last_event_id: Optional[str]) -> list[Any]:
+    """Return domain events strictly after last_event_id (Mongo catch-up)."""
+    if not events:
+        return []
+    if not last_event_id:
+        return list(events)
+    idx = next((i for i, e in enumerate(events) if getattr(e, "id", None) == last_event_id), None)
+    if idx is None:
+        return list(events)
+    return list(events[idx + 1 :])
+
 
 @router.websocket("/sessions")
 async def sessions_list_ws(websocket: WebSocket):
@@ -121,19 +153,23 @@ async def chat_ws(websocket: WebSocket):
     """Chat channel — one connection per tab; switch sessions via join/leave.
 
     Auth: Cookie (browser) or Authorization Bearer (App). No ?token=.
+    Protocol version: client frames must include ``version: 2``.
 
-    Client → Server:
-      {"type":"join_session","session_id":"...","last_event_id":"...?"}
-      {"type":"leave_session","session_id":"..."}
-      {"type":"chat","session_id":"...","message":"...","attachments":[],"timestamp":123}
-      {"type":"stop_session","session_id":"..."}
+    Client → Server (envelope):
+      {
+        "id": "...", "timestamp": 1710000000, "version": 2,
+        "type": "join_session|leave_session|chat|stop_session",
+        "session_id": "...",
+        "last_event_id": "...?", "message": "...?", "attachments": [],
+        "conn_id": "...?"
+      }
 
     Server → Client:
-      {"type":"joined","session_id":"..."}
-      {"type":"left","session_id":"..."}
-      {"type":"event","session_id":"...","event":"message|tool|...","data":{...}}
+      {"type":"joined|left|stopped","session_id":"...","request_id":"...?"}
+      {"type":"ack","request_id":"...","op":"chat","session_id":"...","ok":true}
+      {"type":"event","session_id":"...","event":"message|status_update|...","data":{...}}
       {"type":"stream_end","session_id":"..."}
-      {"type":"error","error":"...","session_id":"...?"}
+      {"type":"error","error":"...","code":4000,"session_id":"...?","request_id":"...?"}
       {"type":"ping"}
     """
     try:
@@ -152,6 +188,42 @@ async def chat_ws(websocket: WebSocket):
     async def safe_send(payload: dict[str, Any]) -> None:
         async with send_lock:
             await websocket.send_json(payload)
+
+    async def send_error(
+        error: str,
+        *,
+        code: int = ERR_INTERNAL,
+        session_id: Optional[str] = None,
+        request_id: Optional[str] = None,
+    ) -> None:
+        payload: dict[str, Any] = {"type": "error", "error": error, "code": code}
+        if session_id:
+            payload["session_id"] = session_id
+        if request_id:
+            payload["request_id"] = request_id
+        await safe_send(payload)
+
+    async def send_status_update(session_id: str, agent_status: str) -> None:
+        await safe_send({
+            "type": "event",
+            "session_id": session_id,
+            "event": "status_update",
+            "data": {
+                "event_id": f"status-{session_id}-{agent_status}-{int(datetime.now().timestamp())}",
+                "timestamp": int(datetime.now().timestamp()),
+                "agent_status": agent_status,
+            },
+        })
+
+    async def send_agent_event(session_id: str, event: Any) -> None:
+        sse = await EventMapper.event_to_sse_event(event)
+        data = sse.data.model_dump(mode="json") if sse.data else {}
+        await safe_send({
+            "type": "event",
+            "session_id": session_id,
+            "event": sse.event,
+            "data": data,
+        })
 
     async def cancel_stream() -> None:
         nonlocal stream_task
@@ -172,6 +244,7 @@ async def chat_ws(websocket: WebSocket):
         attachments: Optional[list[FileInfo]] = None,
         timestamp: Optional[datetime] = None,
     ) -> None:
+        saw_error = False
         try:
             async for event in agent_service.chat(
                 session_id=session_id,
@@ -183,26 +256,27 @@ async def chat_ws(websocket: WebSocket):
             ):
                 if joined_session_id != session_id:
                     break
-                sse = await EventMapper.event_to_sse_event(event)
-                data = sse.data.model_dump(mode="json") if sse.data else {}
-                await safe_send({
-                    "type": "event",
-                    "session_id": session_id,
-                    "event": sse.event,
-                    "data": data,
-                })
+                if getattr(event, "type", None) == "error":
+                    saw_error = True
+                await send_agent_event(session_id, event)
             if joined_session_id == session_id:
                 await safe_send({"type": "stream_end", "session_id": session_id})
+                if saw_error:
+                    await send_status_update(session_id, "error")
+                else:
+                    session = await agent_service.get_session(session_id, user.id)
+                    status = _agent_status_from_session(
+                        session.status if session else "completed"
+                    )
+                    await send_status_update(session_id, status)
         except asyncio.CancelledError:
             raise
         except Exception as e:
             logger.exception("Chat stream failed for session %s", session_id)
             try:
-                await safe_send({
-                    "type": "error",
-                    "session_id": session_id,
-                    "error": str(e),
-                })
+                await send_error(str(e), code=ERR_INTERNAL, session_id=session_id)
+                if joined_session_id == session_id:
+                    await send_status_update(session_id, "error")
             except Exception:
                 pass
 
@@ -229,20 +303,40 @@ async def chat_ws(websocket: WebSocket):
                 await safe_send({"type": "ping"})
                 continue
 
+            if not isinstance(raw, dict):
+                await send_error("Invalid message", code=ERR_BAD_REQUEST)
+                continue
+
             msg_type = raw.get("type")
             session_id = raw.get("session_id")
+            request_id = raw.get("id")
+
+            # leave_session: allow without version (fire-and-forget on tab close)
+            if msg_type != "leave_session" and raw.get("version") != CHAT_WS_PROTOCOL_VERSION:
+                await send_error(
+                    f"Unsupported protocol version (require {CHAT_WS_PROTOCOL_VERSION})",
+                    code=ERR_BAD_VERSION,
+                    session_id=session_id,
+                    request_id=request_id,
+                )
+                continue
 
             if msg_type == "join_session":
                 if not session_id:
-                    await safe_send({"type": "error", "error": "session_id required"})
+                    await send_error(
+                        "session_id required",
+                        code=ERR_BAD_REQUEST,
+                        request_id=request_id,
+                    )
                     continue
                 session = await agent_service.get_session(session_id, user.id)
                 if not session:
-                    await safe_send({
-                        "type": "error",
-                        "session_id": session_id,
-                        "error": "Session not found",
-                    })
+                    await send_error(
+                        "Session not found",
+                        code=ERR_NOT_FOUND,
+                        session_id=session_id,
+                        request_id=request_id,
+                    )
                     continue
 
                 if joined_session_id and joined_session_id != session_id:
@@ -253,21 +347,35 @@ async def chat_ws(websocket: WebSocket):
 
                 joined_session_id = session_id
                 last_event_id = raw.get("last_event_id")
-                await safe_send({"type": "joined", "session_id": session_id})
+                joined_payload: dict[str, Any] = {
+                    "type": "joined",
+                    "session_id": session_id,
+                }
+                if request_id:
+                    joined_payload["request_id"] = request_id
+                await safe_send(joined_payload)
 
-                # Resume live stream only while agent is actively running.
-                # Idle/pending/completed/waiting: join ack only — do NOT send
-                # stream_end here. A follow-up `chat` would otherwise lose the
-                # client "thinking" state when the idle stream_end arrives after
-                # the chat frame was already sent.
-                status = getattr(session.status, "value", session.status)
+                status = _session_status_value(session.status)
+                agent_status = _agent_status_from_session(session.status)
+
+                # Idle/pending/completed/waiting: Mongo catch-up after cursor,
+                # then authoritative status_update. Do NOT send stream_end —
+                # a follow-up chat would otherwise clear client "thinking".
                 if status == "running":
+                    await send_status_update(session_id, "running")
                     await cancel_stream()
                     start_stream(
                         session_id=session_id,
                         message=None,
                         last_event_id=last_event_id,
                     )
+                else:
+                    if last_event_id:
+                        for event in _events_after(session.events or [], last_event_id):
+                            if joined_session_id != session_id:
+                                break
+                            await send_agent_event(session_id, event)
+                    await send_status_update(session_id, agent_status)
 
             elif msg_type == "leave_session":
                 target = session_id or joined_session_id
@@ -276,18 +384,29 @@ async def chat_ws(websocket: WebSocket):
                 if joined_session_id == target:
                     await cancel_stream()
                     joined_session_id = None
-                    await safe_send({"type": "left", "session_id": target})
+                    left_payload: dict[str, Any] = {
+                        "type": "left",
+                        "session_id": target,
+                    }
+                    if request_id:
+                        left_payload["request_id"] = request_id
+                    await safe_send(left_payload)
 
             elif msg_type == "chat":
                 if not session_id:
-                    await safe_send({"type": "error", "error": "session_id required"})
+                    await send_error(
+                        "session_id required",
+                        code=ERR_BAD_REQUEST,
+                        request_id=request_id,
+                    )
                     continue
                 if joined_session_id != session_id:
-                    await safe_send({
-                        "type": "error",
-                        "session_id": session_id,
-                        "error": "Not joined to this session",
-                    })
+                    await send_error(
+                        "Not joined to this session",
+                        code=ERR_NOT_JOINED,
+                        session_id=session_id,
+                        request_id=request_id,
+                    )
                     continue
 
                 message = raw.get("message") or ""
@@ -302,8 +421,17 @@ async def chat_ws(websocket: WebSocket):
                             )
                         )
                 ts = raw.get("timestamp")
-                timestamp = datetime.fromtimestamp(ts) if ts else None
+                timestamp = datetime.fromtimestamp(ts) if isinstance(ts, (int, float)) else None
 
+                if request_id:
+                    await safe_send({
+                        "type": "ack",
+                        "request_id": request_id,
+                        "op": "chat",
+                        "session_id": session_id,
+                        "ok": True,
+                    })
+                await send_status_update(session_id, "running")
                 await cancel_stream()
                 start_stream(
                     session_id=session_id,
@@ -315,22 +443,35 @@ async def chat_ws(websocket: WebSocket):
 
             elif msg_type == "stop_session":
                 if not session_id:
-                    await safe_send({"type": "error", "error": "session_id required"})
+                    await send_error(
+                        "session_id required",
+                        code=ERR_BAD_REQUEST,
+                        request_id=request_id,
+                    )
                     continue
                 try:
                     await agent_service.stop_session(session_id, user.id)
-                    await safe_send({"type": "stopped", "session_id": session_id})
-                except Exception as e:
-                    await safe_send({
-                        "type": "error",
+                    stopped_payload: dict[str, Any] = {
+                        "type": "stopped",
                         "session_id": session_id,
-                        "error": str(e),
-                    })
+                    }
+                    if request_id:
+                        stopped_payload["request_id"] = request_id
+                    await safe_send(stopped_payload)
+                    await send_status_update(session_id, "completed")
+                except Exception as e:
+                    await send_error(
+                        str(e),
+                        code=ERR_INTERNAL,
+                        session_id=session_id,
+                        request_id=request_id,
+                    )
             else:
-                await safe_send({
-                    "type": "error",
-                    "error": f"Unknown type: {msg_type}",
-                })
+                await send_error(
+                    f"Unknown type: {msg_type}",
+                    code=ERR_BAD_REQUEST,
+                    request_id=request_id,
+                )
 
     except WebSocketDisconnect:
         logger.debug("Chat WS disconnected for user %s", user.id)

--- a/backend/app/interfaces/schemas/event.py
+++ b/backend/app/interfaces/schemas/event.py
@@ -12,6 +12,7 @@ from app.domain.models.event import (
     TitleEvent,
     ToolEvent,
     StepEvent,
+    FileUpdateEvent,
 )
 
 class BaseEventData(BaseModel):
@@ -112,6 +113,45 @@ class DoneSSEEvent(BaseSSEEvent):
 class WaitSSEEvent(BaseSSEEvent):
     event: Literal["wait"] = "wait"
 
+
+class TerminalUpdateEventData(BaseEventData):
+    shell_id: str
+    output: Any = None
+    description: Optional[str] = None
+
+
+class TerminalUpdateSSEEvent(BaseSSEEvent):
+    event: Literal["terminal_update"] = "terminal_update"
+    data: TerminalUpdateEventData
+
+
+class FileUpdateEventData(BaseEventData):
+    path: str
+    content: str = ""
+    old_content: Optional[str] = None
+    file: Optional[FileInfoResponse] = None
+
+
+class FileUpdateSSEEvent(BaseSSEEvent):
+    event: Literal["file_update"] = "file_update"
+    data: FileUpdateEventData
+
+    @classmethod
+    async def from_event_async(cls, event: FileUpdateEvent) -> Self:
+        file_resp = (
+            await FileInfoResponse.from_domain(event.file) if event.file else None
+        )
+        return cls(
+            data=FileUpdateEventData(
+                **BaseEventData.base_event_data(event),
+                path=event.path,
+                content=event.content,
+                old_content=event.old_content,
+                file=file_resp,
+            )
+        )
+
+
 class ErrorEventData(BaseEventData):
     error: str
 
@@ -180,6 +220,8 @@ AgentSSEEvent = Union[
     DoneSSEEvent,
     ErrorSSEEvent,
     WaitSSEEvent,
+    TerminalUpdateSSEEvent,
+    FileUpdateSSEEvent,
     CommonSSEEvent,
 ]
 
@@ -194,6 +236,8 @@ _EVENT_TYPE_TO_SSE_CLASS: Dict[str, Type[BaseSSEEvent]] = {
     "done": DoneSSEEvent,
     "error": ErrorSSEEvent,
     "wait": WaitSSEEvent,
+    "terminal_update": TerminalUpdateSSEEvent,
+    "file_update": FileUpdateSSEEvent,
 }
 
 class EventMapper:

--- a/frontend/src/api/agent.ts
+++ b/frontend/src/api/agent.ts
@@ -1,12 +1,14 @@
 // Backend API service
 import { apiClient, ApiResponse, BASE_URL } from './client';
 import { AgentSSEEvent } from '../types/event';
+import type { AgentStatus } from '../types/event';
 import { CreateSessionResponse, GetSessionResponse, ShellViewResponse, FileViewResponse, ListSessionResponse, ListSessionItem, ShareSessionResponse, SharedSessionResponse } from '../types/response';
 import type { FileInfo } from './file';
 
 export type ChatStreamCallbacks = {
   onOpen?: () => void;
   onMessage?: (event: { event: string; data: AgentSSEEvent['data'] }) => void;
+  onStatusUpdate?: (agentStatus: AgentStatus) => void;
   onClose?: () => void;
   onError?: (error: Error) => void;
 };/**
@@ -182,7 +184,12 @@ export const chatWithSession = async (
   ws.setHandlers(sessionId, {
     onOpen: () => callbacks?.onOpen?.(),
     onEvent: ({ event, data }) => {
-      callbacks?.onMessage?.({ event, data });
+      // status_update is delivered via onStatusUpdate; skip duplicate onMessage
+      if (event === 'status_update') return;
+      callbacks?.onMessage?.({ event, data: data as AgentSSEEvent['data'] });
+    },
+    onStatusUpdate: (agentStatus) => {
+      callbacks?.onStatusUpdate?.(agentStatus);
     },
     onStreamEnd: () => {
       callbacks?.onClose?.();

--- a/frontend/src/api/chatWs.ts
+++ b/frontend/src/api/chatWs.ts
@@ -279,14 +279,7 @@ class ChatWebSocket {
 
     this.pendingJoin = { sessionId, lastEventId };
     if (this.joinedSessionId && this.joinedSessionId !== sessionId) {
-      // Fire-and-forget leave (no version required server-side)
-      this.send({
-        type: 'leave_session',
-        session_id: this.joinedSessionId,
-        id: shortUID(),
-        timestamp: Math.floor(Date.now() / 1000),
-        conn_id: this.connId,
-      });
+      this.send(this.envelope('leave_session', { session_id: this.joinedSessionId }));
       this.joinedSessionId = null;
     }
 
@@ -307,13 +300,7 @@ class ChatWebSocket {
       this.pendingJoin = null;
     }
     if (this.ws?.readyState === WebSocket.OPEN) {
-      this.send({
-        type: 'leave_session',
-        session_id: target,
-        id: shortUID(),
-        timestamp: Math.floor(Date.now() / 1000),
-        conn_id: this.connId,
-      });
+      this.send(this.envelope('leave_session', { session_id: target }));
     }
     if (this.joinedSessionId === target) {
       this.joinedSessionId = null;

--- a/frontend/src/api/chatWs.ts
+++ b/frontend/src/api/chatWs.ts
@@ -1,31 +1,49 @@
 /**
  * Chat WebSocket — one connection per tab; switch sessions via join/leave.
- * Aligns with official Manus join_session / leave_session pattern.
+ * Protocol v2: envelope (id/timestamp/version), awaitable control frames,
+ * status_update, error codes — aligned with official Manus control plane.
  */
 import { BASE_URL } from './client';
-import type { AgentSSEEvent } from '../types/event';
+import type { AgentSSEEvent, AgentStatus, StatusUpdateEventData } from '../types/event';
 import type { ChatAttachment } from './agent';
 
+export const CHAT_WS_PROTOCOL_VERSION = 2;
+export const CHAT_WS_REQUEST_TIMEOUT_MS = 10_000;
+
 export type ChatWSServerMessage =
-  | { type: 'joined'; session_id: string }
-  | { type: 'left'; session_id: string }
-  | { type: 'stopped'; session_id: string }
+  | { type: 'joined'; session_id: string; request_id?: string }
+  | { type: 'left'; session_id: string; request_id?: string }
+  | { type: 'stopped'; session_id: string; request_id?: string }
+  | { type: 'ack'; request_id: string; op: string; session_id: string; ok: boolean }
   | { type: 'stream_end'; session_id: string }
   | { type: 'ping' }
-  | { type: 'error'; error: string; session_id?: string }
-  | { type: 'event'; session_id: string; event: string; data: AgentSSEEvent['data'] };
+  | { type: 'error'; error: string; code?: number; session_id?: string; request_id?: string }
+  | { type: 'event'; session_id: string; event: string; data: AgentSSEEvent['data'] | StatusUpdateEventData };
 
 type EventHandler = (msg: {
-  event: AgentSSEEvent['event'];
-  data: AgentSSEEvent['data'];
+  event: AgentSSEEvent['event'] | 'status_update';
+  data: AgentSSEEvent['data'] | StatusUpdateEventData;
 }) => void;
 
 type SessionHandlers = {
   onEvent?: EventHandler;
   onOpen?: () => void;
   onStreamEnd?: () => void;
-  onError?: (error: string) => void;
+  onStatusUpdate?: (agentStatus: AgentStatus) => void;
+  onError?: (error: string, code?: number) => void;
 };
+
+type PendingRequest = {
+  resolve: (msg: ChatWSServerMessage) => void;
+  reject: (error: Error) => void;
+  timer: ReturnType<typeof setTimeout>;
+  /** Accept these server message types as a successful response */
+  expect: Set<string>;
+};
+
+function shortUID(): string {
+  return `${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 10)}`;
+}
 
 class ChatWebSocket {
   private ws: WebSocket | null = null;
@@ -36,7 +54,9 @@ class ChatWebSocket {
   private pendingJoin: { sessionId: string; lastEventId?: string } | null = null;
   private handlers = new Map<string, SessionHandlers>();
   private readyWaiters: Array<() => void> = [];
-  private joinWaiters = new Map<string, Array<(ok: boolean, error?: string) => void>>();
+  private pendingRequests = new Map<string, PendingRequest>();
+  /** Connection generation — regenerated on each (re)connect */
+  private connId = shortUID();
 
   connect() {
     if (this.closed) return;
@@ -49,13 +69,13 @@ class ChatWebSocket {
 
     this.ws.onopen = () => {
       this.reconnectDelay = 1000;
+      this.connId = shortUID();
       this.readyWaiters.splice(0).forEach(resolve => resolve());
       // Re-join after reconnect
       const target = this.pendingJoin || (this.joinedSessionId
         ? { sessionId: this.joinedSessionId }
         : null);
       if (target) {
-        // Clear local join state; wait for server ack via joinSession path below
         this.joinedSessionId = null;
         void this.joinSession(target.sessionId, target.lastEventId);
       }
@@ -74,11 +94,7 @@ class ChatWebSocket {
     this.ws.onclose = () => {
       this.ws = null;
       this.joinedSessionId = null;
-      // Fail pending join waiters so callers don't hang
-      for (const [sid, waiters] of this.joinWaiters) {
-        waiters.forEach(w => w(false, 'WebSocket closed'));
-        this.joinWaiters.delete(sid);
-      }
+      this.failAllPending('WebSocket closed');
       if (this.closed) return;
       this.scheduleReconnect();
     };
@@ -96,6 +112,14 @@ class ChatWebSocket {
     }, this.reconnectDelay);
   }
 
+  private failAllPending(reason: string) {
+    for (const [id, pending] of this.pendingRequests) {
+      clearTimeout(pending.timer);
+      pending.reject(new Error(reason));
+      this.pendingRequests.delete(id);
+    }
+  }
+
   private async waitReady(): Promise<void> {
     this.connect();
     if (this.ws?.readyState === WebSocket.OPEN) return;
@@ -104,25 +128,97 @@ class ChatWebSocket {
     });
   }
 
+  private envelope(type: string, fields: Record<string, unknown> = {}): Record<string, unknown> {
+    return {
+      id: shortUID(),
+      timestamp: Math.floor(Date.now() / 1000),
+      version: CHAT_WS_PROTOCOL_VERSION,
+      conn_id: this.connId,
+      type,
+      ...fields,
+    };
+  }
+
   private send(payload: Record<string, unknown>) {
     if (this.ws?.readyState === WebSocket.OPEN) {
       this.ws.send(JSON.stringify(payload));
     }
   }
 
-  private resolveJoinWaiters(sessionId: string, ok: boolean, error?: string) {
-    const waiters = this.joinWaiters.get(sessionId);
-    if (!waiters?.length) return;
-    this.joinWaiters.delete(sessionId);
-    waiters.forEach(w => w(ok, error));
+  /**
+   * Send a control frame and wait for a matching ack / joined / stopped / error.
+   */
+  private async request(
+    type: string,
+    fields: Record<string, unknown>,
+    expect: string[],
+    timeoutMs = CHAT_WS_REQUEST_TIMEOUT_MS,
+  ): Promise<ChatWSServerMessage> {
+    await this.waitReady();
+    const payload = this.envelope(type, fields);
+    const requestId = String(payload.id);
+
+    return new Promise<ChatWSServerMessage>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.pendingRequests.delete(requestId);
+        reject(new Error(`Chat WS ${type} timed out after ${timeoutMs}ms`));
+      }, timeoutMs);
+
+      this.pendingRequests.set(requestId, {
+        resolve,
+        reject,
+        timer,
+        expect: new Set(expect),
+      });
+
+      this.send(payload);
+    });
+  }
+
+  private resolvePending(msg: ChatWSServerMessage) {
+    const requestId =
+      'request_id' in msg && typeof msg.request_id === 'string'
+        ? msg.request_id
+        : undefined;
+    if (!requestId) return false;
+
+    const pending = this.pendingRequests.get(requestId);
+    if (!pending) return false;
+
+    if (msg.type === 'error') {
+      clearTimeout(pending.timer);
+      this.pendingRequests.delete(requestId);
+      const code = msg.code != null ? ` [${msg.code}]` : '';
+      pending.reject(new Error(`${msg.error}${code}`));
+      return true;
+    }
+
+    if (pending.expect.has(msg.type)) {
+      clearTimeout(pending.timer);
+      this.pendingRequests.delete(requestId);
+      pending.resolve(msg);
+      return true;
+    }
+    return false;
   }
 
   private handleMessage(msg: ChatWSServerMessage) {
     if (msg.type === 'ping') return;
 
+    // Resolve awaitable control-frame waiters first
+    if (this.resolvePending(msg)) {
+      // Still apply side effects for joined / left / stopped / ack below when useful
+      if (msg.type === 'ack') return;
+      if (msg.type === 'error') {
+        const sid = msg.session_id || this.joinedSessionId;
+        if (sid) this.handlers.get(sid)?.onError?.(msg.error, msg.code);
+        else console.error('Chat WS error:', msg.error, msg.code);
+        return;
+      }
+    }
+
     if (msg.type === 'joined') {
       this.joinedSessionId = msg.session_id;
-      this.resolveJoinWaiters(msg.session_id, true);
       this.handlers.get(msg.session_id)?.onOpen?.();
       return;
     }
@@ -134,6 +230,14 @@ class ChatWebSocket {
       return;
     }
 
+    if (msg.type === 'stopped') {
+      return;
+    }
+
+    if (msg.type === 'ack') {
+      return;
+    }
+
     if (msg.type === 'stream_end') {
       this.handlers.get(msg.session_id)?.onStreamEnd?.();
       return;
@@ -141,17 +245,18 @@ class ChatWebSocket {
 
     if (msg.type === 'error') {
       const sid = msg.session_id || this.joinedSessionId;
-      if (sid && this.joinWaiters.has(sid)) {
-        this.resolveJoinWaiters(sid, false, msg.error);
-      }
-      if (sid) this.handlers.get(sid)?.onError?.(msg.error);
-      else console.error('Chat WS error:', msg.error);
+      if (sid) this.handlers.get(sid)?.onError?.(msg.error, msg.code);
+      else console.error('Chat WS error:', msg.error, msg.code);
       return;
     }
 
     if (msg.type === 'event') {
+      if (msg.event === 'status_update') {
+        const data = msg.data as StatusUpdateEventData;
+        this.handlers.get(msg.session_id)?.onStatusUpdate?.(data.agent_status);
+      }
       this.handlers.get(msg.session_id)?.onEvent?.({
-        event: msg.event as AgentSSEEvent['event'],
+        event: msg.event as AgentSSEEvent['event'] | 'status_update',
         data: msg.data,
       });
     }
@@ -174,26 +279,25 @@ class ChatWebSocket {
 
     this.pendingJoin = { sessionId, lastEventId };
     if (this.joinedSessionId && this.joinedSessionId !== sessionId) {
-      this.send({ type: 'leave_session', session_id: this.joinedSessionId });
+      // Fire-and-forget leave (no version required server-side)
+      this.send({
+        type: 'leave_session',
+        session_id: this.joinedSessionId,
+        id: shortUID(),
+        timestamp: Math.floor(Date.now() / 1000),
+        conn_id: this.connId,
+      });
       this.joinedSessionId = null;
     }
 
-    const joined = new Promise<void>((resolve, reject) => {
-      const waiters = this.joinWaiters.get(sessionId) || [];
-      waiters.push((ok, error) => {
-        if (ok) resolve();
-        else reject(new Error(error || 'Failed to join session'));
-      });
-      this.joinWaiters.set(sessionId, waiters);
-    });
-
-    this.send({
-      type: 'join_session',
-      session_id: sessionId,
-      last_event_id: lastEventId,
-    });
-
-    await joined;
+    await this.request(
+      'join_session',
+      {
+        session_id: sessionId,
+        last_event_id: lastEventId,
+      },
+      ['joined'],
+    );
   }
 
   async leaveSession(sessionId?: string) {
@@ -203,7 +307,13 @@ class ChatWebSocket {
       this.pendingJoin = null;
     }
     if (this.ws?.readyState === WebSocket.OPEN) {
-      this.send({ type: 'leave_session', session_id: target });
+      this.send({
+        type: 'leave_session',
+        session_id: target,
+        id: shortUID(),
+        timestamp: Math.floor(Date.now() / 1000),
+        conn_id: this.connId,
+      });
     }
     if (this.joinedSessionId === target) {
       this.joinedSessionId = null;
@@ -220,24 +330,31 @@ class ChatWebSocket {
     if (this.joinedSessionId !== params.sessionId) {
       await this.joinSession(params.sessionId, params.lastEventId);
     }
-    this.send({
-      type: 'chat',
-      session_id: params.sessionId,
-      message: params.message || '',
-      last_event_id: params.lastEventId,
-      timestamp: Math.floor(Date.now() / 1000),
-      attachments: params.attachments || [],
-    });
+    // Await ack so caller knows the server accepted the chat frame
+    await this.request(
+      'chat',
+      {
+        session_id: params.sessionId,
+        message: params.message || '',
+        last_event_id: params.lastEventId,
+        attachments: params.attachments || [],
+      },
+      ['ack'],
+    );
   }
 
   async stopSession(sessionId: string) {
-    await this.waitReady();
-    this.send({ type: 'stop_session', session_id: sessionId });
+    await this.request(
+      'stop_session',
+      { session_id: sessionId },
+      ['stopped'],
+    );
   }
 
   destroy() {
     this.closed = true;
     if (this.reconnectTimer) clearTimeout(this.reconnectTimer);
+    this.failAllPending('WebSocket destroyed');
     this.handlers.clear();
     this.ws?.close();
     this.ws = null;

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1,6 +1,7 @@
 // Backend API client configuration
 import axios, { AxiosError } from 'axios';
 import { clearStoredTokens, getStoredToken, getStoredRefreshToken, storeToken, storeRefreshToken } from './auth';
+import { eventBus } from '../utils/eventBus';
 
 // API configuration
 export const API_CONFIG = {
@@ -132,7 +133,7 @@ const refreshAuthToken = async (): Promise<string | null> => {
     processQueue(refreshError, null);
     
     // Emit logout event
-    window.dispatchEvent(new CustomEvent('auth:logout'));
+    eventBus.emit('auth:logout');
     
     // Redirect to login page
     redirectToLogin();

--- a/frontend/src/components/ComputerPanel.vue
+++ b/frontend/src/components/ComputerPanel.vue
@@ -63,8 +63,7 @@ import type { ToolContent } from '../types/message'
 import type { PlanEventData } from '../types/event'
 import ComputerPanelContent from './ComputerPanelContent.vue'
 import { useResizeObserver } from '../composables/useResizeObserver'
-import { eventBus } from '../utils/eventBus'
-import { EVENT_SHOW_FILE_PREVIEWER, EVENT_SHOW_COMPUTER_PANEL } from '../constants/event'
+import { eventBus, UI_SHOW_FILE_PREVIEWER, UI_SHOW_COMPUTER_PANEL } from '../utils/eventBus'
 
 export type ComputerPresentation = 'sidebar' | 'dialog'
 
@@ -100,7 +99,8 @@ defineProps<{
 }>()
 
 const showComputerPanel = (content: ToolContent, isLive: boolean = false) => {
-  eventBus.emit(EVENT_SHOW_COMPUTER_PANEL)
+  // Notify file previewer: dismiss side mode only (center/fullscreen stay)
+  eventBus.emit(UI_SHOW_COMPUTER_PANEL)
   visible.value = true
   toolContent.value = content
   isShow.value = true
@@ -130,14 +130,17 @@ const onUseComputer = () => {
   emit('useComputer')
 }
 
+/** Opening file previewer hides the computer panel (mutual exclusion). */
+const onShowFilePreviewer = () => {
+  visible.value = false
+}
+
 onMounted(() => {
-  eventBus.on(EVENT_SHOW_FILE_PREVIEWER, () => {
-    visible.value = false
-  })
+  eventBus.on(UI_SHOW_FILE_PREVIEWER, onShowFilePreviewer)
 })
 
 onUnmounted(() => {
-  eventBus.off(EVENT_SHOW_FILE_PREVIEWER)
+  eventBus.off(UI_SHOW_FILE_PREVIEWER, onShowFilePreviewer)
 })
 
 defineExpose({

--- a/frontend/src/components/FilePreviewer.vue
+++ b/frontend/src/components/FilePreviewer.vue
@@ -30,8 +30,8 @@
   </div>
 
   <!-- Official portal: center mask + panel / fullscreen.
-       Keep center/fullscreen above Computer sidebar updates — do not dismiss
-       when EVENT_SHOW_COMPUTER_PANEL fires during a running task. -->
+       Keep center/fullscreen above Computer sidebar updates — only side
+       preview is dismissed on ui:show-computer-panel (see useFilePreviewer). -->
   <Teleport to="body">
     <div
       v-if="isShow && fileInfo && fileType && (viewMode === 'center' || viewMode === 'fullscreen')"

--- a/frontend/src/components/SessionFileList.vue
+++ b/frontend/src/components/SessionFileList.vue
@@ -61,7 +61,7 @@
 
 <script setup lang="ts">
 import { X, Download, File } from 'lucide-vue-next';
-import { ref, watch } from 'vue';
+import { ref, watch, onMounted, onBeforeUnmount } from 'vue';
 import { useRoute } from 'vue-router';
 import type { FileInfo } from '../api/file';
 import { getFileDownloadUrl } from '../api/file';
@@ -70,6 +70,7 @@ import { formatRelativeTime, parseISODateTime } from '../utils/time';
 import { getFileType } from '../utils/fileType';
 import { useSessionFileList } from '../composables/useSessionFileList';
 import { useFilePreviewer } from '../composables/useFilePreviewer';
+import { eventBus } from '../utils/eventBus';
 
 const route = useRoute();
 const files = ref<FileInfo[]>([]);
@@ -92,9 +93,30 @@ const downloadFile = async (fileInfo: FileInfo) => {
     window.open(url, '_blank');
 }
 
-const showFile = (file: FileInfo) => {
-    showFilePreviewer(file);
+const showFile = (fileInfo: FileInfo) => {
+    showFilePreviewer(fileInfo);
     hideSessionFileList();
+}
+
+const onFileUpdate = (payload: {
+    sessionId: string
+    path: string
+    file?: FileInfo | null
+}) => {
+    const sessionId = route.params.sessionId as string
+    if (!sessionId || payload.sessionId !== sessionId) return
+    if (!visible.value) return
+    if (payload.file) {
+        const idx = files.value.findIndex(f => f.file_id === payload.file!.file_id
+            || f.filename === payload.file!.filename)
+        if (idx >= 0) {
+            files.value.splice(idx, 1, payload.file)
+        } else {
+            files.value = [payload.file, ...files.value]
+        }
+    } else {
+        void fetchFiles(sessionId)
+    }
 }
 
 watch(visible, (newVisible) => {
@@ -104,5 +126,13 @@ watch(visible, (newVisible) => {
             fetchFiles(sessionId);
         }
     }
+})
+
+onMounted(() => {
+    eventBus.on('tool:file_update', onFileUpdate)
+})
+
+onBeforeUnmount(() => {
+    eventBus.off('tool:file_update', onFileUpdate)
 })
 </script>

--- a/frontend/src/components/TakeOverView.vue
+++ b/frontend/src/components/TakeOverView.vue
@@ -21,6 +21,7 @@ import { computed, ref, onMounted, onBeforeUnmount } from 'vue';
 import { useRoute } from 'vue-router';
 import { useI18n } from 'vue-i18n';
 import VNCViewer from './VNCViewer.vue';
+import { eventBus } from '../utils/eventBus';
 
 const route = useRoute();
 const { t } = useI18n();
@@ -29,13 +30,9 @@ const { t } = useI18n();
 const takeOverActive = ref(false);
 const currentSessionId = ref('');
 
-
-
-// Listen to takeover events
-const handleTakeOverEvent = (event: Event) => {
-    const customEvent = event as CustomEvent;
-    takeOverActive.value = customEvent.detail.active;
-    currentSessionId.value = customEvent.detail.sessionId;
+const handleTakeOverEvent = (payload: { sessionId: string; active: boolean }) => {
+    takeOverActive.value = payload.active;
+    currentSessionId.value = payload.sessionId;
 };
 
 // Calculate whether to show takeover view
@@ -51,16 +48,12 @@ const shouldShow = computed(() => {
     return !!sessionId && vnc === '1';
 });
 
-// Add event listener when component is mounted
 onMounted(() => {
-    window.addEventListener('takeover', handleTakeOverEvent as EventListener);
+    eventBus.on('ui:takeover', handleTakeOverEvent);
 });
 
-
-
-// Remove event listener when component is unmounted
 onBeforeUnmount(() => {
-    window.removeEventListener('takeover', handleTakeOverEvent as EventListener);
+    eventBus.off('ui:takeover', handleTakeOverEvent);
 });
 
 // Get session ID

--- a/frontend/src/components/toolViews/BrowserToolView.vue
+++ b/frontend/src/components/toolViews/BrowserToolView.vue
@@ -37,6 +37,7 @@ import { ref, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
 import VNCViewer from '@/components/VNCViewer.vue';
 import TakeOverIcon from '@/components/icons/TakeOverIcon.vue';
+import { eventBus } from '@/utils/eventBus';
 
 const props = defineProps<{
   sessionId: string;
@@ -56,11 +57,9 @@ watch(() => props.toolContent?.content?.screenshot, () => {
 }, { immediate: true });
 
 const takeOver = () => {
-  window.dispatchEvent(new CustomEvent('takeover', {
-    detail: {
-      sessionId: props.sessionId,
-      active: true
-    }
-  }));
+  eventBus.emit('ui:takeover', {
+    sessionId: props.sessionId,
+    active: true,
+  });
 };
 </script>

--- a/frontend/src/components/toolViews/FileToolView.vue
+++ b/frontend/src/components/toolViews/FileToolView.vue
@@ -46,13 +46,14 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, toRef, watch } from 'vue';
+import { ref, computed, toRef, watch, onMounted, onBeforeUnmount } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { ToolContent } from '@/types/message';
 import { viewFile } from '@/api/agent';
 import MonacoEditor from '@/components/ui/MonacoEditor.vue';
 import MonacoDiffEditor from '@/components/ui/MonacoDiffEditor.vue';
 import { useLiveToolContent } from '@/composables/useLiveToolContent';
+import { eventBus } from '@/utils/eventBus';
 
 type FileTab = 'diff' | 'oldContent' | 'newContent';
 
@@ -146,5 +147,29 @@ useLiveToolContent({
   live: toRef(props, 'live'),
   targetKey: filePath,
   load: loadFileContent,
+  // Official: file_update over WS — no 5s REST poll
+  pushOnly: true,
 });
+
+const onFileUpdate = (payload: {
+  sessionId: string
+  path: string
+  content: string
+  oldContent?: string | null
+}) => {
+  if (payload.sessionId !== props.sessionId) return
+  if (!filePath.value || payload.path !== filePath.value) return
+  fileContent.value = payload.content
+  if (payload.oldContent !== undefined) {
+    oldContent.value = payload.oldContent ?? ''
+  }
+}
+
+onMounted(() => {
+  eventBus.on('tool:file_update', onFileUpdate)
+})
+
+onBeforeUnmount(() => {
+  eventBus.off('tool:file_update', onFileUpdate)
+})
 </script>

--- a/frontend/src/components/toolViews/ShellToolView.vue
+++ b/frontend/src/components/toolViews/ShellToolView.vue
@@ -16,6 +16,7 @@ import '@xterm/xterm/css/xterm.css';
 import { viewShellSession } from '@/api/agent';
 import { ToolContent } from '@/types/message';
 import { useLiveToolContent } from '@/composables/useLiveToolContent';
+import { eventBus } from '@/utils/eventBus';
 
 const props = defineProps<{
   sessionId: string;
@@ -209,15 +210,32 @@ useLiveToolContent({
   live: toRef(props, 'live'),
   targetKey: shellSessionId,
   load: loadShellContent,
+  // Official: terminalUpdate over WS — no 5s REST poll
+  pushOnly: true,
 });
 
 watch(() => props.toolContent.content?.console, () => {
   if (!props.live) loadShellContent();
 });
 
+const onTerminalUpdate = (payload: {
+  sessionId: string
+  shellId: string
+  output: unknown
+}) => {
+  if (payload.sessionId !== props.sessionId) return
+  if (!shellSessionId.value || payload.shellId !== shellSessionId.value) return
+  void nextTick().then(() => {
+    if (!term) initTerminal()
+    writeTerminal(consoleToText(payload.output))
+    fit()
+  })
+}
+
 onMounted(() => {
   initTerminal();
   loadShellContent();
+  eventBus.on('tool:terminal_update', onTerminalUpdate)
   themeObserver = new MutationObserver(() => {
     const dark = detectDark();
     if (dark !== isDark.value && term) {
@@ -229,6 +247,7 @@ onMounted(() => {
 });
 
 onBeforeUnmount(() => {
+  eventBus.off('tool:terminal_update', onTerminalUpdate)
   themeObserver?.disconnect();
   themeObserver = null;
   resizeObserver?.disconnect();

--- a/frontend/src/components/toolViews/ShellToolView.vue
+++ b/frontend/src/components/toolViews/ShellToolView.vue
@@ -38,6 +38,8 @@ let fitAddon: FitAddon | null = null;
 let resizeObserver: ResizeObserver | null = null;
 let themeObserver: MutationObserver | null = null;
 let lastText = '';
+let terminalDebounceTimer: number | null = null;
+let pendingTerminalOutput: unknown = null;
 
 const shellSessionId = computed(() => {
   if (props.toolContent && props.toolContent.args.id) {
@@ -225,11 +227,19 @@ const onTerminalUpdate = (payload: {
 }) => {
   if (payload.sessionId !== props.sessionId) return
   if (!shellSessionId.value || payload.shellId !== shellSessionId.value) return
-  void nextTick().then(() => {
-    if (!term) initTerminal()
-    writeTerminal(consoleToText(payload.output))
-    fit()
-  })
+  pendingTerminalOutput = payload.output
+  if (terminalDebounceTimer != null) return
+  // Coalesce rapid terminal_update frames (~1/s from server, bursts on catch-up)
+  terminalDebounceTimer = window.setTimeout(() => {
+    terminalDebounceTimer = null
+    const output = pendingTerminalOutput
+    pendingTerminalOutput = null
+    void nextTick().then(() => {
+      if (!term) initTerminal()
+      writeTerminal(consoleToText(output))
+      fit()
+    })
+  }, 100)
 }
 
 onMounted(() => {
@@ -247,6 +257,10 @@ onMounted(() => {
 });
 
 onBeforeUnmount(() => {
+  if (terminalDebounceTimer != null) {
+    clearTimeout(terminalDebounceTimer)
+    terminalDebounceTimer = null
+  }
   eventBus.off('tool:terminal_update', onTerminalUpdate)
   themeObserver?.disconnect();
   themeObserver = null;

--- a/frontend/src/components/ui/Toast.vue
+++ b/frontend/src/components/ui/Toast.vue
@@ -49,6 +49,7 @@ import { ref, onMounted, onUnmounted } from 'vue';
 import ErrorIcon from '@/components/icons/ErrorIcon.vue';
 import InfoIcon from '@/components/icons/InfoIcon.vue';
 import SuccessIcon from '@/components/icons/SuccessIcon.vue';
+import { eventBus } from '@/utils/eventBus';
 
 interface Toast {
   id: number;
@@ -84,19 +85,16 @@ const removeToast = (id: number) => {
   }
 };
 
-// Create custom event bus
-const handleToastEvent = (event: CustomEvent) => {
-  const { message, type, duration } = event.detail;
-  addToast(message, type, duration);
+const handleToastEvent = (detail: { message: string; type: 'error' | 'info' | 'success'; duration: number }) => {
+  addToast(detail.message, detail.type, detail.duration);
 };
 
-// Listen for custom events
 onMounted(() => {
-  window.addEventListener('toast', handleToastEvent as EventListener);
+  eventBus.on('ui:toast', handleToastEvent);
 });
 
 onUnmounted(() => {
-  window.removeEventListener('toast', handleToastEvent as EventListener);
+  eventBus.off('ui:toast', handleToastEvent);
 });
 
 // Expose methods for external use

--- a/frontend/src/composables/useAgentEvents.ts
+++ b/frontend/src/composables/useAgentEvents.ts
@@ -137,6 +137,14 @@ export function useAgentEvents(state: AgentEventState, options: AgentEventOption
   };
 
   const handleEvent = (event: AgentSSEEvent) => {
+    // Control / live computer-panel events — not part of the chat message list
+    if (
+      event.event === 'status_update'
+      || event.event === 'terminal_update'
+      || event.event === 'file_update'
+    ) {
+      return;
+    }
     if (event.event === 'message') {
       handleMessageEvent(event.data as MessageEventData);
     } else if (event.event === 'tool') {
@@ -144,7 +152,7 @@ export function useAgentEvents(state: AgentEventState, options: AgentEventOption
     } else if (event.event === 'step') {
       handleStepEvent(event.data as StepEventData);
     } else if (event.event === 'done') {
-      // Loading state is cleared when the SSE connection closes
+      // Loading state is cleared when the stream ends / status_update arrives
     } else if (event.event === 'wait') {
       // TODO: handle wait event
     } else if (event.event === 'error') {

--- a/frontend/src/composables/useAuth.ts
+++ b/frontend/src/composables/useAuth.ts
@@ -1,4 +1,4 @@
-import { ref, computed, onMounted } from 'vue'
+import { ref, computed, onMounted, onUnmounted } from 'vue'
 import { 
   login as apiLogin, 
   register as apiRegister, 
@@ -19,6 +19,7 @@ import {
   type RegisterResponse
 } from '../api/auth'
 import { getCachedAuthProvider } from '../api/config'
+import { eventBus } from '../utils/eventBus'
 
 // Global auth state
 const currentUser = ref<User | null>(null)
@@ -216,10 +217,14 @@ export function useAuth() {
   }
 
   // Listen for logout events from token refresh interceptor
+  const onAuthLogout = () => {
+    logout(true) // Silent logout
+  }
   onMounted(() => {
-    window.addEventListener('auth:logout', () => {
-      logout(true) // Silent logout
-    })
+    eventBus.on('auth:logout', onAuthLogout)
+  })
+  onUnmounted(() => {
+    eventBus.off('auth:logout', onAuthLogout)
   })
 
   // Auto-initialize auth state when composable is first used

--- a/frontend/src/composables/useFilePreviewer.ts
+++ b/frontend/src/composables/useFilePreviewer.ts
@@ -1,8 +1,7 @@
 import { computed, ref, watch, type Ref } from 'vue'
 import { useMediaQuery } from '@vueuse/core'
 import type { FileInfo } from '../api/file'
-import { eventBus } from '../utils/eventBus'
-import { EVENT_SHOW_FILE_PREVIEWER } from '../constants/event'
+import { eventBus, UI_SHOW_FILE_PREVIEWER, UI_SHOW_COMPUTER_PANEL } from '../utils/eventBus'
 import { router } from '../router'
 
 /** Official filePreviewerSlice viewMode — default is center */
@@ -67,10 +66,16 @@ export function useFilePreviewer() {
       },
       { immediate: true },
     )
+    // Official: keep center/fullscreen above Computer; only dismiss side (space conflict)
+    eventBus.on(UI_SHOW_COMPUTER_PANEL, () => {
+      if (isShow.value && viewMode.value === 'side') {
+        isShow.value = false
+      }
+    })
   }
 
   const showFilePreviewer = (file: FileInfo, mode?: FilePreviewViewMode) => {
-    eventBus.emit(EVENT_SHOW_FILE_PREVIEWER)
+    eventBus.emit(UI_SHOW_FILE_PREVIEWER)
     fileInfo.value = file
     const canUseSide = canUseSideFilePreview.value
     if (mode) {

--- a/frontend/src/composables/useLiveToolContent.ts
+++ b/frontend/src/composables/useLiveToolContent.ts
@@ -7,7 +7,8 @@ const DEFAULT_REFRESH_INTERVAL_MS = 5000
  * Shared load + auto-refresh behavior for tool views (file, shell, ...).
  *
  * Loads content on mount and whenever the tool content changes; while `live`
- * is true and a target key is present, re-loads on a fixed interval.
+ * is true and a target key is present, re-loads on a fixed interval — unless
+ * `pushOnly` (official WS terminalUpdate / file_update drives the panel).
  */
 export function useLiveToolContent(options: {
   toolContent: Ref<ToolContent>
@@ -16,10 +17,18 @@ export function useLiveToolContent(options: {
   targetKey: Ref<string>
   load: () => void | Promise<void>
   intervalMs?: number
+  /** When true, skip REST polling — rely on WS push + toolContent watches. */
+  pushOnly?: Ref<boolean> | boolean
 }) {
   const { toolContent, live, targetKey, load } = options
   const intervalMs = options.intervalMs ?? DEFAULT_REFRESH_INTERVAL_MS
   const refreshTimer = ref<number | null>(null)
+
+  const isPushOnly = () => {
+    const v = options.pushOnly
+    if (v == null) return false
+    return typeof v === 'boolean' ? v : v.value
+  }
 
   const stopAutoRefresh = () => {
     if (refreshTimer.value) {
@@ -30,6 +39,7 @@ export function useLiveToolContent(options: {
 
   const startAutoRefresh = () => {
     stopAutoRefresh()
+    if (isPushOnly()) return
     if (live.value && targetKey.value) {
       refreshTimer.value = window.setInterval(() => {
         load()

--- a/frontend/src/constants/event.ts
+++ b/frontend/src/constants/event.ts
@@ -1,2 +1,10 @@
-export const EVENT_SHOW_COMPUTER_PANEL = 'EVENT_SHOW_COMPUTER_PANEL'
-export const EVENT_SHOW_FILE_PREVIEWER = 'EVENT_SHOW_FILE_PREVIEWER'
+/**
+ * Re-exports UI panel event names from the typed eventBus.
+ * Prefer importing from `@/utils/eventBus` for new code.
+ */
+export {
+  UI_SHOW_FILE_PREVIEWER as EVENT_SHOW_FILE_PREVIEWER,
+  UI_SHOW_COMPUTER_PANEL as EVENT_SHOW_COMPUTER_PANEL,
+  UI_SHOW_FILE_PREVIEWER,
+  UI_SHOW_COMPUTER_PANEL,
+} from '../utils/eventBus'

--- a/frontend/src/pages/ChatPage.vue
+++ b/frontend/src/pages/ChatPage.vue
@@ -771,9 +771,10 @@ const handleTakeControl = () => {
     realTime.value = true;
     computerPanel.value?.showComputerPanel(browserTool, true);
   }
-  window.dispatchEvent(new CustomEvent('takeover', {
-    detail: { sessionId: sessionId.value, active: true }
-  }));
+  eventBus.emit('ui:takeover', {
+    sessionId: sessionId.value,
+    active: true,
+  });
 }
 
 const handleSelectTool = (tool: ToolContent) => {

--- a/frontend/src/pages/ChatPage.vue
+++ b/frontend/src/pages/ChatPage.vue
@@ -164,7 +164,7 @@ import ChatTaskCompleted from '../components/ChatTaskCompleted.vue';
 import ChatWaitingContinue from '../components/ChatWaitingContinue.vue';
 import * as agentApi from '../api/agent';
 import { Message, MessageContent, ToolContent, AttachmentsContent, StepContent, isConsecutiveAssistant } from '../types/message';
-import { PlanEventData, AgentSSEEvent } from '../types/event';
+import { PlanEventData, AgentSSEEvent, type AgentStatus, type TerminalUpdateEventData, type FileUpdateEventData } from '../types/event';
 import { useAgentEvents } from '../composables/useAgentEvents';
 import ComputerPanel from '../components/ComputerPanel.vue'
 import { ArrowDown, FileSearch, Lock, Globe, Link, Check, Ellipsis, Pencil, Star, Trash, FolderPlus, Folder, FolderSync, Pin } from 'lucide-vue-next';
@@ -359,6 +359,9 @@ const { handleEvent: handleAgentEvent } = useAgentEvents(
 
 const handleEvent = (event: AgentSSEEvent) => {
   handleAgentEvent(event);
+  if (event.event === 'status_update') {
+    return;
+  }
   if (event.event === 'done') {
     sessionStatus.value = SessionStatus.COMPLETED;
   } else if (event.event === 'wait') {
@@ -367,6 +370,30 @@ const handleEvent = (event: AgentSSEEvent) => {
     if (sessionStatus.value !== SessionStatus.WAITING) {
       sessionStatus.value = SessionStatus.RUNNING;
     }
+  }
+};
+
+/** Drive loading / sessionStatus from authoritative WS status_update. */
+const applyAgentStatus = (agentStatus: AgentStatus) => {
+  if (agentStatus === 'running') {
+    isLoading.value = true;
+    sessionStatus.value = SessionStatus.RUNNING;
+  } else if (agentStatus === 'waiting') {
+    isLoading.value = false;
+    sessionStatus.value = SessionStatus.WAITING;
+  } else if (agentStatus === 'pending') {
+    isLoading.value = false;
+    sessionStatus.value = SessionStatus.PENDING;
+  } else if (agentStatus === 'error') {
+    isLoading.value = false;
+    // Keep sessionStatus as-is unless unknown; treat like completed for footer UX
+    if (sessionStatus.value === SessionStatus.RUNNING || sessionStatus.value === SessionStatus.PENDING) {
+      sessionStatus.value = SessionStatus.COMPLETED;
+    }
+  } else {
+    // completed
+    isLoading.value = false;
+    sessionStatus.value = SessionStatus.COMPLETED;
   }
 };
 
@@ -401,6 +428,56 @@ watch(messages, async () => {
 }, { deep: true });
 
 
+
+const chatStreamCallbacks = (): agentApi.ChatStreamCallbacks => ({
+  onOpen: () => {
+    // Keep loading only when we already marked a turn in flight (chat send)
+  },
+  onMessage: ({ event, data }) => {
+    if (event === 'terminal_update') {
+      const d = data as TerminalUpdateEventData;
+      if (!sessionId.value) return;
+      eventBus.emit('tool:terminal_update', {
+        sessionId: sessionId.value,
+        shellId: d.shell_id,
+        output: d.output,
+      });
+      return;
+    }
+    if (event === 'file_update') {
+      const d = data as FileUpdateEventData;
+      if (!sessionId.value) return;
+      eventBus.emit('tool:file_update', {
+        sessionId: sessionId.value,
+        path: d.path,
+        content: d.content,
+        oldContent: d.old_content,
+        file: d.file ?? null,
+      });
+      return;
+    }
+    handleEvent({
+      event: event as AgentSSEEvent['event'],
+      data: data as AgentSSEEvent['data'],
+    });
+  },
+  onStatusUpdate: (agentStatus) => {
+    applyAgentStatus(agentStatus);
+  },
+  onClose: () => {
+    // Loading is driven by status_update (follows stream_end). Do not clear here.
+    if (cancelCurrentChat.value) {
+      cancelCurrentChat.value = null;
+    }
+  },
+  onError: (error) => {
+    console.error('Chat error:', error);
+    isLoading.value = false;
+    if (cancelCurrentChat.value) {
+      cancelCurrentChat.value = null;
+    }
+  },
+});
 
 const handleSubmit = () => {
   chat(inputMessage.value, attachments.value);
@@ -445,7 +522,6 @@ const chat = async (message: string = '', files: FileInfo[] = []) => {
   isLoading.value = true;
 
   try {
-    // Use the split event handler function and store the cancel function
     cancelCurrentChat.value = await agentApi.chatWithSession(
       sessionId.value,
       message,
@@ -453,30 +529,10 @@ const chat = async (message: string = '', files: FileInfo[] = []) => {
       files.map((file: FileInfo) => ({file_id : file.file_id, 
                                         filename : file.filename})),
       {
+        ...chatStreamCallbacks(),
         onOpen: () => {
           isLoading.value = true;
         },
-        onMessage: ({ event, data }) => {
-          handleEvent({
-            event: event as AgentSSEEvent['event'],
-            data: data as AgentSSEEvent['data']
-          });
-        },
-        onClose: () => {
-          isLoading.value = false;
-          // Clear the cancel function when connection is closed normally
-          if (cancelCurrentChat.value) {
-            cancelCurrentChat.value = null;
-          }
-        },
-        onError: (error) => {
-          console.error('Chat error:', error);
-          isLoading.value = false;
-          // Clear the cancel function when there's an error
-          if (cancelCurrentChat.value) {
-            cancelCurrentChat.value = null;
-          }
-        }
       }
     );
   } catch (error) {
@@ -504,10 +560,42 @@ const restoreSession = async () => {
     handleEvent(event);
   }
   realTime.value = true;
-  // Only resume the live stream while the agent is running. Idle join no longer
-  // emits stream_end; pending/completed sessions must not leave isLoading stuck.
-  if (session.status === SessionStatus.RUNNING) {
-    await chat();
+
+  // Always join the chat channel (status_update + idle Mongo catch-up).
+  // Only resume the live Redis stream while the agent is running — idle join
+  // no longer emits stream_end, so this will not stick isLoading.
+  if (cancelCurrentChat.value) {
+    cancelCurrentChat.value();
+    cancelCurrentChat.value = null;
+  }
+  try {
+    if (session.status === SessionStatus.RUNNING) {
+      isLoading.value = true;
+      cancelCurrentChat.value = await agentApi.chatWithSession(
+        sessionId.value,
+        '',
+        lastEventId.value,
+        undefined,
+        {
+          ...chatStreamCallbacks(),
+          onOpen: () => {
+            isLoading.value = true;
+          },
+        },
+      );
+    } else {
+      cancelCurrentChat.value = await agentApi.chatWithSession(
+        sessionId.value,
+        '',
+        lastEventId.value,
+        undefined,
+        chatStreamCallbacks(),
+      );
+    }
+  } catch (error) {
+    console.error('Failed to join chat session:', error);
+    isLoading.value = false;
+    cancelCurrentChat.value = null;
   }
   agentApi.clearUnreadMessageCount(sessionId.value);
 }

--- a/frontend/src/types/event.ts
+++ b/frontend/src/types/event.ts
@@ -1,13 +1,35 @@
 import type { FileInfo } from '../api/file';
 
+/** Wire agent_status from chat WS status_update (official Manus-aligned). */
+export type AgentStatus = 'pending' | 'running' | 'waiting' | 'completed' | 'error';
+
 export type AgentSSEEvent = {
-  event: 'tool' | 'step' | 'message' | 'error' | 'done' | 'title' | 'wait' | 'plan' | 'attachments';
-  data: ToolEventData | StepEventData | MessageEventData | ErrorEventData | DoneEventData | TitleEventData | WaitEventData | PlanEventData;
+  event: 'tool' | 'step' | 'message' | 'error' | 'done' | 'title' | 'wait' | 'plan' | 'attachments' | 'status_update' | 'terminal_update' | 'file_update';
+  data: ToolEventData | StepEventData | MessageEventData | ErrorEventData | DoneEventData | TitleEventData | WaitEventData | PlanEventData | StatusUpdateEventData | TerminalUpdateEventData | FileUpdateEventData;
 }
 
 export interface BaseEventData {
   event_id: string;
   timestamp: number;
+}
+
+export interface StatusUpdateEventData extends BaseEventData {
+  agent_status: AgentStatus;
+}
+
+/** Official Manus ``terminalUpdate`` — live shell console push. */
+export interface TerminalUpdateEventData extends BaseEventData {
+  shell_id: string;
+  output: unknown;
+  description?: string | null;
+}
+
+/** Official text_editor / file panel content push. */
+export interface FileUpdateEventData extends BaseEventData {
+  path: string;
+  content: string;
+  old_content?: string | null;
+  file?: FileInfo | null;
 }
 
 export interface ToolEventData extends BaseEventData {

--- a/frontend/src/utils/eventBus.ts
+++ b/frontend/src/utils/eventBus.ts
@@ -1,10 +1,34 @@
 import mitt from 'mitt'
+import type { FileInfo } from '../api/file'
 
-/** Keep string events for panel toggles; typed keys for project/session refresh */
+/** UI mutual-exclusion / panel chrome */
+export const UI_SHOW_FILE_PREVIEWER = 'ui:show-file-previewer' as const
+export const UI_SHOW_COMPUTER_PANEL = 'ui:show-computer-panel' as const
+
+/**
+ * Typed app-wide mitt bus. No `[key: string]` escape — new events must be declared here.
+ *
+ * Window CustomEvents (`takeover`, `toast`, `auth:logout`) stay on `window` for now.
+ */
 export type AppEvents = {
   'projects:changed': undefined
   'sessions:changed': undefined
-  [key: string]: unknown
+  'ui:show-file-previewer': undefined
+  'ui:show-computer-panel': undefined
+  /** Official terminalUpdate — live shell console */
+  'tool:terminal_update': {
+    sessionId: string
+    shellId: string
+    output: unknown
+  }
+  /** Official file / text_editor panel update */
+  'tool:file_update': {
+    sessionId: string
+    path: string
+    content: string
+    oldContent?: string | null
+    file?: FileInfo | null
+  }
 }
 
 export const eventBus = mitt<AppEvents>()

--- a/frontend/src/utils/eventBus.ts
+++ b/frontend/src/utils/eventBus.ts
@@ -7,14 +7,25 @@ export const UI_SHOW_COMPUTER_PANEL = 'ui:show-computer-panel' as const
 
 /**
  * Typed app-wide mitt bus. No `[key: string]` escape — new events must be declared here.
- *
- * Window CustomEvents (`takeover`, `toast`, `auth:logout`) stay on `window` for now.
  */
 export type AppEvents = {
   'projects:changed': undefined
   'sessions:changed': undefined
   'ui:show-file-previewer': undefined
   'ui:show-computer-panel': undefined
+  /** VNC browser takeover overlay */
+  'ui:takeover': {
+    sessionId: string
+    active: boolean
+  }
+  /** Global toast notifications */
+  'ui:toast': {
+    message: string
+    type: 'error' | 'info' | 'success'
+    duration: number
+  }
+  /** Token refresh failed — clear session silently */
+  'auth:logout': undefined
   /** Official terminalUpdate — live shell console */
   'tool:terminal_update': {
     sessionId: string

--- a/frontend/src/utils/toast.ts
+++ b/frontend/src/utils/toast.ts
@@ -2,6 +2,7 @@
  * Toast service
  * Provide global Toast message notification functionality
  */
+import { eventBus } from './eventBus'
 
 type ToastType = 'error' | 'info' | 'success';
 
@@ -24,18 +25,11 @@ export function showToast(options: ToastOptions | string): void {
     config = options;
   }
   
-  // Default configuration
-  const detail = {
+  eventBus.emit('ui:toast', {
     message: config.message,
     type: config.type || 'info',
-    duration: config.duration === undefined ? 3000 : config.duration
-  };
-  
-  // Create custom event
-  const event = new CustomEvent('toast', { detail });
-  
-  // Trigger event
-  window.dispatchEvent(event);
+    duration: config.duration === undefined ? 3000 : config.duration,
+  });
 }
 
 // Convenient methods
@@ -71,4 +65,4 @@ if (typeof window !== 'undefined') {
     info: showInfoToast,
     success: showSuccessToast
   };
-} 
+}


### PR DESCRIPTION
## Summary
- Add chat WS protocol v2: versioned envelopes, awaitable `request_id` ack/timeout, authoritative `status_update`, idle join Mongo catch-up, and typed error codes.
- Push live `terminal_update` / `file_update` over WS so Computer shell/file panels stop 5s REST polling; debounce xterm writes and cheap console fingerprints.
- Always join on session restore (status only when idle; resume stream only when running); tighten typed `eventBus` for panel chrome, takeover, toast, and auth logout.

## Test plan
- [ ] Open idle session → join ack + `status_update`, no stuck thinking / no idle `stream_end`
- [ ] Send chat → `version: 2` + `ack` + `status_update(running)`; show「Manus 正在思考」until first visible output
- [ ] Shell tool → `terminal_update` streams into Computer terminal without REST poll
- [ ] File write → `file_update` updates monaco + SessionFileList when open
- [ ] Switch sessions → leave/join with versioned frames; re-join idle then send works
- [ ] Stop task → `stopped` + `status_update(completed)`
- [ ] File previewer side vs Computer mutual exclusion; takeover / toast / auth logout via eventBus
- [ ] `cd frontend && npm run type-check`


Made with [Cursor](https://cursor.com)