### PR TITLE
refactor: remove leftover SSE naming after WebSocket migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ See [docs/roadmap.md](docs/en/roadmap.md) for the full checklist (including comp
 2. The Sandbox is an Ubuntu Docker environment that starts Chrome browser and API services for tools like File/Shell.
 3. Web sends user messages to the session ID, and when the Server receives user messages, it forwards them to the PlanAct Agent for processing.
 4. During processing, the PlanAct Agent plans and executes steps: the planner/executor submit structured results through native tool calls, and call sandbox tools (Shell / Browser / File / Search / MCP) as needed.
-5. All events generated during Agent processing are sent back to Web via SSE.
+5. All events generated during Agent processing are sent back to Web via WebSocket.
 
 **When users browse tools:**
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -190,7 +190,7 @@ docker compose up -d
 2. Sandbox 是一个 Ubuntu Docker 环境，里面会启动 chrome 浏览器及 File/Shell 等工具的 API 服务。
 3. Web 往会话 ID 中发送用户消息，Server 收到用户消息后，将消息发送给 PlanAct Agent 处理。
 4. PlanAct Agent 进行规划与执行：规划器/执行器通过原生工具调用提交结构化结果，并按需调用沙盒工具（Shell / Browser / File / Search / MCP）。
-5. Agent 处理过程中产生的所有事件通过 SSE 发回 Web。
+5. Agent 处理过程中产生的所有事件通过 WebSocket 发回 Web。
 
 **当用户浏览工具时：**
 

--- a/backend/app/application/services/claw_service.py
+++ b/backend/app/application/services/claw_service.py
@@ -11,7 +11,7 @@ logger = logging.getLogger(__name__)
 
 
 class ClawEventBus:
-    """Simple in-memory pub/sub per user for broadcasting SSE events."""
+    """Simple in-memory pub/sub per user for broadcasting Claw stream events."""
 
     def __init__(self):
         self._subscribers: dict[str, list[asyncio.Queue]] = defaultdict(list)
@@ -35,7 +35,7 @@ class ClawEventBus:
 
 
 class _ChatState:
-    """Tracks an in-progress response so new SSE clients can catch up."""
+    """Tracks an in-progress response so new WebSocket clients can catch up."""
     __slots__ = ("pending_text",)
 
     def __init__(self):
@@ -47,7 +47,7 @@ class ClawService:
 
     Thin orchestration layer: delegates core business logic to
     ``ClawDomainService`` and adds application-level concerns such as
-    the SSE event bus, background task scheduling, and chat state tracking.
+    the Claw event bus, background task scheduling, and chat state tracking.
     """
 
     def __init__(self, claw_domain_service: ClawDomainService):
@@ -143,7 +143,7 @@ class ClawService:
             self._chat_states.pop(user_id, None)
 
     def get_pending_content(self, user_id: str) -> Optional[str]:
-        """Return accumulated text for an in-progress response (for SSE catch-up)."""
+        """Return accumulated text for an in-progress response (for WS catch-up)."""
         state = self._chat_states.get(user_id)
         if state and state.pending_text:
             return state.pending_text

--- a/backend/app/domain/services/claw_domain_service.py
+++ b/backend/app/domain/services/claw_domain_service.py
@@ -27,7 +27,7 @@ class ClawDomainService:
     """Domain service for Claw lifecycle, history merge, and auth logic.
 
     This service encapsulates pure business rules that are independent of
-    application-level concerns (SSE event bus, background task scheduling, etc.).
+    application-level concerns (event bus, background task scheduling, etc.).
     """
 
     def __init__(
@@ -285,7 +285,7 @@ class ClawDomainService:
         """Stream chat from the claw client, persisting messages.
 
         Yields raw chunk dicts from the claw client. The caller is responsible
-        for broadcasting chunks to SSE / WebSocket consumers.
+        for broadcasting chunks to WebSocket consumers.
         """
         assistant_content: list[str] = []
         file_attachments: list[ClawAttachment] = []

--- a/backend/app/interfaces/api/session_routes.py
+++ b/backend/app/interfaces/api/session_routes.py
@@ -52,7 +52,7 @@ async def get_session(
         session_id=session.id,
         title=session.title,
         status=session.status,
-        events=await EventMapper.events_to_sse_events(session.events),
+        events=await EventMapper.events_to_stream_events(session.events),
         is_shared=session.is_shared,
         is_favorite=session.is_favorite,
         is_pinned=session.is_pinned,
@@ -286,6 +286,6 @@ async def get_shared_session(
         session_id=session.id,
         title=session.title,
         status=session.status,
-        events=await EventMapper.events_to_sse_events(session.events),
+        events=await EventMapper.events_to_stream_events(session.events),
         is_shared=session.is_shared
     ))

--- a/backend/app/interfaces/api/ws_routes.py
+++ b/backend/app/interfaces/api/ws_routes.py
@@ -216,12 +216,12 @@ async def chat_ws(websocket: WebSocket):
         })
 
     async def send_agent_event(session_id: str, event: Any) -> None:
-        sse = await EventMapper.event_to_sse_event(event)
-        data = sse.data.model_dump(mode="json") if sse.data else {}
+        stream_event = await EventMapper.event_to_stream_event(event)
+        data = stream_event.data.model_dump(mode="json") if stream_event.data else {}
         await safe_send({
             "type": "event",
             "session_id": session_id,
-            "event": sse.event,
+            "event": stream_event.event,
             "data": data,
         })
 

--- a/backend/app/interfaces/schemas/event.py
+++ b/backend/app/interfaces/schemas/event.py
@@ -45,7 +45,7 @@ class CommonEventData(BaseEventData):
         }
         extra = "allow"
 
-class BaseSSEEvent(BaseModel):
+class BaseStreamEvent(BaseModel):
     event: str
     data: BaseEventData
 
@@ -62,7 +62,7 @@ class MessageEventData(BaseEventData):
     content: str
     attachments: Optional[List[FileInfoResponse]] = None
 
-class MessageSSEEvent(BaseSSEEvent):
+class MessageStreamEvent(BaseStreamEvent):
     event: Literal["message"] = "message"
     data: MessageEventData
 
@@ -85,7 +85,7 @@ class ToolEventData(BaseEventData):
     args: Dict[str, Any]
     content: Optional[ToolContent] = None
 
-class ToolSSEEvent(BaseSSEEvent):
+class ToolStreamEvent(BaseStreamEvent):
     event: Literal["tool"] = "tool"
     data: ToolEventData
 
@@ -107,10 +107,10 @@ class ToolSSEEvent(BaseSSEEvent):
             )
         )
 
-class DoneSSEEvent(BaseSSEEvent):
+class DoneStreamEvent(BaseStreamEvent):
     event: Literal["done"] = "done"
 
-class WaitSSEEvent(BaseSSEEvent):
+class WaitStreamEvent(BaseStreamEvent):
     event: Literal["wait"] = "wait"
 
 
@@ -120,7 +120,7 @@ class TerminalUpdateEventData(BaseEventData):
     description: Optional[str] = None
 
 
-class TerminalUpdateSSEEvent(BaseSSEEvent):
+class TerminalUpdateStreamEvent(BaseStreamEvent):
     event: Literal["terminal_update"] = "terminal_update"
     data: TerminalUpdateEventData
 
@@ -132,7 +132,7 @@ class FileUpdateEventData(BaseEventData):
     file: Optional[FileInfoResponse] = None
 
 
-class FileUpdateSSEEvent(BaseSSEEvent):
+class FileUpdateStreamEvent(BaseStreamEvent):
     event: Literal["file_update"] = "file_update"
     data: FileUpdateEventData
 
@@ -155,7 +155,7 @@ class FileUpdateSSEEvent(BaseSSEEvent):
 class ErrorEventData(BaseEventData):
     error: str
 
-class ErrorSSEEvent(BaseSSEEvent):
+class ErrorStreamEvent(BaseStreamEvent):
     event: Literal["error"] = "error"
     data: ErrorEventData
 
@@ -164,7 +164,7 @@ class StepEventData(BaseEventData):
     id: str
     description: str
 
-class StepSSEEvent(BaseSSEEvent):
+class StepStreamEvent(BaseStreamEvent):
     event: Literal["step"] = "step"
     data: StepEventData
 
@@ -182,14 +182,14 @@ class StepSSEEvent(BaseSSEEvent):
 class TitleEventData(BaseEventData):
     title: str
 
-class TitleSSEEvent(BaseSSEEvent):
+class TitleStreamEvent(BaseStreamEvent):
     event: Literal["title"] = "title"
     data: TitleEventData
 
 class PlanEventData(BaseEventData):
     steps: List[StepEventData]
 
-class PlanSSEEvent(BaseSSEEvent):
+class PlanStreamEvent(BaseStreamEvent):
     event: Literal["plan"] = "plan"
     data: PlanEventData
 
@@ -207,54 +207,54 @@ class PlanSSEEvent(BaseSSEEvent):
             )
         )
 
-class CommonSSEEvent(BaseSSEEvent):
+class CommonStreamEvent(BaseStreamEvent):
     event: str
     data: CommonEventData
 
-AgentSSEEvent = Union[
-    PlanSSEEvent,
-    MessageSSEEvent,
-    TitleSSEEvent,
-    ToolSSEEvent,
-    StepSSEEvent,
-    DoneSSEEvent,
-    ErrorSSEEvent,
-    WaitSSEEvent,
-    TerminalUpdateSSEEvent,
-    FileUpdateSSEEvent,
-    CommonSSEEvent,
+AgentStreamEvent = Union[
+    PlanStreamEvent,
+    MessageStreamEvent,
+    TitleStreamEvent,
+    ToolStreamEvent,
+    StepStreamEvent,
+    DoneStreamEvent,
+    ErrorStreamEvent,
+    WaitStreamEvent,
+    TerminalUpdateStreamEvent,
+    FileUpdateStreamEvent,
+    CommonStreamEvent,
 ]
 
-# Explicit registry: domain event type -> SSE event class.
+# Explicit registry: domain event type -> wire stream event class.
 # Register new event types here when adding them to AgentEvent.
-_EVENT_TYPE_TO_SSE_CLASS: Dict[str, Type[BaseSSEEvent]] = {
-    "plan": PlanSSEEvent,
-    "message": MessageSSEEvent,
-    "title": TitleSSEEvent,
-    "tool": ToolSSEEvent,
-    "step": StepSSEEvent,
-    "done": DoneSSEEvent,
-    "error": ErrorSSEEvent,
-    "wait": WaitSSEEvent,
-    "terminal_update": TerminalUpdateSSEEvent,
-    "file_update": FileUpdateSSEEvent,
+_EVENT_TYPE_TO_STREAM_CLASS: Dict[str, Type[BaseStreamEvent]] = {
+    "plan": PlanStreamEvent,
+    "message": MessageStreamEvent,
+    "title": TitleStreamEvent,
+    "tool": ToolStreamEvent,
+    "step": StepStreamEvent,
+    "done": DoneStreamEvent,
+    "error": ErrorStreamEvent,
+    "wait": WaitStreamEvent,
+    "terminal_update": TerminalUpdateStreamEvent,
+    "file_update": FileUpdateStreamEvent,
 }
 
 class EventMapper:
-    """Map AgentEvent (domain) to SSEEvent (wire format)"""
+    """Map AgentEvent (domain) to AgentStreamEvent (WS / REST wire format)"""
 
     @staticmethod
-    async def event_to_sse_event(event: AgentEvent) -> AgentSSEEvent:
-        sse_event_class = _EVENT_TYPE_TO_SSE_CLASS.get(event.type, CommonSSEEvent)
+    async def event_to_stream_event(event: AgentEvent) -> AgentStreamEvent:
+        stream_event_class = _EVENT_TYPE_TO_STREAM_CLASS.get(event.type, CommonStreamEvent)
         # Classes needing IO (e.g. signed URLs) define from_event_async
-        from_event_async = getattr(sse_event_class, "from_event_async", None)
+        from_event_async = getattr(stream_event_class, "from_event_async", None)
         if from_event_async is not None:
             return await from_event_async(event)
-        return sse_event_class.from_event(event)
+        return stream_event_class.from_event(event)
 
     @staticmethod
-    async def events_to_sse_events(events: List[AgentEvent]) -> List[AgentSSEEvent]:
-        """Create SSE event list from event list"""
+    async def events_to_stream_events(events: List[AgentEvent]) -> List[AgentStreamEvent]:
+        """Create wire event list from domain event list"""
         return [
-            await EventMapper.event_to_sse_event(event) for event in events if event
+            await EventMapper.event_to_stream_event(event) for event in events if event
         ]

--- a/backend/app/interfaces/schemas/session.py
+++ b/backend/app/interfaces/schemas/session.py
@@ -1,6 +1,6 @@
 from pydantic import BaseModel
 from typing import Optional, List
-from app.interfaces.schemas.event import AgentSSEEvent
+from app.interfaces.schemas.event import AgentStreamEvent
 from app.domain.models.session import SessionStatus, SessionSummary, TaskMode
 
 
@@ -19,7 +19,7 @@ class GetSessionResponse(BaseModel):
     session_id: str
     title: Optional[str] = None
     status: SessionStatus
-    events: List[AgentSSEEvent] = []
+    events: List[AgentStreamEvent] = []
     is_shared: bool = False
     is_favorite: bool = False
     is_pinned: bool = False
@@ -159,5 +159,5 @@ class SharedSessionResponse(BaseModel):
     session_id: str
     title: Optional[str] = None
     status: SessionStatus
-    events: List[AgentSSEEvent] = []
+    events: List[AgentStreamEvent] = []
     is_shared: bool

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -6,7 +6,7 @@ This is the frontend for AI Manus × Claw, built with Vue 3 + TypeScript + Vite.
 
 ## Features
 
-- Chat interface with task sessions, plan panel, and SSE event streaming
+- Chat interface with task sessions, plan panel, and WebSocket event streaming
 - Tool panels with rich renderers (Search, Files, Terminal, Browser, MCP)
 - VNC viewer for real-time sandbox viewing and takeover
 - Login/authentication, session sharing, and file upload/download
@@ -67,7 +67,7 @@ docker run -d -p 8080:80 ai-chatbot-vue
 
 ```
 src/
-├── api/             # API layer (axios client, SSE, auth, files, claw, config)
+├── api/             # API layer (axios client, WebSocket, auth, files, claw, config)
 ├── assets/          # Static resources and CSS files
 ├── components/      # Reusable components
 │   ├── toolViews/       # Rich tool renderers (Browser, File, Shell, Search, MCP)

--- a/frontend/README_zh.md
+++ b/frontend/README_zh.md
@@ -6,7 +6,7 @@
 
 ## 特性
 
-- 聊天界面与任务会话，支持计划面板与 SSE 事件流
+- 聊天界面与任务会话，支持计划面板与 WebSocket 事件流
 - 工具面板与富渲染视图（搜索、文件、终端、浏览器、MCP）
 - VNC 查看器，支持实时查看与接管沙盒
 - 登录认证、会话分享、文件上传与下载
@@ -67,7 +67,7 @@ docker run -d -p 8080:80 ai-chatbot-vue
 
 ```
 src/
-├── api/             # API 层（axios 客户端、SSE、认证、文件、Claw、配置）
+├── api/             # API 层（axios 客户端、WebSocket、认证、文件、Claw、配置）
 ├── assets/          # 静态资源和CSS文件
 ├── components/      # 可复用组件
 │   ├── toolViews/       # 工具富渲染视图（浏览器、文件、终端、搜索、MCP）

--- a/frontend/src/api/agent.ts
+++ b/frontend/src/api/agent.ts
@@ -1,13 +1,13 @@
 // Backend API service
 import { apiClient, ApiResponse, BASE_URL } from './client';
-import { AgentSSEEvent } from '../types/event';
+import { AgentEvent } from '../types/event';
 import type { AgentStatus } from '../types/event';
 import { CreateSessionResponse, GetSessionResponse, ShellViewResponse, FileViewResponse, ListSessionResponse, ListSessionItem, ShareSessionResponse, SharedSessionResponse } from '../types/response';
 import type { FileInfo } from './file';
 
 export type ChatStreamCallbacks = {
   onOpen?: () => void;
-  onMessage?: (event: { event: string; data: AgentSSEEvent['data'] }) => void;
+  onMessage?: (event: { event: string; data: AgentEvent['data'] }) => void;
   onStatusUpdate?: (agentStatus: AgentStatus) => void;
   onClose?: () => void;
   onError?: (error: Error) => void;
@@ -186,7 +186,7 @@ export const chatWithSession = async (
     onEvent: ({ event, data }) => {
       // status_update is delivered via onStatusUpdate; skip duplicate onMessage
       if (event === 'status_update') return;
-      callbacks?.onMessage?.({ event, data: data as AgentSSEEvent['data'] });
+      callbacks?.onMessage?.({ event, data: data as AgentEvent['data'] });
     },
     onStatusUpdate: (agentStatus) => {
       callbacks?.onStatusUpdate?.(agentStatus);

--- a/frontend/src/api/chatWs.ts
+++ b/frontend/src/api/chatWs.ts
@@ -4,7 +4,7 @@
  * status_update, error codes — aligned with official Manus control plane.
  */
 import { BASE_URL } from './client';
-import type { AgentSSEEvent, AgentStatus, StatusUpdateEventData } from '../types/event';
+import type { AgentEvent, AgentStatus, StatusUpdateEventData } from '../types/event';
 import type { ChatAttachment } from './agent';
 
 export const CHAT_WS_PROTOCOL_VERSION = 2;
@@ -18,11 +18,11 @@ export type ChatWSServerMessage =
   | { type: 'stream_end'; session_id: string }
   | { type: 'ping' }
   | { type: 'error'; error: string; code?: number; session_id?: string; request_id?: string }
-  | { type: 'event'; session_id: string; event: string; data: AgentSSEEvent['data'] | StatusUpdateEventData };
+  | { type: 'event'; session_id: string; event: string; data: AgentEvent['data'] | StatusUpdateEventData };
 
 type EventHandler = (msg: {
-  event: AgentSSEEvent['event'] | 'status_update';
-  data: AgentSSEEvent['data'] | StatusUpdateEventData;
+  event: AgentEvent['event'] | 'status_update';
+  data: AgentEvent['data'] | StatusUpdateEventData;
 }) => void;
 
 type SessionHandlers = {
@@ -256,7 +256,7 @@ class ChatWebSocket {
         this.handlers.get(msg.session_id)?.onStatusUpdate?.(data.agent_status);
       }
       this.handlers.get(msg.session_id)?.onEvent?.({
-        event: msg.event as AgentSSEEvent['event'] | 'status_update',
+        event: msg.event as AgentEvent['event'] | 'status_update',
         data: msg.data,
       });
     }

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -90,7 +90,7 @@ const redirectToLogin = () => {
 };
 
 /**
- * Common token refresh logic used by both axios interceptor and SSE connections
+ * Common token refresh logic used by the axios interceptor
  */
 const refreshAuthToken = async (): Promise<string | null> => {
   if (isRefreshing) {

--- a/frontend/src/composables/useAgentEvents.ts
+++ b/frontend/src/composables/useAgentEvents.ts
@@ -13,7 +13,7 @@ import {
   ErrorEventData,
   TitleEventData,
   PlanEventData,
-  AgentSSEEvent,
+  AgentEvent,
 } from '../types/event';
 
 export interface AgentEventState {
@@ -32,7 +32,7 @@ export interface AgentEventOptions {
 }
 
 /**
- * Shared conversion of agent SSE events into the UI message list.
+ * Shared conversion of agent stream events into the UI message list.
  * Used by both ChatPage (live chat) and SharePage (replay).
  */
 export function useAgentEvents(state: AgentEventState, options: AgentEventOptions = {}) {
@@ -136,7 +136,7 @@ export function useAgentEvents(state: AgentEventState, options: AgentEventOption
     plan.value = planData;
   };
 
-  const handleEvent = (event: AgentSSEEvent) => {
+  const handleEvent = (event: AgentEvent) => {
     // Control / live computer-panel events — not part of the chat message list
     if (
       event.event === 'status_update'

--- a/frontend/src/pages/ChatPage.vue
+++ b/frontend/src/pages/ChatPage.vue
@@ -164,7 +164,7 @@ import ChatTaskCompleted from '../components/ChatTaskCompleted.vue';
 import ChatWaitingContinue from '../components/ChatWaitingContinue.vue';
 import * as agentApi from '../api/agent';
 import { Message, MessageContent, ToolContent, AttachmentsContent, StepContent, isConsecutiveAssistant } from '../types/message';
-import { PlanEventData, AgentSSEEvent, type AgentStatus, type TerminalUpdateEventData, type FileUpdateEventData } from '../types/event';
+import { PlanEventData, AgentEvent, type AgentStatus, type TerminalUpdateEventData, type FileUpdateEventData } from '../types/event';
 import { useAgentEvents } from '../composables/useAgentEvents';
 import ComputerPanel from '../components/ComputerPanel.vue'
 import { ArrowDown, FileSearch, Lock, Globe, Link, Check, Ellipsis, Pencil, Star, Trash, FolderPlus, Folder, FolderSync, Pin } from 'lucide-vue-next';
@@ -345,7 +345,7 @@ const isAssistantLastBeforeUser = (index: number) => {
   return false;
 };
 
-// Shared SSE event -> message list conversion
+// Shared agent event -> message list conversion
 const { handleEvent: handleAgentEvent } = useAgentEvents(
   { messages, title, plan, isLoading, lastEventId, lastTool, lastNoMessageTool },
   {
@@ -357,7 +357,7 @@ const { handleEvent: handleAgentEvent } = useAgentEvents(
   }
 );
 
-const handleEvent = (event: AgentSSEEvent) => {
+const handleEvent = (event: AgentEvent) => {
   handleAgentEvent(event);
   if (event.event === 'status_update') {
     return;
@@ -457,8 +457,8 @@ const chatStreamCallbacks = (): agentApi.ChatStreamCallbacks => ({
       return;
     }
     handleEvent({
-      event: event as AgentSSEEvent['event'],
-      data: data as AgentSSEEvent['data'],
+      event: event as AgentEvent['event'],
+      data: data as AgentEvent['data'],
     });
   },
   onStatusUpdate: (agentStatus) => {

--- a/frontend/src/pages/SharePage.vue
+++ b/frontend/src/pages/SharePage.vue
@@ -204,7 +204,7 @@ const showThinking = computed(() => {
   return true;
 });
 
-// Shared SSE event -> message list conversion
+// Shared agent event -> message list conversion
 const { handleEvent } = useAgentEvents(
   { messages, title, plan, isLoading, lastEventId, lastTool, lastNoMessageTool },
   {

--- a/frontend/src/types/event.ts
+++ b/frontend/src/types/event.ts
@@ -3,7 +3,8 @@ import type { FileInfo } from '../api/file';
 /** Wire agent_status from chat WS status_update (official Manus-aligned). */
 export type AgentStatus = 'pending' | 'running' | 'waiting' | 'completed' | 'error';
 
-export type AgentSSEEvent = {
+/** Chat / session agent event over WebSocket (and history REST payloads). */
+export type AgentEvent = {
   event: 'tool' | 'step' | 'message' | 'error' | 'done' | 'title' | 'wait' | 'plan' | 'attachments' | 'status_update' | 'terminal_update' | 'file_update';
   data: ToolEventData | StepEventData | MessageEventData | ErrorEventData | DoneEventData | TitleEventData | WaitEventData | PlanEventData | StatusUpdateEventData | TerminalUpdateEventData | FileUpdateEventData;
 }

--- a/frontend/src/types/response.ts
+++ b/frontend/src/types/response.ts
@@ -1,4 +1,4 @@
-import { AgentSSEEvent } from "./event";
+import { AgentEvent } from "./event";
 
 export enum SessionStatus {
     PENDING = "pending",
@@ -15,7 +15,7 @@ export interface GetSessionResponse {
     session_id: string;
     title: string | null;
     status: SessionStatus;
-    events: AgentSSEEvent[];
+    events: AgentEvent[];
     is_shared: boolean;
     is_favorite: boolean;
     is_pinned: boolean;
@@ -103,7 +103,7 @@ export interface SharedSessionResponse {
     session_id: string;
     title: string | null;
     status: SessionStatus;
-    events: AgentSSEEvent[];
+    events: AgentEvent[];
     is_shared: boolean;
 }
   


### PR DESCRIPTION
## Summary
- Frontend: rename `AgentSSEEvent` → `AgentEvent`; update comments/READMEs to WebSocket.
- Backend: rename wire `*SSEEvent` → `*StreamEvent`, `EventMapper.event_to_stream_event` / `events_to_stream_events`.
- Docs (root + frontend README) no longer describe agent events as SSE.
- Keep `MCPTransport.SSE` (actual MCP protocol transport).

## Test plan
- [ ] `cd frontend && npm run type-check && npm run test`
- [ ] Open a chat session — events still stream over WS
- [ ] Session history REST still returns events array
- [ ] Claw chat WS still receives chunks


Made with [Cursor](https://cursor.com)