### PR TITLE
feat: unify live session phase on WS status_update

### DIFF
--- a/backend/app/interfaces/api/ws_routes.py
+++ b/backend/app/interfaces/api/ws_routes.py
@@ -259,6 +259,10 @@ async def chat_ws(websocket: WebSocket):
                 if getattr(event, "type", None) == "error":
                     saw_error = True
                 await send_agent_event(session_id, event)
+                # Mid-stream phase: WaitEvent means Mongo is already WAITING — tell
+                # clients immediately so phase UI does not depend on domain→phase fallbacks.
+                if getattr(event, "type", None) == "wait":
+                    await send_status_update(session_id, "waiting")
             if joined_session_id == session_id:
                 session = await agent_service.get_session(session_id, user.id)
                 final_status = _session_status_value(session.status) if session else "completed"

--- a/docs/superpowers/specs/2026-08-03-backend-status-channel-design.md
+++ b/docs/superpowers/specs/2026-08-03-backend-status-channel-design.md
@@ -1,0 +1,96 @@
+# Backend Status Channel Unification (Approach A)
+
+**Date:** 2026-08-03  
+**Status:** Approved for implementation  
+**Scope:** Make wire `status_update` the sole live authority for session phase; align with frontend `useSessionPhase`.
+
+## Problem
+
+Session phase is driven by overlapping sources:
+
+1. Domain events `wait` / `done` / `error` (business + timeline)
+2. Synthetic WS `status_update` (intended authority for busy/footer)
+3. REST `session.status` (hydrate)
+
+Frontend #201 still calls `noteDomainEvent('wait'|'done')` as a defense when `status_update` is late or dropped. That re-creates dual writers after we extracted `useSessionPhase`.
+
+Backend already (via #200):
+
+- Sends `status_update` **before** `stream_end`
+- Prefers Mongo `WAITING` over stream-local `saw_error`
+
+Gap: **`WaitEvent` does not emit a mid-stream `status_update(waiting)`**, so the client must either wait for stream end or keep domain→phase fallbacks.
+
+## Goal
+
+- Live phase: **only** `status_update` (+ REST hydrate + optimistic local run)
+- Domain `wait` / `done` / `error` remain on the wire for timeline / copy; they **do not** drive phase on the client
+- When `WaitEvent` is forwarded, immediately emit `status_update(waiting)` so waiting UI works before `stream_end`
+
+### Non-goals
+
+- Moving UI enrichment out of `AgentTaskRunner` (Approach B)
+- Splitting live-only events from `AgentEvent` union (Approach C)
+- Introducing a new `PhaseEvent` domain type
+
+## Design
+
+### Authority table
+
+| Source | Drives phase? | Role |
+|--------|---------------|------|
+| REST `session.status` | Yes (hydrate only) | Refresh / idle join |
+| `status_update` | Yes (live) | Sole live authority |
+| Optimistic `chat()` | Yes (local) | Instant busy |
+| Domain `wait` / `done` / `error` | **No** (after this work) | Timeline / assistant error bubble |
+
+### Backend (`chat_ws.stream_session`)
+
+After `await send_agent_event(session_id, event)`:
+
+```python
+if getattr(event, "type", None) == "wait":
+    await send_status_update(session_id, "waiting")
+```
+
+Rationale: Runner sets Mongo `WAITING` before/as `WaitEvent` is queued; Domain yields `wait` then breaks. Emitting status immediately matches Mongo and unblocks the UI without waiting for the end-of-stream status block.
+
+End-of-stream logic from #200 stays:
+
+1. Resolve final status from Mongo (`waiting` > `saw_error` > mapped session status)
+2. `status_update(final)`
+3. `stream_end`
+
+Optional (out of scope unless cheap): mid-stream `status_update(completed)` on `done` — not required if end-of-stream always fires.
+
+### Frontend
+
+[`ChatPage.vue`](../../../frontend/src/pages/ChatPage.vue):
+
+- `handleEvent`: stop calling `noteDomainEvent('wait'|'done')`
+- Keep `onStreamError → noteDomainEvent('error')` **or** remove and rely on end-of-stream `status_update(error|completed)` — prefer **remove** for purity; accept that busy clears on status_update (already before stream_end). Error assistant bubbles still come from `useAgentEvents` timeline.
+- `showTakeControlBanner` already uses `phase === 'waiting' && !isBusy` — works once mid-stream waiting status arrives
+
+[`useSessionPhase.ts`](../../../frontend/src/composables/useSessionPhase.ts):
+
+- Keep `noteDomainEvent` API for unit tests / rare defense; ChatPage production path stops using wait/done/error notes
+- Update / add a comment that live phase authority is `applyStatusUpdate`
+
+Tests:
+
+- Backend: if no pytest for WS, add a focused unit test of the helper that maps “after wait event → should emit waiting status” **or** document manual e2e with `chat_page_parity_e2e.yaml`
+- Frontend: adjust ChatPage if any; keep `useSessionPhase` unit tests for `noteDomainEvent` as library behavior; add/adjust a test that documents production relies on `applyStatusUpdate('waiting')`
+
+### Success criteria
+
+- After `message_ask_user` → `WaitEvent`, client receives `status_update(waiting)` **before** `stream_end`
+- ChatPage has no `noteDomainEvent('wait'|'done')` (and preferably no error note) on the live path
+- TakeControlBanner / waiting footer appear without reload when browser tool + waiting
+- `npm run test && type-check` (frontend); backend smoke or existing tests still pass
+
+## Rollout
+
+1. Backend mid-stream waiting status  
+2. Frontend remove domain→phase notes on live path  
+3. Verify with mock e2e yaml or manual session  
+4. PR against `main`

--- a/frontend/src/composables/useSessionPhase.ts
+++ b/frontend/src/composables/useSessionPhase.ts
@@ -18,6 +18,13 @@ function toPhase(status: string): SessionPhase | undefined {
   return undefined
 }
 
+/**
+ * Session phase view-model: busy flag + footer/thinking derived from a single
+ * phase FSM. Live phase authority is WS `status_update` (+ REST hydrate +
+ * optimistic run). `noteDomainEvent` remains for client/transport failures only.
+ *
+ * @see docs/superpowers/specs/2026-08-03-backend-status-channel-design.md
+ */
 export function useSessionPhase(options?: { messages?: Ref<Message[]> }) {
   const phase = ref<SessionPhase | undefined>(undefined)
   const isBusy = ref(false)

--- a/frontend/src/pages/ChatPage.vue
+++ b/frontend/src/pages/ChatPage.vue
@@ -286,7 +286,6 @@ const {
 } = useSessionPhase({ messages });
 
 // Non-state refs that don't need reset
-const isHydrating = ref(false)
 const computerPanel = ref<InstanceType<typeof ComputerPanel>>()
 const simpleBarRef = ref<InstanceType<typeof SimpleBar>>();
 const observerRef = ref<HTMLDivElement>();
@@ -391,18 +390,12 @@ const { handleEvent: handleAgentEvent } = useAgentEvents(
         computerPanel.value?.showComputerPanel(tool, true);
       }
     },
-    onStreamError: () => {
-      if (!isHydrating.value) noteDomainEvent('error');
-    },
   }
 );
 
 const handleEvent = (event: AgentEvent) => {
   handleAgentEvent(event);
-  if (isHydrating.value) return;
-  if (event.event === 'status_update') return;
-  if (event.event === 'wait') noteDomainEvent('wait');
-  else if (event.event === 'done') noteDomainEvent('done');
+  // Live phase authority is status_update only (backend-status-channel design).
 };
 
 // Reset all refs to their initial values
