### PR TITLE
fix(sandbox): 对齐 Manus——读文件不默认硬截断

### DIFF
--- a/backend/app/application/services/agent_service.py
+++ b/backend/app/application/services/agent_service.py
@@ -321,7 +321,7 @@ class AgentService:
         if not sandbox:
             raise RuntimeError("Sandbox environment not found")
         
-        result = await sandbox.file_read(file_path)
+        result = await sandbox.file_read(file_path, max_length=None)
         if result.success:
             return FileViewResponse(**result.data)
         else:

--- a/backend/app/domain/external/sandbox.py
+++ b/backend/app/domain/external/sandbox.py
@@ -113,7 +113,8 @@ class Sandbox(Protocol):
         file: str, 
         start_line: int = None, 
         end_line: int = None, 
-        sudo: bool = False
+        sudo: bool = False,
+        max_length: int = None,
     ) -> ToolResult:
         """Read file content
         
@@ -122,6 +123,8 @@ class Sandbox(Protocol):
             start_line: Start line number
             end_line: End line number
             sudo: Whether to use sudo privileges
+            max_length: Content length cap. Omit for sandbox default (~10k for agents).
+                Pass None explicitly via implementations that support full reads for UI.
             
         Returns:
             File content

--- a/backend/app/domain/services/agent_task_runner.py
+++ b/backend/app/domain/services/agent_task_runner.py
@@ -187,7 +187,7 @@ class AgentTaskRunner(TaskRunner):
             ):
                 try:
                     file_path = event.function_args["file"]
-                    prior = await self._sandbox.file_read(file_path)
+                    prior = await self._sandbox.file_read(file_path, max_length=None)
                     if prior and prior.success and isinstance(prior.data, dict):
                         self._file_old_by_call[event.tool_call_id] = prior.data.get("content", "") or ""
                 except Exception:
@@ -212,7 +212,8 @@ class AgentTaskRunner(TaskRunner):
                 elif event.tool_name == "file":
                     if "file" in event.function_args:
                         file_path = event.function_args["file"]
-                        file_read_result = await self._sandbox.file_read(file_path)
+                        # Full content for Computer panel / Diff — agent tool reads stay capped.
+                        file_read_result = await self._sandbox.file_read(file_path, max_length=None)
                         file_content: str = file_read_result.data.get("content", "")
                         old_content = self._file_old_by_call.pop(event.tool_call_id, None)
                         # Only expose old_content when there was a prior snapshot (enables Diff tabs).

--- a/backend/app/domain/services/agents/base.py
+++ b/backend/app/domain/services/agents/base.py
@@ -110,7 +110,8 @@ class BaseAgent(ABC):
         omitted = len(content) - self.max_tool_result_chars
         return (
             content[: self.max_tool_result_chars]
-            + f"... [truncated {omitted} chars to save context]"
+            + f"... [truncated {omitted} chars to save context; "
+            "for files, re-read with start_line/end_line]"
         )
 
     async def invoke_tool(self, tool: Tool, tool_call: ToolCall) -> LLMMessage:

--- a/backend/app/domain/services/tools/file.py
+++ b/backend/app/domain/services/tools/file.py
@@ -13,7 +13,8 @@ class FileToolkit(BaseToolkit):
 - Optionally keep /home/ubuntu/todo.md as personal working notes; it does not drive the Plan UI
 - Use append mode to concatenate content onto an existing file
 - Only read text, code, or markdown files; never read binary files
-- For large files, always use start_line/end_line (or file_find_in_content) instead of reading the whole file; oversized reads are truncated
+- Use line range limits appropriately; when uncertain, start by reading the first 20 lines
+- Be mindful of performance impact with large files
 """
     
     def __init__(self, sandbox: Sandbox):
@@ -37,9 +38,9 @@ class FileToolkit(BaseToolkit):
         
         Args:
             file: Absolute path of the file to read
