### PR TITLE
docs: publish README demos with Jump to live

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,19 +23,19 @@ Enjoy your own agent with AI Manus!
 
 * Task: Code Use, Browser Use, and multi-session switching
 
-https://github.com/user-attachments/assets/a73e5be2-822a-4aa9-b2c1-08adc30629a5
+https://github.com/user-attachments/assets/89e0da0f-789f-464f-8648-49eb5035fe2f
 
 ### Browser Use
 
 * Task: Find latest news
 
-<https://github.com/user-attachments/assets/be459984-561a-4aa3-8c6d-868d2ed9fa56>
+<https://github.com/user-attachments/assets/11a0aa98-4a74-4de9-a72f-2d384e89799a>
 
 ### Code Use
 
 * Task: Write a complex Python example
 
-<https://github.com/user-attachments/assets/db4e4048-35c3-4511-a13b-d4f71c54d647>
+<https://github.com/user-attachments/assets/fa45bcac-92c7-41ce-b8f6-7d9d99747f92>
 <!-- /demos:readme:en -->
 
 ## Key Features

--- a/README_zh.md
+++ b/README_zh.md
@@ -23,19 +23,19 @@ AI Manus 是一个通用的 AI Agent 系统，支持在沙盒环境中运行各�
 
 * 任务: Code Use、Browser Use 与多会话切换
 
-https://github.com/user-attachments/assets/a73e5be2-822a-4aa9-b2c1-08adc30629a5
+https://github.com/user-attachments/assets/89e0da0f-789f-464f-8648-49eb5035fe2f
 
 ### Browser Use
 
 * 任务: 找一下最新新闻
 
-https://github.com/user-attachments/assets/be459984-561a-4aa3-8c6d-868d2ed9fa56
+https://github.com/user-attachments/assets/11a0aa98-4a74-4de9-a72f-2d384e89799a
 
 ### Code Use
 
 * 任务: 写一个复杂的 python 示例
 
-https://github.com/user-attachments/assets/db4e4048-35c3-4511-a13b-d4f71c54d647
+https://github.com/user-attachments/assets/fa45bcac-92c7-41ce-b8f6-7d9d99747f92
 <!-- /demos:readme:zh -->
 
 ## 主要特性

--- a/docs/README.md
+++ b/docs/README.md
@@ -18,7 +18,7 @@ AI Manus 中每个服务与工具都包含一个 Built-in 版本，可以做到�
 
 ## 基本功能
 
-[](https://github.com/user-attachments/assets/a73e5be2-822a-4aa9-b2c1-08adc30629a5 ':include :type=video controls width="100%"')
+[](https://github.com/user-attachments/assets/89e0da0f-789f-464f-8648-49eb5035fe2f ':include :type=video controls width="100%"')
 
 ## 核心功能
 

--- a/docs/demos.yml
+++ b/docs/demos.yml
@@ -11,8 +11,8 @@
 # Local recordings stay in tmp/videos/ (gitignored).
 # Do not commit MP4s into the repo.
 #
-# 2026-08-13: re-recorded in English with Computer panel, waiting until
-# Task completed; Basic Features shows multi-session switching.
+# 2026-08-22: re-recorded with Jump to live on Computer panel
+# (English UI, Task completed; Basic Features still shows multi-session switching).
 
 readme:
   - id: basic
@@ -20,18 +20,18 @@ readme:
     title_zh: 基本功能
     task_en: Code Use, Browser Use, and multi-session switching
     task_zh: Code Use、Browser Use 与多会话切换
-    url: https://github.com/user-attachments/assets/a73e5be2-822a-4aa9-b2c1-08adc30629a5
+    url: https://github.com/user-attachments/assets/89e0da0f-789f-464f-8648-49eb5035fe2f
 
   - id: browser
     title_en: Browser Use
     title_zh: Browser Use
     task_en: Find latest news
     task_zh: 找一下最新新闻
-    url: https://github.com/user-attachments/assets/be459984-561a-4aa3-8c6d-868d2ed9fa56
+    url: https://github.com/user-attachments/assets/11a0aa98-4a74-4de9-a72f-2d384e89799a
 
   - id: code
     title_en: Code Use
     title_zh: Code Use
     task_en: Write a complex Python example
     task_zh: 写一个复杂的 python 示例
-    url: https://github.com/user-attachments/assets/db4e4048-35c3-4511-a13b-d4f71c54d647
+    url: https://github.com/user-attachments/assets/fa45bcac-92c7-41ce-b8f6-7d9d99747f92

--- a/docs/en/README.md
+++ b/docs/en/README.md
@@ -18,7 +18,7 @@ Each service and tool in AI Manus includes a Built-in version that can be fully 
 
 ## Basic Features
 
-[](https://github.com/user-attachments/assets/a73e5be2-822a-4aa9-b2c1-08adc30629a5 ':include :type=video controls width="100%"')
+[](https://github.com/user-attachments/assets/89e0da0f-789f-464f-8648-49eb5035fe2f ':include :type=video controls width="100%"')
 
 ## Core Features
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Re-recorded README demos so **Basic Features**, **Browser Use**, and **Code Use** show Computer **Jump to live** (English UI, wait until Task completed; Basic still switches sessions). Point README and Docsify home at the new `user-attachments` URLs.

Based on current `main` (after #206 and the Claw removal). Does not change takeover / file / MCP scenario pages.

## README demos

| Demo | Task | URL |
|---|---|---|
| Basic Features | Code Use, Browser Use, and multi-session switching | https://github.com/user-attachments/assets/89e0da0f-789f-464f-8648-49eb5035fe2f |
| Browser Use | Find latest news | https://github.com/user-attachments/assets/11a0aa98-4a74-4de9-a72f-2d384e89799a |
| Code Use | Write a complex Python example | https://github.com/user-attachments/assets/fa45bcac-92c7-41ce-b8f6-7d9d99747f92 |

[basic.mp4](https://cursor.com/agents/bc-bc5c63c8-c461-459a-a835-39edd243b6e7/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbasic.mp4)
[browser-use.mp4](https://cursor.com/agents/bc-bc5c63c8-c461-459a-a835-39edd243b6e7/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbrowser-use.mp4)
[code-use.mp4](https://cursor.com/agents/bc-bc5c63c8-c461-459a-a835-39edd243b6e7/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcode-use.mp4)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bc5c63c8-c461-459a-a835-39edd243b6e7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bc5c63c8-c461-459a-a835-39edd243b6e7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

