### PR TITLE
docs: fix broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,4 +263,4 @@ export IMAGE_TAG=latest
 
 ## ⭐️ Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=Simpleyyt/ai-manus&type=Date)](https://www.star-history.com/#Simpleyyt/ai-manus&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=Simpleyyt/ai-manus&type=Date)](https://star-history.dera.page/#Simpleyyt/ai-manus&type=Date)

--- a/README_zh.md
+++ b/README_zh.md
@@ -264,4 +264,4 @@ export IMAGE_TAG=latest
 
 ## ⭐️ Star 记录
 
-[![Star History Chart](https://api.star-history.com/svg?repos=Simpleyyt/ai-manus&type=Date)](https://www.star-history.com/#Simpleyyt/ai-manus&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=Simpleyyt/ai-manus&type=Date)](https://star-history.dera.page/#Simpleyyt/ai-manus&type=Date)


### PR DESCRIPTION
The star history chart in the README is currently broken due to GitHub stargazer API restrictions on the upstream service. This PR moves the chart to star-history.dera.page, which serves both the image and the interactive link from a single domain and uses an alternative data source that requires no API token. A fix is necessary so the chart renders again.