### PR TITLE
fix: waiting status / TakeControlBanner after WaitEvent

### DIFF
--- a/backend/app/interfaces/api/ws_routes.py
+++ b/backend/app/interfaces/api/ws_routes.py
@@ -260,15 +260,24 @@ async def chat_ws(websocket: WebSocket):
                     saw_error = True
                 await send_agent_event(session_id, event)
             if joined_session_id == session_id:
-                await safe_send({"type": "stream_end", "session_id": session_id})
-                if saw_error:
+                session = await agent_service.get_session(session_id, user.id)
+                final_status = _session_status_value(session.status) if session else "completed"
+                # Prefer authoritative session status (e.g. waiting after message_ask_user)
+                # over saw_error — early tool errors can coexist with a later WaitEvent.
+                # Send status_update BEFORE stream_end: clients often clear handlers on
+                # stream_end, which would drop a trailing status_update.
+                if final_status == "waiting":
+                    await send_status_update(session_id, "waiting")
+                elif saw_error:
                     await send_status_update(session_id, "error")
                 else:
-                    session = await agent_service.get_session(session_id, user.id)
-                    status = _agent_status_from_session(
-                        session.status if session else "completed"
+                    await send_status_update(
+                        session_id,
+                        _agent_status_from_session(
+                            session.status if session else "completed"
+                        ),
                     )
-                    await send_status_update(session_id, status)
+                await safe_send({"type": "stream_end", "session_id": session_id})
         except asyncio.CancelledError:
             raise
         except Exception as e:

--- a/frontend/src/pages/ChatPage.vue
+++ b/frontend/src/pages/ChatPage.vue
@@ -365,7 +365,10 @@ const handleEvent = (event: AgentEvent) => {
   if (event.event === 'done') {
     sessionStatus.value = SessionStatus.COMPLETED;
   } else if (event.event === 'wait') {
+    // WaitEvent means the agent paused for user input — clear loading even if
+    // a later stream_end clears handlers before status_update(waiting) arrives.
     sessionStatus.value = SessionStatus.WAITING;
+    isLoading.value = false;
   } else if (event.event === 'message' || event.event === 'tool' || event.event === 'step') {
     if (sessionStatus.value !== SessionStatus.WAITING) {
       sessionStatus.value = SessionStatus.RUNNING;

--- a/mockserver/mock_datas/chat_page_parity_e2e.yaml
+++ b/mockserver/mock_datas/chat_page_parity_e2e.yaml
@@ -1,0 +1,49 @@
+# Short script: plan → browser → ask user (WAITING + takeover banner)
+- choices:
+    - index: 0
+      message:
+        role: assistant
+        content: null
+        tool_calls:
+          - type: function
+            function:
+              name: create_plan
+              arguments: |
+                {
+                  "message": "I'll open a page and then ask you to take over.",
+                  "language": "zh",
+                  "goal": "demo take control banner",
+                  "title": "Chat page parity e2e",
+                  "steps": [
+                    { "id": "1", "description": "Open example.com then wait for user takeover" }
+                  ]
+                }
+
+- choices:
+    - index: 0
+      message:
+        role: assistant
+        content: null
+        tool_calls:
+          - type: function
+            function:
+              name: browser_navigate
+              arguments: |
+                {
+                    "url": "https://example.com"
+                }
+
+- choices:
+    - index: 0
+      message:
+        role: assistant
+        content: null
+        tool_calls:
+          - type: function
+            function:
+              name: message_ask_user
+              arguments: |
+                {
+                    "text": "Please take over the browser to finish the next step.",
+                    "suggest_user_takeover": "browser"
+                }


### PR DESCRIPTION
## Summary
- Chat WS: emit `status_update` **before** `stream_end`, and prefer final session `waiting` over `saw_error` so early tool errors do not wipe a later `WaitEvent`.
- ChatPage: clear `isLoading` on `wait` so `TakeControlBanner` can render even if a trailing status update is dropped.
- Add `mockserver/mock_datas/chat_page_parity_e2e.yaml` (plan → browser_navigate → message_ask_user) for local e2e.

## Test plan
- [ ] Point `API_BASE` at mockserver with `MOCK_DATA_FILE=chat_page_parity_e2e.yaml`, create session, send a message
- [ ] Confirm session ends `waiting`, browser tool present, and TakeControlBanner +「接管」appear without reload
- [ ] Early planner tool errors + later wait still yield `status_update: waiting` (not stuck `error` / loading)


Made with [Cursor](https://cursor.com)