-            start_line: (Optional) Starting line to read from, 0-based — prefer this for large files
-            end_line: (Optional) Ending line number (exclusive)
-            sudo: (Optional) Whether to use sudo privileges
+            start_line: (Optional) Starting line to read from, 0-based. If not specified, starts from beginning
+            end_line: (Optional) Ending line number (exclusive). If not specified, reads entire file
+            sudo: (Optional) Whether to use sudo privileges, defaults to false
         """
         # Directly call sandbox's file_read method
         return await self.sandbox.file_read(

--- a/backend/app/domain/services/tools/file.py
+++ b/backend/app/domain/services/tools/file.py
@@ -13,6 +13,7 @@ class FileToolkit(BaseToolkit):
 - Optionally keep /home/ubuntu/todo.md as personal working notes; it does not drive the Plan UI
 - Use append mode to concatenate content onto an existing file
 - Only read text, code, or markdown files; never read binary files
+- For large files, always use start_line/end_line (or file_find_in_content) instead of reading the whole file; oversized reads are truncated
 """
     
     def __init__(self, sandbox: Sandbox):
@@ -36,7 +37,7 @@ class FileToolkit(BaseToolkit):
         
         Args:
             file: Absolute path of the file to read
-            start_line: (Optional) Starting line to read from, 0-based
+            start_line: (Optional) Starting line to read from, 0-based — prefer this for large files
             end_line: (Optional) Ending line number (exclusive)
             sudo: (Optional) Whether to use sudo privileges
         """

--- a/backend/app/infrastructure/external/sandbox/docker_sandbox.py
+++ b/backend/app/infrastructure/external/sandbox/docker_sandbox.py
@@ -16,6 +16,10 @@ from app.domain.external.browser import Browser
 
 logger = logging.getLogger(__name__)
 
+# Sentinel: omit max_length from the request so sandbox applies its agent-facing default.
+_UNSET = object()
+
+
 class DockerSandbox(Sandbox):
     def __init__(self, ip: str = None, container_name: str = None):
         """Initialize Docker sandbox and API interaction client"""
@@ -259,8 +263,14 @@ class DockerSandbox(Sandbox):
         )
         return ToolResult(**response.json())
 
-    async def file_read(self, file: str, start_line: int = None, 
-                        end_line: int = None, sudo: bool = False) -> ToolResult:
+    async def file_read(
+        self,
+        file: str,
+        start_line: int = None,
+        end_line: int = None,
+        sudo: bool = False,
+        max_length=_UNSET,
+    ) -> ToolResult:
         """Read file content
         
         Args:
@@ -268,18 +278,23 @@ class DockerSandbox(Sandbox):
             start_line: Start line number
             end_line: End line number
             sudo: Whether to use sudo privileges