@@ -554,14 +547,9 @@ const restoreSession = async () => {
   projectId.value = session.project_id ?? null;
   taskMode.value = session.task_mode === 'chat' ? 'chat' : 'agent';
   realTime.value = false;
-  isHydrating.value = true;
-  try {
-    hydrateFromSessionStatus(session.status);
-    for (const event of session.events) {
-      handleAgentEvent(event);
-    }
-  } finally {
-    isHydrating.value = false;
+  hydrateFromSessionStatus(session.status);
+  for (const event of session.events) {
+    handleAgentEvent(event);
   }
   realTime.value = true;
 


### PR DESCRIPTION
## Summary
- Backend: after forwarding a domain `wait` event, immediately send `status_update(waiting)` (Mongo is already WAITING).
- Frontend: live phase is driven only by `status_update` (+ REST hydrate + optimistic run); drop domain `wait`/`done`/`error` → `noteDomainEvent` on the chat stream path.
- Spec: `docs/superpowers/specs/2026-08-03-backend-status-channel-design.md` (Approach A).

Builds on #200 (status before stream_end) and #201 (`useSessionPhase`).

## Test plan
- [ ] `cd frontend && npm run test && npm run type-check`
- [ ] Mock/e2e: `message_ask_user` → client gets `status_update(waiting)` before `stream_end`
- [ ] Waiting footer / TakeControlBanner without reload when browser tool + waiting
- [ ] Transport/WS error still clears busy via `noteDomainEvent('error')` on `onError` / catch only


Made with [Cursor](https://cursor.com)