+            max_length: Omit for sandbox default (agent-safe cap). Pass None for full content
+                (UI / diffs). Pass an int to set an explicit cap.
             
         Returns:
             File content
         """
+        payload = {
+            "file": file,
+            "start_line": start_line,
+            "end_line": end_line,
+            "sudo": sudo,
+        }
+        if max_length is not _UNSET:
+            payload["max_length"] = max_length
         response = await self.client.post(
             f"{self.base_url}/api/v1/file/read",
-            json={
-                "file": file,
-                "start_line": start_line,
-                "end_line": end_line,
-                "sudo": sudo
-            }
+            json=payload,
         )
         return ToolResult(**response.json())
         

--- a/sandbox/app/schemas/file.py
+++ b/sandbox/app/schemas/file.py
@@ -12,8 +12,11 @@ class FileReadRequest(BaseModel):
     end_line: Optional[int] = Field(None, description="End line (not inclusive)")
     sudo: Optional[bool] = Field(False, description="Whether to use sudo privileges")
     max_length: Optional[int] = Field(
-        None,
-        description="Optional maximum length of content to return; omit or null for no truncation",
+        10000,
+        description=(
+            "Maximum length of content to return (default 10000). "
+            "Pass null for no truncation. Prefer start_line/end_line for large files."
+        ),
     )
 
 class FileWriteRequest(BaseModel):

--- a/sandbox/app/schemas/file.py
+++ b/sandbox/app/schemas/file.py
@@ -11,7 +11,10 @@ class FileReadRequest(BaseModel):
     start_line: Optional[int] = Field(None, description="Start line (0-based)")
     end_line: Optional[int] = Field(None, description="End line (not inclusive)")
     sudo: Optional[bool] = Field(False, description="Whether to use sudo privileges")
-    max_length: Optional[int] = Field(10000, description="Maximum length of the content to return")
+    max_length: Optional[int] = Field(
+        None,
+        description="Optional maximum length of content to return; omit or null for no truncation",
+    )
 
 class FileWriteRequest(BaseModel):
     """File write request"""

--- a/sandbox/app/schemas/file.py
+++ b/sandbox/app/schemas/file.py
@@ -12,10 +12,10 @@ class FileReadRequest(BaseModel):
     end_line: Optional[int] = Field(None, description="End line (not inclusive)")
     sudo: Optional[bool] = Field(False, description="Whether to use sudo privileges")
     max_length: Optional[int] = Field(
-        10000,
+        None,
         description=(
-            "Maximum length of content to return (default 10000). "
-            "Pass null for no truncation. Prefer start_line/end_line for large files."
+            "Optional maximum content length. Omit/null returns full content "
+            "(Manus-style; prefer start_line/end_line for large files)."
         ),
     )
 

--- a/sandbox/app/services/file.py
+++ b/sandbox/app/services/file.py
@@ -20,7 +20,7 @@ class FileService:
     """File Operation Service"""
 
     async def read_file(self, file: str, start_line: Optional[int] = None, 
-                 end_line: Optional[int] = None, sudo: bool = False, max_length: Optional[int] = 10000) -> FileReadResult:
+                 end_line: Optional[int] = None, sudo: bool = False, max_length: Optional[int] = None) -> FileReadResult:
         """
         Asynchronously read file content
         
@@ -29,6 +29,7 @@ class FileService:
             start_line: Starting line (0-based)
             end_line: Ending line (not included)
             sudo: Whether to use sudo privileges
+            max_length: Optional max content length; None means return full content
         """
         # Check if file exists
         if not os.path.exists(file) and not sudo:
@@ -53,7 +54,7 @@ class FileService:
                 content = stdout.decode('utf-8')
             else:
                 # Asynchronously read file
-                def read_file_async():
+                def read_file_sync():
                     try:
                         with open(file, 'r', encoding='utf-8') as f:
                             return f.read()
@@ -61,7 +62,7 @@ class FileService:
                         raise AppException(message=f"Failed to read file: {str(e)}")
                 
                 # Execute IO operation in thread pool
-                content = await asyncio.to_thread(read_file_async)
+                content = await asyncio.to_thread(read_file_sync)
             
             # Process line range
             if start_line is not None or end_line is not None:
@@ -165,8 +166,8 @@ class FileService:
             new_str: New replacement string
             sudo: Whether to use sudo privileges
         """
-        # First read file content
-        file_result = await self.read_file(file, sudo=sudo)
+        # Always read the full file — truncating here would corrupt content on write-back
+        file_result = await self.read_file(file, sudo=sudo, max_length=None)
         content = file_result.content
         
         # Calculate replacement count
@@ -198,8 +199,8 @@ class FileService:
             regex: Regular expression pattern
             sudo: Whether to use sudo privileges
         """
-        # Read file
-        file_result = await self.read_file(file, sudo=sudo)
+        # Always search the full file so matches past any read cap are not missed
+        file_result = await self.read_file(file, sudo=sudo, max_length=None)
         content = file_result.content
         
         # Process line by line

--- a/sandbox/app/services/file.py
+++ b/sandbox/app/services/file.py
@@ -19,8 +19,13 @@ from app.core.exceptions import AppException, ResourceNotFoundException, BadRequ
 class FileService:
     """File Operation Service"""
 
+    # Default cap for file/read responses so agents cannot dump huge files into context.
+    # Pass max_length=None for full content (used by replace/search and UI viewers).
+    DEFAULT_READ_MAX_LENGTH = 10000
+
     async def read_file(self, file: str, start_line: Optional[int] = None, 
-                 end_line: Optional[int] = None, sudo: bool = False, max_length: Optional[int] = None) -> FileReadResult:
+                 end_line: Optional[int] = None, sudo: bool = False,
+                 max_length: Optional[int] = DEFAULT_READ_MAX_LENGTH) -> FileReadResult:
         """
         Asynchronously read file content
         
@@ -29,7 +34,7 @@ class FileService:
             start_line: Starting line (0-based)
             end_line: Ending line (not included)
             sudo: Whether to use sudo privileges
-            max_length: Optional max content length; None means return full content
+            max_length: Max content length to return; None means return full content
         """
         # Check if file exists
         if not os.path.exists(file) and not sudo:
@@ -72,7 +77,11 @@ class FileService:
                 content = '\n'.join(lines[start:end])
             
             if max_length is not None and max_length > 0 and len(content) > max_length:
-                content = content[:max_length] + "(truncated)"
+                omitted = len(content) - max_length
+                content = (
+                    content[:max_length]
+                    + f"\n... (truncated {omitted} chars; use start_line/end_line to read more)"
+                )
             
             return FileReadResult(
                 content=content,

--- a/sandbox/app/services/file.py
+++ b/sandbox/app/services/file.py
@@ -19,13 +19,12 @@ from app.core.exceptions import AppException, ResourceNotFoundException, BadRequ
 class FileService:
     """File Operation Service"""
 
-    # Default cap for file/read responses so agents cannot dump huge files into context.
-    # Pass max_length=None for full content (used by replace/search and UI viewers).
-    DEFAULT_READ_MAX_LENGTH = 10000
-
+    # No default char cap — align with Manus: agents use start_line/end_line;
+    # context budgets (backend max_tool_result_chars) bound what enters the LLM.
+    # Callers may still pass max_length explicitly when they need a hard cap.
     async def read_file(self, file: str, start_line: Optional[int] = None, 
                  end_line: Optional[int] = None, sudo: bool = False,
-                 max_length: Optional[int] = DEFAULT_READ_MAX_LENGTH) -> FileReadResult:
+                 max_length: Optional[int] = None) -> FileReadResult:
         """
         Asynchronously read file content
         
@@ -34,7 +33,7 @@ class FileService:
             start_line: Starting line (0-based)
             end_line: Ending line (not included)
             sudo: Whether to use sudo privileges
-            max_length: Max content length to return; None means return full content
+            max_length: Optional max content length; None means return full content
         """
         # Check if file exists
         if not os.path.exists(file) and not sudo:

--- a/sandbox/tests/test_file_truncation.py
+++ b/sandbox/tests/test_file_truncation.py
@@ -1,4 +1,8 @@
-"""Unit tests for file read truncation and replace/search full-file behavior."""
+"""Unit tests for file read truncation and replace/search full-file behavior.
+
+Aligned with Manus: file/read has no default char cap; agents are guided to use
+start_line/end_line. Context budgets live in the backend agent layer.
+"""
 import os
 import tempfile
 
@@ -20,29 +24,27 @@ def _write_temp(content: str) -> str:
 
 
 @pytest.mark.asyncio
-async def test_read_file_truncates_by_default_for_agents(file_service):
-    """Default read caps large files so models cannot dump huge files into context."""
+async def test_read_file_returns_full_content_by_default(file_service):
+    """Manus-style: no default char truncation on file/read."""
     body = "A" * 25000 + "TAIL_MARKER"
     path = _write_temp(body)
     try:
         result = await file_service.read_file(path)
-        assert len(result.content) < len(body)
-        assert result.content.startswith("A" * 100)
-        assert "truncated" in result.content
-        assert "start_line/end_line" in result.content
-        assert "TAIL_MARKER" not in result.content
+        assert result.content == body
+        assert "truncated" not in result.content
     finally:
         os.unlink(path)
 
 
 @pytest.mark.asyncio
-async def test_read_file_full_content_when_max_length_none(file_service):
-    body = "A" * 25000 + "TAIL_MARKER"
-    path = _write_temp(body)
+async def test_read_file_honors_line_range(file_service):
+    path = _write_temp("\n".join(f"line-{i}" for i in range(30)))
     try:
-        result = await file_service.read_file(path, max_length=None)
-        assert result.content == body
-        assert "truncated" not in result.content
+        result = await file_service.read_file(path, start_line=0, end_line=20)
+        lines = result.content.splitlines()
+        assert len(lines) == 20
+        assert lines[0] == "line-0"
+        assert lines[-1] == "line-19"
     finally:
         os.unlink(path)
 
@@ -70,7 +72,7 @@ async def test_str_replace_on_large_file_preserves_tail(file_service):
         result = await file_service.str_replace(path, "PREFIX_TOKEN", "REPLACED")
         assert result.replaced_count == 1
 
-        after = await file_service.read_file(path, max_length=None)
+        after = await file_service.read_file(path)
         assert after.content.startswith("REPLACED")
         assert after.content.endswith("SUFFIX_KEEP_ME")
         assert "truncated" not in after.content
@@ -80,8 +82,8 @@ async def test_str_replace_on_large_file_preserves_tail(file_service):
 
 
 @pytest.mark.asyncio
-async def test_find_in_content_matches_past_default_cap(file_service):
-    """Search must scan the whole file, not only the first 10k chars."""
+async def test_find_in_content_matches_past_former_default_cap(file_service):
+    """Search must scan the whole file."""
     path = _write_temp("Y" * 15000 + "NEEDLE_AT_END")
     try:
         result = await file_service.find_in_content(path, r"NEEDLE_AT_END")

--- a/sandbox/tests/test_file_truncation.py
+++ b/sandbox/tests/test_file_truncation.py
@@ -1,0 +1,76 @@
+"""Unit tests for file read truncation and replace/search full-file behavior."""
+import asyncio
+import os
+import tempfile
+
+import pytest
+
+from app.services.file import FileService
+
+
+@pytest.fixture
+def file_service():
+    return FileService()
+
+
+def _write_temp(content: str) -> str:
+    fd, path = tempfile.mkstemp(suffix=".txt")
+    with os.fdopen(fd, "w", encoding="utf-8") as f:
+        f.write(content)
+    return path
+
+
+@pytest.mark.asyncio
+async def test_read_file_returns_full_content_by_default(file_service):
+    """Default read must not truncate large files (used by UI / tool views)."""
+    body = "A" * 25000 + "TAIL_MARKER"
+    path = _write_temp(body)
+    try:
+        result = await file_service.read_file(path)
+        assert result.content == body
+        assert "(truncated)" not in result.content
+    finally:
+        os.unlink(path)
+
+
+@pytest.mark.asyncio
+async def test_read_file_honors_explicit_max_length(file_service):
+    body = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+    path = _write_temp(body)
+    try:
+        result = await file_service.read_file(path, max_length=10)
+        assert result.content == "ABCDEFGHIJ(truncated)"
+    finally:
+        os.unlink(path)
+
+
+@pytest.mark.asyncio
+async def test_str_replace_on_large_file_preserves_tail(file_service):
+    """Replace must read the full file; truncating would wipe content past the cap."""
+    prefix = "PREFIX_TOKEN"
+    middle = "X" * 20000
+    suffix = "SUFFIX_KEEP_ME"
+    path = _write_temp(prefix + middle + suffix)
+    try:
+        result = await file_service.str_replace(path, "PREFIX_TOKEN", "REPLACED")
+        assert result.replaced_count == 1
+
+        after = await file_service.read_file(path)
+        assert after.content.startswith("REPLACED")
+        assert after.content.endswith("SUFFIX_KEEP_ME")
+        assert "(truncated)" not in after.content
+        assert len(after.content) == len("REPLACED" + middle + suffix)
+    finally:
+        os.unlink(path)
+
+
+@pytest.mark.asyncio
+async def test_find_in_content_matches_past_former_default_cap(file_service):
+    """Search must scan the whole file, not only the first 10k chars."""
+    path = _write_temp("Y" * 15000 + "NEEDLE_AT_END")
+    try:
+        result = await file_service.find_in_content(path, r"NEEDLE_AT_END")
+        assert result.matches
+        assert any("NEEDLE_AT_END" in m for m in result.matches)
+    finally:
+        os.unlink(path)

--- a/sandbox/tests/test_file_truncation.py
+++ b/sandbox/tests/test_file_truncation.py
@@ -1,5 +1,4 @@
 """Unit tests for file read truncation and replace/search full-file behavior."""
-import asyncio
 import os
 import tempfile
 
@@ -21,14 +20,29 @@ def _write_temp(content: str) -> str:
 
 
 @pytest.mark.asyncio
-async def test_read_file_returns_full_content_by_default(file_service):
-    """Default read must not truncate large files (used by UI / tool views)."""
+async def test_read_file_truncates_by_default_for_agents(file_service):
+    """Default read caps large files so models cannot dump huge files into context."""
     body = "A" * 25000 + "TAIL_MARKER"
     path = _write_temp(body)
     try:
         result = await file_service.read_file(path)
+        assert len(result.content) < len(body)
+        assert result.content.startswith("A" * 100)
+        assert "truncated" in result.content
+        assert "start_line/end_line" in result.content
+        assert "TAIL_MARKER" not in result.content
+    finally:
+        os.unlink(path)
+
+
+@pytest.mark.asyncio
+async def test_read_file_full_content_when_max_length_none(file_service):
+    body = "A" * 25000 + "TAIL_MARKER"
+    path = _write_temp(body)
+    try:
+        result = await file_service.read_file(path, max_length=None)
         assert result.content == body
-        assert "(truncated)" not in result.content
+        assert "truncated" not in result.content
     finally:
         os.unlink(path)
 
@@ -39,7 +53,8 @@ async def test_read_file_honors_explicit_max_length(file_service):
     path = _write_temp(body)
     try:
         result = await file_service.read_file(path, max_length=10)
-        assert result.content == "ABCDEFGHIJ(truncated)"
+        assert result.content.startswith("ABCDEFGHIJ")
+        assert "truncated" in result.content
     finally:
         os.unlink(path)
 
@@ -55,17 +70,17 @@ async def test_str_replace_on_large_file_preserves_tail(file_service):
         result = await file_service.str_replace(path, "PREFIX_TOKEN", "REPLACED")
         assert result.replaced_count == 1
 
-        after = await file_service.read_file(path)
+        after = await file_service.read_file(path, max_length=None)
         assert after.content.startswith("REPLACED")
         assert after.content.endswith("SUFFIX_KEEP_ME")
-        assert "(truncated)" not in after.content
+        assert "truncated" not in after.content
         assert len(after.content) == len("REPLACED" + middle + suffix)
     finally:
         os.unlink(path)
 
 
 @pytest.mark.asyncio
-async def test_find_in_content_matches_past_former_default_cap(file_service):
+async def test_find_in_content_matches_past_default_cap(file_service):
     """Search must scan the whole file, not only the first 10k chars."""
     path = _write_temp("Y" * 15000 + "NEEDLE_AT_END")
     try:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 对齐官方 Manus

官方 Manus 的 `file_read` **没有** `max_length`，靠工具说明引导模型：

- 不确定时先读前 20 行
- 大文件用 `start_line` / `end_line`
- 注意大文件性能

进模型的上下文体积由上层预算控制，而不是 sandbox API 硬砍。

## 改动

| 层 | 行为 |
|---|---|
| sandbox `file/read` | 默认**不截断**；`max_length` 仅作可选硬上限 |
| `str_replace` / `find_in_content` | 始终读全文件（避免大文件写坏） |
| Computer / Diff / `file_view` | 完整内容 |
| FileToolkit 说明 | 对齐 Manus：先读 20 行、注意大文件 |
| backend `max_tool_result_chars` | 仍 **16k** 裁剪进 LLM 的 tool result，并提示按行重读 |

## 测试

```bash
cd sandbox && PYTHONPATH=. python3 -m pytest tests/test_file_truncation.py -v --asyncio-mode=auto
# 5 passed
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ffbbd-9e47-736c-8781-fec30e02b72a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ffbbd-9e47-736c-8781-fec30e02b72a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

