### PR TITLE
refactor(backend): @tool 支持装饰器参数或 docstring

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,7 +79,7 @@ Session state lives in MongoDB; `SessionStatus` (`PENDING`/`RUNNING`/`WAITING`/e
 
 ### Tools
 
-Each toolkit in `domain/services/tools/` (shell, browser, file, search, message, mcp) extends `BaseToolkit` and lists `Tool` subclasses (`name` / `description` / Pydantic `Args` / `run`). Shell/file tools call the **sandbox** API; browser tools drive the sandbox's headless Chrome (viewable via VNC→websockify→NoVNC); `mcp.py` loads external MCP servers from a mounted `mcp.json` (see `mcp.json.example`). Plan progress for the UI comes from Flow/`ExecutionAgent` `StepEvent`s and Planner `PlanEvent`s (not from parsing `todo.md`).
+Each toolkit in `domain/services/tools/` (shell, browser, file, search, message, mcp) extends `BaseToolkit` and exposes methods decorated as `Tool`s. Shell/file tools call the **sandbox** API; browser tools drive the sandbox's headless Chrome (viewable via VNC→websockify→NoVNC); `mcp.py` loads external MCP servers from a mounted `mcp.json` (see `mcp.json.example`). Plan progress for the UI comes from Flow/`ExecutionAgent` `StepEvent`s and Planner `PlanEvent`s (not from parsing `todo.md`).
 
 ## Sandbox
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,7 +79,7 @@ Session state lives in MongoDB; `SessionStatus` (`PENDING`/`RUNNING`/`WAITING`/e
 
 ### Tools
 
-Each toolkit in `domain/services/tools/` (shell, browser, file, search, message, mcp) extends `BaseToolkit` and exposes methods decorated as `Tool`s. Shell/file tools call the **sandbox** API; browser tools drive the sandbox's headless Chrome (viewable via VNC→websockify→NoVNC); `mcp.py` loads external MCP servers from a mounted `mcp.json` (see `mcp.json.example`). Plan progress for the UI comes from Flow/`ExecutionAgent` `StepEvent`s and Planner `PlanEvent`s (not from parsing `todo.md`).
+Each toolkit in `domain/services/tools/` (shell, browser, file, search, message, mcp) extends `BaseToolkit` and lists `Tool` subclasses (`name` / `description` / Pydantic `Args` / `run`). Shell/file tools call the **sandbox** API; browser tools drive the sandbox's headless Chrome (viewable via VNC→websockify→NoVNC); `mcp.py` loads external MCP servers from a mounted `mcp.json` (see `mcp.json.example`). Plan progress for the UI comes from Flow/`ExecutionAgent` `StepEvent`s and Planner `PlanEvent`s (not from parsing `todo.md`).
 
 ## Sandbox
 

--- a/backend/app/domain/services/tools/base.py
+++ b/backend/app/domain/services/tools/base.py
@@ -171,14 +171,30 @@ class ToolFunction:
         self.parameters = parameters
 
 
+def _coerce_arg_docs(args: Dict[str, Any]) -> Dict[str, str]:
+    """Accept ``{name: description}`` or ``{name: {description: ...}}``."""
+    docs: Dict[str, str] = {}
+    for key, value in args.items():
+        if isinstance(value, str):
+            docs[key] = value
+        elif isinstance(value, dict):
+            desc = value.get("description")
+            if not isinstance(desc, str):
+                raise TypeError(f"@tool args[{key!r}] needs a description string")
+            docs[key] = desc
+        else:
+            raise TypeError(f"@tool args[{key!r}] must be a description string")
+    return docs
+
+
 def tool(__fn_or_description: Any = None, /, **kwargs: Any):
     """Mark an async toolkit method as an invocable tool.
 
     Two mutually exclusive ways to supply descriptions:
 
     * ``@tool`` plus a Google-style docstring (summary + ``Args:``).
-    * ``@tool(...)`` with ``description`` / parameter docs — the docstring
-      is ignored.
+    * ``@tool(description=..., args={...})`` — parameter docs go in
+      ``args``, not as sibling kwargs. The docstring is ignored.
 
     Parameter types still come from the method signature unless a full
     ``parameters`` schema is passed. The method itself stays callable.
@@ -189,16 +205,18 @@ def tool(__fn_or_description: Any = None, /, **kwargs: Any):
     explicit_parameters = kwargs.pop("parameters", None)
     explicit_required = kwargs.pop("required", None)
     explicit_args = kwargs.pop("args", None)
+    if kwargs:
+        unexpected = ", ".join(sorted(kwargs))
+        raise TypeError(
+            f"@tool got unexpected keyword(s): {unexpected}. "
+            "Put parameter descriptions in args={...}."
+        )
     if explicit_args is None:
-        explicit_args = {}
+        arg_docs: Dict[str, str] = {}
     elif not isinstance(explicit_args, dict):
         raise TypeError("@tool args= must be a dict of parameter descriptions")
-
-    extra_param_docs: Dict[str, str] = {}
-    for key, value in kwargs.items():
-        if not isinstance(value, str):
-            raise TypeError(f"@tool {key}= must be a description string")
-        extra_param_docs[key] = value
+    else:
+        arg_docs = _coerce_arg_docs(explicit_args)
 
     positional_description = (
         __fn_or_description if isinstance(__fn_or_description, str) else None
@@ -207,8 +225,7 @@ def tool(__fn_or_description: Any = None, /, **kwargs: Any):
         positional_description
         or explicit_description
         or explicit_parameters is not None
-        or explicit_args
-        or extra_param_docs
+        or arg_docs
     )
 
     def decorate(f: Callable) -> Callable:
@@ -217,7 +234,7 @@ def tool(__fn_or_description: Any = None, /, **kwargs: Any):
             if explicit_parameters is not None:
                 parameters = _normalize_parameters(explicit_parameters, explicit_required)
             else:
-                parameters = _build_parameters(f, {**explicit_args, **extra_param_docs})
+                parameters = _build_parameters(f, arg_docs)
         else:
             desc, param_docs = _parse_docstring(f.__doc__)
             parameters = _build_parameters(f, param_docs)

--- a/backend/app/domain/services/tools/base.py
+++ b/backend/app/domain/services/tools/base.py
@@ -1,9 +1,9 @@
 """Framework-agnostic tool abstraction for the domain layer.
 
-A lightweight ``@tool`` decorator parses the method signature and its
-Google-style docstring into an OpenAI-compatible function schema, and
-``Tool`` / ``BaseToolkit`` expose the tools for the agent loop and the LLM
-gateway.
+Tools are written as classes — ``name``, ``description``, a Pydantic
+``Args`` / ``args_schema``, and ``run`` — matching the usual structured-tool
+shape without depending on LangChain. ``Tool`` / ``BaseToolkit`` expose them
+to the agent loop and the LLM gateway.
 
 Two additional concepts support modern context engineering:
 
@@ -16,47 +16,10 @@ Two additional concepts support modern context engineering:
   errors back to the model for self-repair. This replaces the legacy
   "JSON-in-prompt + repair parser" protocol with native function calling.
 """
-import inspect
-import re
 import copy
-from typing import Any, Awaitable, Callable, Dict, List, Optional, Type, get_type_hints
+from typing import Any, Awaitable, Callable, Dict, List, Optional, Sequence, Type
 
-from pydantic import BaseModel, Field, ValidationError, create_model
-
-
-def _parse_docstring(doc: Optional[str]) -> tuple[str, Dict[str, str]]:
-    """Split a Google-style docstring into (summary, {param: description})."""
-    if not doc:
-        return "", {}
-
-    lines = doc.strip("\n").split("\n")
-    summary_lines: List[str] = []
-    param_docs: Dict[str, str] = {}
-    in_args = False
-    current: Optional[str] = None
-
-    for raw in lines:
-        line = raw.strip()
-        if re.match(r"^(Args|Arguments|Parameters)\s*:\s*$", line):
-            in_args = True
-            current = None
-            continue
-        if in_args and re.match(r"^(Returns?|Raises?|Yields?|Examples?|Note)\s*:", line):
-            in_args = False
-            current = None
-            continue
-        if in_args:
-            m = re.match(r"^(\w+)\s*(?:\([^)]*\))?\s*:\s*(.*)$", line)
-            if m:
-                current = m.group(1)
-                param_docs[current] = m.group(2).strip()
-            elif current and line:
-                param_docs[current] += " " + line
-        else:
-            summary_lines.append(line)
-
-    summary = " ".join(s for s in summary_lines if s).strip()
-    return summary, param_docs
+from pydantic import BaseModel, ValidationError
 
 
 def _clean_schema(schema: Dict[str, Any]) -> Dict[str, Any]:
@@ -122,89 +85,57 @@ def take_brief(args: Optional[Dict[str, Any]]) -> tuple[Optional[str], Dict[str,
     return (text or None), clean
 
 
-def _build_parameters(func: Callable, param_docs: Dict[str, str]) -> Dict[str, Any]:
-    """Derive an OpenAI ``parameters`` JSON schema from a function signature."""
-    sig = inspect.signature(func)
-    try:
-        hints = get_type_hints(func)
-    except Exception:
-        hints = {}
-
-    fields: Dict[str, Any] = {}
-    for pname, param in sig.parameters.items():
-        if pname == "self":
-            continue
-        annotation = hints.get(pname, str)
-        default = ... if param.default is inspect.Parameter.empty else param.default
-        fields[pname] = (annotation, Field(default, description=param_docs.get(pname)))
-
-    model = create_model(f"{func.__name__}Args", **fields)
-    return _clean_schema(model.model_json_schema())
-
-
-class ToolFunction:
-    """Marker produced by ``@tool``; collected by ``BaseToolkit`` at init."""
-
-    def __init__(self, func: Callable, name: str, description: str, parameters: Dict[str, Any]):
-        self.func = func
-        self.name = name
-        self.description = description
-        self.parameters = parameters
-
-
-def tool(func: Optional[Callable] = None, **_kwargs: Any):
-    """Decorator that turns an async method into a :class:`ToolFunction`.
-
-    Accepts and ignores extra keyword arguments (e.g. ``parse_docstring``) for
-    drop-in compatibility with the previous LangChain decorator call sites.
-    """
-
-    def decorator(f: Callable) -> ToolFunction:
-        summary, param_docs = _parse_docstring(f.__doc__)
-        parameters = _build_parameters(f, param_docs)
-        return ToolFunction(
-            func=f,
-            name=f.__name__,
-            description=summary,
-            parameters=parameters,
-        )
-
-    if callable(func):
-        return decorator(func)
-    return decorator
+def _nested_args_schema(cls: Type["Tool"]) -> Optional[Type[BaseModel]]:
+    """Return a nested ``Args`` model declared on ``cls``, if any."""
+    nested = cls.__dict__.get("Args")
+    if isinstance(nested, type) and issubclass(nested, BaseModel):
+        return nested
+    return None
 
 
 class Tool:
-    """An invocable tool bound to its owning toolkit."""
+    """An invocable tool bound to its owning toolkit.
+
+    Subclass and set ``name`` / ``description``, declare arguments as a nested
+    ``Args`` Pydantic model (or ``args_schema``), and implement ``run``.
+    Runtime-discovered tools (MCP) are built with :meth:`dynamic` instead.
+    """
+
+    name: str = ""
+    description: str = ""
+    args_schema: Optional[Type[BaseModel]] = None
+
+    def __init_subclass__(cls, **kwargs: Any) -> None:
+        super().__init_subclass__(**kwargs)
+        if cls.__dict__.get("args_schema") is None:
+            nested = _nested_args_schema(cls)
+            if nested is not None:
+                cls.args_schema = nested
 
     def __init__(
         self,
-        name: str,
-        description: str,
-        parameters: Dict[str, Any],
-        invoker: Callable[[Dict[str, Any]], Awaitable[Any]],
-        toolkit: "BaseToolkit",
+        *,
+        toolkit: Optional["BaseToolkit"] = None,
+        name: Optional[str] = None,
+        description: Optional[str] = None,
+        parameters: Optional[Dict[str, Any]] = None,
+        invoker: Optional[Callable[[Dict[str, Any]], Awaitable[Any]]] = None,
+        args_schema: Optional[Type[BaseModel]] = None,
     ):
-        self.name = name
-        self.description = description
-        self.parameters = parameters
         self.toolkit = toolkit
+        if name is not None:
+            self.name = name
+        if description is not None:
+            self.description = description
+        if args_schema is not None:
+            self.args_schema = args_schema
         self._invoker = invoker
-
-    @classmethod
-    def from_function(cls, tool_function: ToolFunction, toolkit: "BaseToolkit") -> "Tool":
-        """Build a tool from a ``@tool``-decorated toolkit method."""
-
-        async def invoker(args: Dict[str, Any]) -> Any:
-            return await tool_function.func(toolkit, **(args or {}))
-
-        return cls(
-            name=tool_function.name,
-            description=tool_function.description,
-            parameters=tool_function.parameters,
-            invoker=invoker,
-            toolkit=toolkit,
-        )
+        if parameters is not None:
+            self.parameters = parameters
+        elif self.args_schema is not None:
+            self.parameters = _clean_schema(self.args_schema.model_json_schema())
+        else:
+            self.parameters = {"type": "object", "properties": {}}
 
     @classmethod
     def dynamic(
@@ -224,10 +155,19 @@ class Tool:
             toolkit=toolkit,
         )
 
+    async def run(self, **kwargs: Any) -> Any:
+        """Execute the tool implementation. Subclasses override this."""
+        raise NotImplementedError(f"{type(self).__name__} must implement run()")
+
     async def invoke(self, args: Dict[str, Any]) -> Any:
-        """Invoke the underlying coroutine with the given arguments."""
+        """Invoke the tool, stripping UI-only ``brief`` and validating args."""
         _, clean = take_brief(args)
-        return await self._invoker(clean)
+        if self._invoker is not None:
+            return await self._invoker(clean)
+        if self.args_schema is not None:
+            validated = self.args_schema.model_validate(clean)
+            return await self.run(**validated.model_dump())
+        return await self.run(**clean)
 
     def to_openai_schema(self) -> Dict[str, Any]:
         """Render this tool as an OpenAI function-calling schema."""
@@ -287,20 +227,18 @@ class OutputTool:
 class BaseToolkit:
     """Base toolset class, providing common tool discovery and lookup.
 
-    Subclasses may set ``instructions`` — usage guidance that is assembled
-    into the system prompt only when the toolkit is actually bound to the
-    agent, keeping prompt content and available tools in sync.
+    Subclasses set ``tool_types`` to the :class:`Tool` classes they expose.
+    They may also set ``instructions`` — usage guidance assembled into the
+    system prompt only when the toolkit is actually bound to the agent,
+    keeping prompt content and available tools in sync.
     """
 
     name: str = ""
     instructions: str = ""
+    tool_types: Sequence[Type[Tool]] = ()
 
     def __init__(self):
-        self.tools: List[Tool] = []
-        for _, member in inspect.getmembers(
-            type(self), lambda x: isinstance(x, ToolFunction)
-        ):
-            self.tools.append(Tool.from_function(member, toolkit=self))
+        self.tools: List[Tool] = [cls(toolkit=self) for cls in type(self).tool_types]
 
     def get_tools(self) -> List[Tool]:
         """Return all invocable tools in this toolkit."""
@@ -334,9 +272,7 @@ def describe_toolkits(toolkits: List[BaseToolkit]) -> str:
 
 
 __all__ = [
-    "tool",
     "Tool",
-    "ToolFunction",
     "OutputTool",
     "BaseToolkit",
     "describe_toolkits",

--- a/backend/app/domain/services/tools/base.py
+++ b/backend/app/domain/services/tools/base.py
@@ -1,9 +1,9 @@
 """Framework-agnostic tool abstraction for the domain layer.
 
-Tools are written as classes — ``name``, ``description``, a Pydantic
-``Args`` / ``args_schema``, and ``run`` — matching the usual structured-tool
-shape without depending on LangChain. ``Tool`` / ``BaseToolkit`` expose them
-to the agent loop and the LLM gateway.
+A lightweight ``@tool`` decorator marks toolkit methods and parses the
+signature plus Google-style docstring into an OpenAI-compatible function
+schema. The method stays a normal method; ``Tool`` / ``BaseToolkit`` expose
+the bound tools to the agent loop and the LLM gateway.
 
 Two additional concepts support modern context engineering:
 
@@ -16,10 +16,47 @@ Two additional concepts support modern context engineering:
   errors back to the model for self-repair. This replaces the legacy
   "JSON-in-prompt + repair parser" protocol with native function calling.
 """
+import inspect
+import re
 import copy
-from typing import Any, Awaitable, Callable, Dict, List, Optional, Sequence, Type
+from typing import Any, Awaitable, Callable, Dict, List, Optional, Type, get_type_hints
 
-from pydantic import BaseModel, ValidationError
+from pydantic import BaseModel, Field, ValidationError, create_model
+
+
+def _parse_docstring(doc: Optional[str]) -> tuple[str, Dict[str, str]]:
+    """Split a Google-style docstring into (summary, {param: description})."""
+    if not doc:
+        return "", {}
+
+    lines = doc.strip("\n").split("\n")
+    summary_lines: List[str] = []
+    param_docs: Dict[str, str] = {}
+    in_args = False
+    current: Optional[str] = None
+
+    for raw in lines:
+        line = raw.strip()
+        if re.match(r"^(Args|Arguments|Parameters)\s*:\s*$", line):
+            in_args = True
+            current = None
+            continue
+        if in_args and re.match(r"^(Returns?|Raises?|Yields?|Examples?|Note)\s*:", line):
+            in_args = False
+            current = None
+            continue
+        if in_args:
+            m = re.match(r"^(\w+)\s*(?:\([^)]*\))?\s*:\s*(.*)$", line)
+            if m:
+                current = m.group(1)
+                param_docs[current] = m.group(2).strip()
+            elif current and line:
+                param_docs[current] += " " + line
+        else:
+            summary_lines.append(line)
+
+    summary = " ".join(s for s in summary_lines if s).strip()
+    return summary, param_docs
 
 
 def _clean_schema(schema: Dict[str, Any]) -> Dict[str, Any]:
@@ -85,57 +122,90 @@ def take_brief(args: Optional[Dict[str, Any]]) -> tuple[Optional[str], Dict[str,
     return (text or None), clean
 
 
-def _nested_args_schema(cls: Type["Tool"]) -> Optional[Type[BaseModel]]:
-    """Return a nested ``Args`` model declared on ``cls``, if any."""
-    nested = cls.__dict__.get("Args")
-    if isinstance(nested, type) and issubclass(nested, BaseModel):
-        return nested
-    return None
+def _build_parameters(func: Callable, param_docs: Dict[str, str]) -> Dict[str, Any]:
+    """Derive an OpenAI ``parameters`` JSON schema from a function signature."""
+    sig = inspect.signature(func)
+    try:
+        hints = get_type_hints(func)
+    except Exception:
+        hints = {}
+
+    fields: Dict[str, Any] = {}
+    for pname, param in sig.parameters.items():
+        if pname == "self":
+            continue
+        annotation = hints.get(pname, str)
+        default = ... if param.default is inspect.Parameter.empty else param.default
+        fields[pname] = (annotation, Field(default, description=param_docs.get(pname)))
+
+    model = create_model(f"{func.__name__}Args", **fields)
+    return _clean_schema(model.model_json_schema())
+
+
+class ToolFunction:
+    """Metadata attached by ``@tool``; collected by ``BaseToolkit`` at init."""
+
+    def __init__(self, func: Callable, name: str, description: str, parameters: Dict[str, Any]):
+        self.func = func
+        self.name = name
+        self.description = description
+        self.parameters = parameters
+
+
+def tool(func: Optional[Callable] = None):
+    """Mark an async toolkit method as an invocable tool.
+
+    The wrapped method is unchanged and remains callable on the instance.
+    Schema fields come from the signature; descriptions come from a
+    Google-style ``Args:`` docstring.
+    """
+
+    def decorator(f: Callable) -> Callable:
+        summary, param_docs = _parse_docstring(f.__doc__)
+        f._tool = ToolFunction(
+            func=f,
+            name=f.__name__,
+            description=summary,
+            parameters=_build_parameters(f, param_docs),
+        )
+        return f
+
+    if func is None:
+        return decorator
+    return decorator(func)
 
 
 class Tool:
-    """An invocable tool bound to its owning toolkit.
-
-    Subclass and set ``name`` / ``description``, declare arguments as a nested
-    ``Args`` Pydantic model (or ``args_schema``), and implement ``run``.
-    Runtime-discovered tools (MCP) are built with :meth:`dynamic` instead.
-    """
-
-    name: str = ""
-    description: str = ""
-    args_schema: Optional[Type[BaseModel]] = None
-
-    def __init_subclass__(cls, **kwargs: Any) -> None:
-        super().__init_subclass__(**kwargs)
-        if cls.__dict__.get("args_schema") is None:
-            nested = _nested_args_schema(cls)
-            if nested is not None:
-                cls.args_schema = nested
+    """An invocable tool bound to its owning toolkit."""
 
     def __init__(
         self,
-        *,
-        toolkit: Optional["BaseToolkit"] = None,
-        name: Optional[str] = None,
-        description: Optional[str] = None,
-        parameters: Optional[Dict[str, Any]] = None,
-        invoker: Optional[Callable[[Dict[str, Any]], Awaitable[Any]]] = None,
-        args_schema: Optional[Type[BaseModel]] = None,
+        name: str,
+        description: str,
+        parameters: Dict[str, Any],
+        invoker: Callable[[Dict[str, Any]], Awaitable[Any]],
+        toolkit: "BaseToolkit",
     ):
+        self.name = name
+        self.description = description
+        self.parameters = parameters
         self.toolkit = toolkit
-        if name is not None:
-            self.name = name
-        if description is not None:
-            self.description = description
-        if args_schema is not None:
-            self.args_schema = args_schema
         self._invoker = invoker
-        if parameters is not None:
-            self.parameters = parameters
-        elif self.args_schema is not None:
-            self.parameters = _clean_schema(self.args_schema.model_json_schema())
-        else:
-            self.parameters = {"type": "object", "properties": {}}
+
+    @classmethod
+    def from_function(cls, tool_function: ToolFunction, toolkit: "BaseToolkit") -> "Tool":
+        """Build a tool from a ``@tool``-decorated toolkit method."""
+
+        async def invoker(args: Dict[str, Any]) -> Any:
+            return await tool_function.func(toolkit, **(args or {}))
+
+        return cls(
+            name=tool_function.name,
+            description=tool_function.description,
+            parameters=tool_function.parameters,
+            invoker=invoker,
+            toolkit=toolkit,
+        )
 
     @classmethod
     def dynamic(
@@ -155,19 +225,10 @@ class Tool:
             toolkit=toolkit,
         )
 
-    async def run(self, **kwargs: Any) -> Any:
-        """Execute the tool implementation. Subclasses override this."""
-        raise NotImplementedError(f"{type(self).__name__} must implement run()")
-
     async def invoke(self, args: Dict[str, Any]) -> Any:
-        """Invoke the tool, stripping UI-only ``brief`` and validating args."""
+        """Invoke the underlying coroutine with the given arguments."""
         _, clean = take_brief(args)
-        if self._invoker is not None:
-            return await self._invoker(clean)
-        if self.args_schema is not None:
-            validated = self.args_schema.model_validate(clean)
-            return await self.run(**validated.model_dump())
-        return await self.run(**clean)
+        return await self._invoker(clean)
 
     def to_openai_schema(self) -> Dict[str, Any]:
         """Render this tool as an OpenAI function-calling schema."""
@@ -227,18 +288,20 @@ class OutputTool:
 class BaseToolkit:
     """Base toolset class, providing common tool discovery and lookup.
 
-    Subclasses set ``tool_types`` to the :class:`Tool` classes they expose.
-    They may also set ``instructions`` — usage guidance assembled into the
-    system prompt only when the toolkit is actually bound to the agent,
-    keeping prompt content and available tools in sync.
+    Subclasses may set ``instructions`` — usage guidance that is assembled
+    into the system prompt only when the toolkit is actually bound to the
+    agent, keeping prompt content and available tools in sync.
     """
 
     name: str = ""
     instructions: str = ""
-    tool_types: Sequence[Type[Tool]] = ()
 
     def __init__(self):
-        self.tools: List[Tool] = [cls(toolkit=self) for cls in type(self).tool_types]
+        self.tools: List[Tool] = []
+        for _, member in inspect.getmembers(type(self), inspect.isfunction):
+            meta = getattr(member, "_tool", None)
+            if isinstance(meta, ToolFunction):
+                self.tools.append(Tool.from_function(meta, toolkit=self))
 
     def get_tools(self) -> List[Tool]:
         """Return all invocable tools in this toolkit."""
@@ -272,7 +335,9 @@ def describe_toolkits(toolkits: List[BaseToolkit]) -> str:
 
 
 __all__ = [
+    "tool",
     "Tool",
+    "ToolFunction",
     "OutputTool",
     "BaseToolkit",
     "describe_toolkits",

--- a/backend/app/domain/services/tools/base.py
+++ b/backend/app/domain/services/tools/base.py
@@ -1,8 +1,8 @@
 """Framework-agnostic tool abstraction for the domain layer.
 
-A lightweight ``@tool`` decorator marks toolkit methods and parses the
-signature plus Google-style docstring into an OpenAI-compatible function
-schema. The method stays a normal method; ``Tool`` / ``BaseToolkit`` expose
+A lightweight ``@tool`` decorator marks toolkit methods. Descriptions come
+from **either** ``@tool(...)`` arguments **or** a Google-style docstring,
+not a mix. The method stays callable; ``Tool`` / ``BaseToolkit`` expose
 the bound tools to the agent loop and the LLM gateway.
 
 Two additional concepts support modern context engineering:
@@ -142,6 +142,25 @@ def _build_parameters(func: Callable, param_docs: Dict[str, str]) -> Dict[str, A
     return _clean_schema(model.model_json_schema())
 
 
+def _normalize_parameters(
+    parameters: Dict[str, Any],
+    required: Optional[List[str]] = None,
+) -> Dict[str, Any]:
+    """Accept a full JSON schema or a ``{name: {type, description}}`` map."""
+    if parameters.get("type") == "object" and "properties" in parameters:
+        schema = copy.deepcopy(parameters)
+        if required is not None:
+            schema["required"] = list(required)
+        return _clean_schema(schema)
+    schema: Dict[str, Any] = {
+        "type": "object",
+        "properties": copy.deepcopy(parameters),
+    }
+    if required is not None:
+        schema["required"] = list(required)
+    return _clean_schema(schema)
+
+
 class ToolFunction:
     """Metadata attached by ``@tool``; collected by ``BaseToolkit`` at init."""
 
@@ -152,27 +171,68 @@ class ToolFunction:
         self.parameters = parameters
 
 
-def tool(func: Optional[Callable] = None):
+def tool(__fn_or_description: Any = None, /, **kwargs: Any):
     """Mark an async toolkit method as an invocable tool.
 
-    The wrapped method is unchanged and remains callable on the instance.
-    Schema fields come from the signature; descriptions come from a
-    Google-style ``Args:`` docstring.
+    Two mutually exclusive ways to supply descriptions:
+
+    * ``@tool`` plus a Google-style docstring (summary + ``Args:``).
+    * ``@tool(...)`` with ``description`` / parameter docs — the docstring
+      is ignored.
+
+    Parameter types still come from the method signature unless a full
+    ``parameters`` schema is passed. The method itself stays callable.
     """
 
-    def decorator(f: Callable) -> Callable:
-        summary, param_docs = _parse_docstring(f.__doc__)
+    explicit_name = kwargs.pop("name", None)
+    explicit_description = kwargs.pop("description", None)
+    explicit_parameters = kwargs.pop("parameters", None)
+    explicit_required = kwargs.pop("required", None)
+    explicit_args = kwargs.pop("args", None)
+    if explicit_args is None:
+        explicit_args = {}
+    elif not isinstance(explicit_args, dict):
+        raise TypeError("@tool args= must be a dict of parameter descriptions")
+
+    extra_param_docs: Dict[str, str] = {}
+    for key, value in kwargs.items():
+        if not isinstance(value, str):
+            raise TypeError(f"@tool {key}= must be a description string")
+        extra_param_docs[key] = value
+
+    positional_description = (
+        __fn_or_description if isinstance(__fn_or_description, str) else None
+    )
+    use_decorator_docs = bool(
+        positional_description
+        or explicit_description
+        or explicit_parameters is not None
+        or explicit_args
+        or extra_param_docs
+    )
+
+    def decorate(f: Callable) -> Callable:
+        if use_decorator_docs:
+            desc = explicit_description or positional_description or ""
+            if explicit_parameters is not None:
+                parameters = _normalize_parameters(explicit_parameters, explicit_required)
+            else:
+                parameters = _build_parameters(f, {**explicit_args, **extra_param_docs})
+        else:
+            desc, param_docs = _parse_docstring(f.__doc__)
+            parameters = _build_parameters(f, param_docs)
+
         f._tool = ToolFunction(
             func=f,
-            name=f.__name__,
-            description=summary,
-            parameters=_build_parameters(f, param_docs),
+            name=explicit_name or f.__name__,
+            description=desc,
+            parameters=parameters,
         )
         return f
 
-    if func is None:
-        return decorator
-    return decorator(func)
+    if callable(__fn_or_description):
+        return decorate(__fn_or_description)
+    return decorate
 
 
 class Tool:

--- a/backend/app/domain/services/tools/browser.py
+++ b/backend/app/domain/services/tools/browser.py
@@ -1,218 +1,7 @@
 from typing import Optional
-
-from pydantic import BaseModel, Field
-
 from app.domain.external.browser import Browser
+from app.domain.services.tools.base import BaseToolkit, tool
 from app.domain.models.tool_result import ToolResult
-from app.domain.services.tools.base import BaseToolkit, Tool
-
-
-class BrowserViewTool(Tool):
-    name = "browser_view"
-    description = (
-        "View content of the current browser page. Use for checking the latest "
-        "state of previously opened pages."
-    )
-
-    class Args(BaseModel):
-        pass
-
-    async def run(self) -> ToolResult:
-        return await self.toolkit.browser.view_page()
-
-
-class BrowserNavigateTool(Tool):
-    name = "browser_navigate"
-    description = "Navigate browser to specified URL. Use when accessing new pages is needed."
-
-    class Args(BaseModel):
-        url: str = Field(description="Complete URL to visit. Must include protocol prefix.")
-
-    async def run(self, url: str) -> ToolResult:
-        return await self.toolkit.browser.navigate(url)
-
-
-class BrowserRestartTool(Tool):
-    name = "browser_restart"
-    description = (
-        "Restart browser and navigate to specified URL. Use when browser state needs to be reset."
-    )
-
-    class Args(BaseModel):
-        url: str = Field(
-            description="Complete URL to visit after restart. Must include protocol prefix."
-        )
-
-    async def run(self, url: str) -> ToolResult:
-        return await self.toolkit.browser.restart(url)
-
-
-class BrowserClickTool(Tool):
-    name = "browser_click"
-    description = "Click on elements in the current browser page. Use when clicking page elements is needed."
-
-    class Args(BaseModel):
-        index: Optional[int] = Field(
-            default=None, description="(Optional) Index number of the element to click"
-        )
-        coordinate_x: Optional[float] = Field(
-            default=None, description="(Optional) X coordinate of click position"
-        )
-        coordinate_y: Optional[float] = Field(
-            default=None, description="(Optional) Y coordinate of click position"
-        )
-
-    async def run(
-        self,
-        index: Optional[int] = None,
-        coordinate_x: Optional[float] = None,
-        coordinate_y: Optional[float] = None,
-    ) -> ToolResult:
-        return await self.toolkit.browser.click(index, coordinate_x, coordinate_y)
-
-
-class BrowserInputTool(Tool):
-    name = "browser_input"
-    description = (
-        "Overwrite text in editable elements on the current browser page. "
-        "Use when filling content in input fields."
-    )
-
-    class Args(BaseModel):
-        text: str = Field(description="Complete text content to overwrite")
-        press_enter: bool = Field(description="Whether to press Enter key after input")
-        index: Optional[int] = Field(
-            default=None, description="(Optional) Index number of the element to overwrite text"
-        )
-        coordinate_x: Optional[float] = Field(
-            default=None, description="(Optional) X coordinate of the element to overwrite text"
-        )
-        coordinate_y: Optional[float] = Field(
-            default=None, description="(Optional) Y coordinate of the element to overwrite text"
-        )
-
-    async def run(
-        self,
-        text: str,
-        press_enter: bool,
-        index: Optional[int] = None,
-        coordinate_x: Optional[float] = None,
-        coordinate_y: Optional[float] = None,
-    ) -> ToolResult:
-        return await self.toolkit.browser.input(
-            text, press_enter, index, coordinate_x, coordinate_y
-        )
-
-
-class BrowserMoveMouseTool(Tool):
-    name = "browser_move_mouse"
-    description = (
-        "Move cursor to specified position on the current browser page. "
-        "Use when simulating user mouse movement."
-    )
-
-    class Args(BaseModel):
-        coordinate_x: float = Field(description="X coordinate of target cursor position")
-        coordinate_y: float = Field(description="Y coordinate of target cursor position")
-
-    async def run(self, coordinate_x: float, coordinate_y: float) -> ToolResult:
-        return await self.toolkit.browser.move_mouse(coordinate_x, coordinate_y)
-
-
-class BrowserPressKeyTool(Tool):
-    name = "browser_press_key"
-    description = (
-        "Simulate key press in the current browser page. Use when specific keyboard operations are needed."
-    )
-
-    class Args(BaseModel):
-        key: str = Field(
-            description=(
-                "Key name to simulate (e.g., Enter, Tab, ArrowUp), "
-                "supports key combinations (e.g., Control+Enter)."
-            )
-        )
-
-    async def run(self, key: str) -> ToolResult:
-        return await self.toolkit.browser.press_key(key)
-
-
-class BrowserSelectOptionTool(Tool):
-    name = "browser_select_option"
-    description = (
-        "Select specified option from dropdown list element in the current browser page. "
-        "Use when selecting dropdown menu options."
-    )
-
-    class Args(BaseModel):
-        index: int = Field(description="Index number of the dropdown list element")
-        option: int = Field(description="Option number to select, starting from 0.")
-
-    async def run(self, index: int, option: int) -> ToolResult:
-        return await self.toolkit.browser.select_option(index, option)
-
-
-class BrowserScrollUpTool(Tool):
-    name = "browser_scroll_up"
-    description = (
-        "Scroll up the current browser page. Use when viewing content above or returning to page top."
-    )
-
-    class Args(BaseModel):
-        to_top: Optional[bool] = Field(
-            default=None,
-            description="(Optional) Whether to scroll directly to page top instead of one viewport up.",
-        )
-
-    async def run(self, to_top: Optional[bool] = None) -> ToolResult:
-        return await self.toolkit.browser.scroll_up(to_top)
-
-
-class BrowserScrollDownTool(Tool):
-    name = "browser_scroll_down"
-    description = (
-        "Scroll down the current browser page. Use when viewing content below or jumping to page bottom."
-    )
-
-    class Args(BaseModel):
-        to_bottom: Optional[bool] = Field(
-            default=None,
-            description="(Optional) Whether to scroll directly to page bottom instead of one viewport down.",
-        )
-
-    async def run(self, to_bottom: Optional[bool] = None) -> ToolResult:
-        return await self.toolkit.browser.scroll_down(to_bottom)
-
-
-class BrowserConsoleExecTool(Tool):
-    name = "browser_console_exec"
-    description = (
-        "Execute JavaScript code in browser console. Use when custom scripts need to be executed."
-    )
-
-    class Args(BaseModel):
-        javascript: str = Field(
-            description="JavaScript code to execute. Note that the runtime environment is browser console."
-        )
-
-    async def run(self, javascript: str) -> ToolResult:
-        return await self.toolkit.browser.console_exec(javascript)
-
-
-class BrowserConsoleViewTool(Tool):
-    name = "browser_console_view"
-    description = (
-        "View browser console output. Use when checking JavaScript logs or debugging page errors."
-    )
-
-    class Args(BaseModel):
-        max_lines: Optional[int] = Field(
-            default=None, description="(Optional) Maximum number of log lines to return."
-        )
-
-    async def run(self, max_lines: Optional[int] = None) -> ToolResult:
-        return await self.toolkit.browser.console_view(max_lines)
-
 
 class BrowserToolkit(BaseToolkit):
     """Browser tool class, providing browser interaction functions"""
@@ -227,26 +16,160 @@ class BrowserToolkit(BaseToolkit):
 - Pages are auto-extracted to Markdown when possible; the extraction may include off-screen text but omits links/images and is not guaranteed complete
 - If the extracted Markdown already covers what you need, don't scroll; otherwise scroll to view the full page
 """
-    tool_types = [
-        BrowserViewTool,
-        BrowserNavigateTool,
-        BrowserRestartTool,
-        BrowserClickTool,
-        BrowserInputTool,
-        BrowserMoveMouseTool,
-        BrowserPressKeyTool,
-        BrowserSelectOptionTool,
-        BrowserScrollUpTool,
-        BrowserScrollDownTool,
-        BrowserConsoleExecTool,
-        BrowserConsoleViewTool,
-    ]
-
+    
     def __init__(self, browser: Browser):
         """Initialize browser tool class
-
+        
         Args:
             browser: Browser service
         """
-        self.browser = browser
         super().__init__()
+        self.browser = browser
+    
+    @tool
+    async def browser_view(self) -> ToolResult:
+        """View content of the current browser page. Use for checking the latest state of previously opened pages.
+        """
+        return await self.browser.view_page()
+    
+    @tool
+    async def browser_navigate(self, url: str) -> ToolResult:
+        """Navigate browser to specified URL. Use when accessing new pages is needed.
+        
+        Args:
+            url: Complete URL to visit. Must include protocol prefix.
+        """
+        return await self.browser.navigate(url)
+    
+    @tool
+    async def browser_restart(self, url: str) -> ToolResult:
+        """Restart browser and navigate to specified URL. Use when browser state needs to be reset.
+        
+        Args:
+            url: Complete URL to visit after restart. Must include protocol prefix.
+        """
+        return await self.browser.restart(url)
+    
+    @tool
+    async def browser_click(
+        self,
+        index: Optional[int] = None,
+        coordinate_x: Optional[float] = None,
+        coordinate_y: Optional[float] = None
+    ) -> ToolResult:
+        """Click on elements in the current browser page. Use when clicking page elements is needed.
+        
+        Args:
+            index: (Optional) Index number of the element to click
+            coordinate_x: (Optional) X coordinate of click position
+            coordinate_y: (Optional) Y coordinate of click position
+        """
+        return await self.browser.click(index, coordinate_x, coordinate_y)
+    
+    @tool
+    async def browser_input(
+        self,
+        text: str,
+        press_enter: bool,
+        index: Optional[int] = None,
+        coordinate_x: Optional[float] = None,
+        coordinate_y: Optional[float] = None
+    ) -> ToolResult:
+        """Overwrite text in editable elements on the current browser page. Use when filling content in input fields.
+        
+        Args:
+            index: (Optional) Index number of the element to overwrite text
+            coordinate_x: (Optional) X coordinate of the element to overwrite text
+            coordinate_y: (Optional) Y coordinate of the element to overwrite text
+            text: Complete text content to overwrite
+            press_enter: Whether to press Enter key after input
+        """
+        return await self.browser.input(text, press_enter, index, coordinate_x, coordinate_y)
+    
+    @tool
+    async def browser_move_mouse(
+        self,
+        coordinate_x: float,
+        coordinate_y: float
+    ) -> ToolResult:
+        """Move cursor to specified position on the current browser page. Use when simulating user mouse movement.
+        
+        Args:
+            coordinate_x: X coordinate of target cursor position
+            coordinate_y: Y coordinate of target cursor position
+        """
+        return await self.browser.move_mouse(coordinate_x, coordinate_y)
+    
+    @tool
+    async def browser_press_key(
+        self,
+        key: str
+    ) -> ToolResult:
+        """Simulate key press in the current browser page. Use when specific keyboard operations are needed.
+        
+        Args:
+            key: Key name to simulate (e.g., Enter, Tab, ArrowUp), supports key combinations (e.g., Control+Enter).
+        """
+        return await self.browser.press_key(key)
+    
+    @tool
+    async def browser_select_option(
+        self,
+        index: int,
+        option: int
+    ) -> ToolResult:
+        """Select specified option from dropdown list element in the current browser page. Use when selecting dropdown menu options.
+        
+        Args:
+            index: Index number of the dropdown list element
+            option: Option number to select, starting from 0.
+        """
+        return await self.browser.select_option(index, option)
+    
+    @tool
+    async def browser_scroll_up(
+        self,
+        to_top: Optional[bool] = None
+    ) -> ToolResult:
+        """Scroll up the current browser page. Use when viewing content above or returning to page top.
+        
+        Args:
+            to_top: (Optional) Whether to scroll directly to page top instead of one viewport up.
+        """
+        return await self.browser.scroll_up(to_top)
+    
+    @tool
+    async def browser_scroll_down(
+        self,
+        to_bottom: Optional[bool] = None
+    ) -> ToolResult:
+        """Scroll down the current browser page. Use when viewing content below or jumping to page bottom.
+        
+        Args:
+            to_bottom: (Optional) Whether to scroll directly to page bottom instead of one viewport down.
+        """
+        return await self.browser.scroll_down(to_bottom)
+    
+    @tool
+    async def browser_console_exec(
+        self,
+        javascript: str
+    ) -> ToolResult:
+        """Execute JavaScript code in browser console. Use when custom scripts need to be executed.
+        
+        Args:
+            javascript: JavaScript code to execute. Note that the runtime environment is browser console.
+        """
+        return await self.browser.console_exec(javascript)
+    
+    @tool
+    async def browser_console_view(
+        self,
+        max_lines: Optional[int] = None
+    ) -> ToolResult:
+        """View browser console output. Use when checking JavaScript logs or debugging page errors.
+        
+        Args:
+            max_lines: (Optional) Maximum number of log lines to return.
+        """
+        return await self.browser.console_view(max_lines) 

--- a/backend/app/domain/services/tools/browser.py
+++ b/backend/app/domain/services/tools/browser.py
@@ -1,7 +1,218 @@
 from typing import Optional
+
+from pydantic import BaseModel, Field
+
 from app.domain.external.browser import Browser
-from app.domain.services.tools.base import BaseToolkit, tool
 from app.domain.models.tool_result import ToolResult
+from app.domain.services.tools.base import BaseToolkit, Tool
+
+
+class BrowserViewTool(Tool):
+    name = "browser_view"
+    description = (
+        "View content of the current browser page. Use for checking the latest "
+        "state of previously opened pages."
+    )
+
+    class Args(BaseModel):
+        pass
+
+    async def run(self) -> ToolResult:
+        return await self.toolkit.browser.view_page()
+
+
+class BrowserNavigateTool(Tool):
+    name = "browser_navigate"
+    description = "Navigate browser to specified URL. Use when accessing new pages is needed."
+
+    class Args(BaseModel):
+        url: str = Field(description="Complete URL to visit. Must include protocol prefix.")
+
+    async def run(self, url: str) -> ToolResult:
+        return await self.toolkit.browser.navigate(url)
+
+
+class BrowserRestartTool(Tool):
+    name = "browser_restart"
+    description = (
+        "Restart browser and navigate to specified URL. Use when browser state needs to be reset."
+    )
+
+    class Args(BaseModel):
+        url: str = Field(
+            description="Complete URL to visit after restart. Must include protocol prefix."
+        )
+
+    async def run(self, url: str) -> ToolResult:
+        return await self.toolkit.browser.restart(url)
+
+
+class BrowserClickTool(Tool):
+    name = "browser_click"
+    description = "Click on elements in the current browser page. Use when clicking page elements is needed."
+
+    class Args(BaseModel):
+        index: Optional[int] = Field(
+            default=None, description="(Optional) Index number of the element to click"
+        )
+        coordinate_x: Optional[float] = Field(
+            default=None, description="(Optional) X coordinate of click position"
+        )
+        coordinate_y: Optional[float] = Field(
+            default=None, description="(Optional) Y coordinate of click position"
+        )
+
+    async def run(
+        self,
+        index: Optional[int] = None,
+        coordinate_x: Optional[float] = None,
+        coordinate_y: Optional[float] = None,
+    ) -> ToolResult:
+        return await self.toolkit.browser.click(index, coordinate_x, coordinate_y)
+
+
+class BrowserInputTool(Tool):
+    name = "browser_input"
+    description = (
+        "Overwrite text in editable elements on the current browser page. "
+        "Use when filling content in input fields."
+    )
+
+    class Args(BaseModel):
+        text: str = Field(description="Complete text content to overwrite")
+        press_enter: bool = Field(description="Whether to press Enter key after input")
+        index: Optional[int] = Field(
+            default=None, description="(Optional) Index number of the element to overwrite text"
+        )
+        coordinate_x: Optional[float] = Field(
+            default=None, description="(Optional) X coordinate of the element to overwrite text"
+        )
+        coordinate_y: Optional[float] = Field(
+            default=None, description="(Optional) Y coordinate of the element to overwrite text"
+        )
+
+    async def run(
+        self,
+        text: str,
+        press_enter: bool,
+        index: Optional[int] = None,
+        coordinate_x: Optional[float] = None,
+        coordinate_y: Optional[float] = None,
+    ) -> ToolResult:
+        return await self.toolkit.browser.input(
+            text, press_enter, index, coordinate_x, coordinate_y
+        )
+
+
+class BrowserMoveMouseTool(Tool):
+    name = "browser_move_mouse"
+    description = (
+        "Move cursor to specified position on the current browser page. "
+        "Use when simulating user mouse movement."
+    )
+
+    class Args(BaseModel):
+        coordinate_x: float = Field(description="X coordinate of target cursor position")
+        coordinate_y: float = Field(description="Y coordinate of target cursor position")
+
+    async def run(self, coordinate_x: float, coordinate_y: float) -> ToolResult:
+        return await self.toolkit.browser.move_mouse(coordinate_x, coordinate_y)
+
+
+class BrowserPressKeyTool(Tool):
+    name = "browser_press_key"
+    description = (
+        "Simulate key press in the current browser page. Use when specific keyboard operations are needed."
+    )
+
+    class Args(BaseModel):
+        key: str = Field(
+            description=(
+                "Key name to simulate (e.g., Enter, Tab, ArrowUp), "
+                "supports key combinations (e.g., Control+Enter)."
+            )
+        )
+
+    async def run(self, key: str) -> ToolResult:
+        return await self.toolkit.browser.press_key(key)
+
+
+class BrowserSelectOptionTool(Tool):
+    name = "browser_select_option"
+    description = (
+        "Select specified option from dropdown list element in the current browser page. "
+        "Use when selecting dropdown menu options."
+    )
+
+    class Args(BaseModel):
+        index: int = Field(description="Index number of the dropdown list element")
+        option: int = Field(description="Option number to select, starting from 0.")
+
+    async def run(self, index: int, option: int) -> ToolResult:
+        return await self.toolkit.browser.select_option(index, option)
+
+
+class BrowserScrollUpTool(Tool):
+    name = "browser_scroll_up"
+    description = (
+        "Scroll up the current browser page. Use when viewing content above or returning to page top."
+    )
+
+    class Args(BaseModel):
+        to_top: Optional[bool] = Field(
+            default=None,
+            description="(Optional) Whether to scroll directly to page top instead of one viewport up.",
+        )
+
+    async def run(self, to_top: Optional[bool] = None) -> ToolResult:
+        return await self.toolkit.browser.scroll_up(to_top)
+
+
+class BrowserScrollDownTool(Tool):
+    name = "browser_scroll_down"
+    description = (
+        "Scroll down the current browser page. Use when viewing content below or jumping to page bottom."
+    )
+
+    class Args(BaseModel):
+        to_bottom: Optional[bool] = Field(
+            default=None,
+            description="(Optional) Whether to scroll directly to page bottom instead of one viewport down.",
+        )
+
+    async def run(self, to_bottom: Optional[bool] = None) -> ToolResult:
+        return await self.toolkit.browser.scroll_down(to_bottom)
+
+
+class BrowserConsoleExecTool(Tool):
+    name = "browser_console_exec"
+    description = (
+        "Execute JavaScript code in browser console. Use when custom scripts need to be executed."
+    )
+
+    class Args(BaseModel):
+        javascript: str = Field(
+            description="JavaScript code to execute. Note that the runtime environment is browser console."
+        )
+
+    async def run(self, javascript: str) -> ToolResult:
+        return await self.toolkit.browser.console_exec(javascript)
+
+
+class BrowserConsoleViewTool(Tool):
+    name = "browser_console_view"
+    description = (
+        "View browser console output. Use when checking JavaScript logs or debugging page errors."
+    )
+
+    class Args(BaseModel):
+        max_lines: Optional[int] = Field(
+            default=None, description="(Optional) Maximum number of log lines to return."
+        )
+
+    async def run(self, max_lines: Optional[int] = None) -> ToolResult:
+        return await self.toolkit.browser.console_view(max_lines)
+
 
 class BrowserToolkit(BaseToolkit):
     """Browser tool class, providing browser interaction functions"""
@@ -16,160 +227,26 @@ class BrowserToolkit(BaseToolkit):
 - Pages are auto-extracted to Markdown when possible; the extraction may include off-screen text but omits links/images and is not guaranteed complete
 - If the extracted Markdown already covers what you need, don't scroll; otherwise scroll to view the full page
 """
-    
+    tool_types = [
+        BrowserViewTool,
+        BrowserNavigateTool,
+        BrowserRestartTool,
+        BrowserClickTool,
+        BrowserInputTool,
+        BrowserMoveMouseTool,
+        BrowserPressKeyTool,
+        BrowserSelectOptionTool,
+        BrowserScrollUpTool,
+        BrowserScrollDownTool,
+        BrowserConsoleExecTool,
+        BrowserConsoleViewTool,
+    ]
+
     def __init__(self, browser: Browser):
         """Initialize browser tool class
-        
+
         Args:
             browser: Browser service
         """
-        super().__init__()
         self.browser = browser
-    
-    @tool(parse_docstring=True)
-    async def browser_view(self) -> ToolResult:
-        """View content of the current browser page. Use for checking the latest state of previously opened pages.
-        """
-        return await self.browser.view_page()
-    
-    @tool(parse_docstring=True)
-    async def browser_navigate(self, url: str) -> ToolResult:
-        """Navigate browser to specified URL. Use when accessing new pages is needed.
-        
-        Args:
-            url: Complete URL to visit. Must include protocol prefix.
-        """
-        return await self.browser.navigate(url)
-    
-    @tool(parse_docstring=True)
-    async def browser_restart(self, url: str) -> ToolResult:
-        """Restart browser and navigate to specified URL. Use when browser state needs to be reset.
-        
-        Args:
-            url: Complete URL to visit after restart. Must include protocol prefix.
-        """
-        return await self.browser.restart(url)
-    
-    @tool(parse_docstring=True)
-    async def browser_click(
-        self,
-        index: Optional[int] = None,
-        coordinate_x: Optional[float] = None,
-        coordinate_y: Optional[float] = None
-    ) -> ToolResult:
-        """Click on elements in the current browser page. Use when clicking page elements is needed.
-        
-        Args:
-            index: (Optional) Index number of the element to click
-            coordinate_x: (Optional) X coordinate of click position
-            coordinate_y: (Optional) Y coordinate of click position
-        """
-        return await self.browser.click(index, coordinate_x, coordinate_y)
-    
-    @tool(parse_docstring=True)
-    async def browser_input(
-        self,
-        text: str,
-        press_enter: bool,
-        index: Optional[int] = None,
-        coordinate_x: Optional[float] = None,
-        coordinate_y: Optional[float] = None
-    ) -> ToolResult:
-        """Overwrite text in editable elements on the current browser page. Use when filling content in input fields.
-        
-        Args:
-            index: (Optional) Index number of the element to overwrite text
-            coordinate_x: (Optional) X coordinate of the element to overwrite text
-            coordinate_y: (Optional) Y coordinate of the element to overwrite text
-            text: Complete text content to overwrite
-            press_enter: Whether to press Enter key after input
-        """
-        return await self.browser.input(text, press_enter, index, coordinate_x, coordinate_y)
-    
-    @tool(parse_docstring=True)
-    async def browser_move_mouse(
-        self,
-        coordinate_x: float,
-        coordinate_y: float
-    ) -> ToolResult:
-        """Move cursor to specified position on the current browser page. Use when simulating user mouse movement.
-        
-        Args:
-            coordinate_x: X coordinate of target cursor position
-            coordinate_y: Y coordinate of target cursor position
-        """
-        return await self.browser.move_mouse(coordinate_x, coordinate_y)
-    
-    @tool(parse_docstring=True)
-    async def browser_press_key(
-        self,
-        key: str
-    ) -> ToolResult:
-        """Simulate key press in the current browser page. Use when specific keyboard operations are needed.
-        
-        Args:
-            key: Key name to simulate (e.g., Enter, Tab, ArrowUp), supports key combinations (e.g., Control+Enter).
-        """
-        return await self.browser.press_key(key)
-    
-    @tool(parse_docstring=True)
-    async def browser_select_option(
-        self,
-        index: int,
-        option: int
-    ) -> ToolResult:
-        """Select specified option from dropdown list element in the current browser page. Use when selecting dropdown menu options.
-        
-        Args:
-            index: Index number of the dropdown list element
-            option: Option number to select, starting from 0.
-        """
-        return await self.browser.select_option(index, option)
-    
-    @tool(parse_docstring=True)
-    async def browser_scroll_up(
-        self,
-        to_top: Optional[bool] = None
-    ) -> ToolResult:
-        """Scroll up the current browser page. Use when viewing content above or returning to page top.
-        
-        Args:
-            to_top: (Optional) Whether to scroll directly to page top instead of one viewport up.
-        """
-        return await self.browser.scroll_up(to_top)
-    
-    @tool(parse_docstring=True)
-    async def browser_scroll_down(
-        self,
-        to_bottom: Optional[bool] = None
-    ) -> ToolResult:
-        """Scroll down the current browser page. Use when viewing content below or jumping to page bottom.
-        
-        Args:
-            to_bottom: (Optional) Whether to scroll directly to page bottom instead of one viewport down.
-        """
-        return await self.browser.scroll_down(to_bottom)
-    
-    @tool(parse_docstring=True)
-    async def browser_console_exec(
-        self,
-        javascript: str
-    ) -> ToolResult:
-        """Execute JavaScript code in browser console. Use when custom scripts need to be executed.
-        
-        Args:
-            javascript: JavaScript code to execute. Note that the runtime environment is browser console.
-        """
-        return await self.browser.console_exec(javascript)
-    
-    @tool(parse_docstring=True)
-    async def browser_console_view(
-        self,
-        max_lines: Optional[int] = None
-    ) -> ToolResult:
-        """View browser console output. Use when checking JavaScript logs or debugging page errors.
-        
-        Args:
-            max_lines: (Optional) Maximum number of log lines to return.
-        """
-        return await self.browser.console_view(max_lines) 
+        super().__init__()

--- a/backend/app/domain/services/tools/file.py
+++ b/backend/app/domain/services/tools/file.py
@@ -1,166 +1,7 @@
-from typing import Optional
-
-from pydantic import BaseModel, Field
-
+from typing import Optional, Dict, Any
 from app.domain.external.sandbox import Sandbox
+from app.domain.services.tools.base import BaseToolkit, tool
 from app.domain.models.tool_result import ToolResult
-from app.domain.services.tools.base import BaseToolkit, Tool
-
-
-class FileReadTool(Tool):
-    name = "file_read"
-    description = (
-        "Read file content. Use for checking file contents, analyzing logs, "
-        "or reading configuration files."
-    )
-
-    class Args(BaseModel):
-        file: str = Field(description="Absolute path of the file to read")
-        start_line: Optional[int] = Field(
-            default=None,
-            description="(Optional) Starting line to read from, 0-based. If not specified, starts from beginning",
-        )
-        end_line: Optional[int] = Field(
-            default=None,
-            description="(Optional) Ending line number (exclusive). If not specified, reads entire file",
-        )
-        sudo: Optional[bool] = Field(
-            default=False,
-            description="(Optional) Whether to use sudo privileges, defaults to false",
-        )
-
-    async def run(
-        self,
-        file: str,
-        start_line: Optional[int] = None,
-        end_line: Optional[int] = None,
-        sudo: Optional[bool] = False,
-    ) -> ToolResult:
-        return await self.toolkit.sandbox.file_read(
-            file=file,
-            start_line=start_line,
-            end_line=end_line,
-            sudo=sudo,
-        )
-
-
-class FileWriteTool(Tool):
-    name = "file_write"
-    description = (
-        "Overwrite or append content to a file. Use for creating new files, "
-        "appending content, or modifying existing files."
-    )
-
-    class Args(BaseModel):
-        file: str = Field(description="Absolute path of the file to write to")
-        content: str = Field(description="Text content to write")
-        append: Optional[bool] = Field(
-            default=False, description="(Optional) Whether to use append mode"
-        )
-        leading_newline: Optional[bool] = Field(
-            default=False, description="(Optional) Whether to add a leading newline"
-        )
-        trailing_newline: Optional[bool] = Field(
-            default=False, description="(Optional) Whether to add a trailing newline"
-        )
-        sudo: Optional[bool] = Field(
-            default=False, description="(Optional) Whether to use sudo privileges"
-        )
-
-    async def run(
-        self,
-        file: str,
-        content: str,
-        append: Optional[bool] = False,
-        leading_newline: Optional[bool] = False,
-        trailing_newline: Optional[bool] = False,
-        sudo: Optional[bool] = False,
-    ) -> ToolResult:
-        final_content = content
-        if leading_newline:
-            final_content = "\n" + final_content
-        if trailing_newline:
-            final_content = final_content + "\n"
-
-        return await self.toolkit.sandbox.file_write(
-            file=file,
-            content=final_content,
-            append=append,
-            leading_newline=False,
-            trailing_newline=False,
-            sudo=sudo,
-        )
-
-
-class FileStrReplaceTool(Tool):
-    name = "file_str_replace"
-    description = (
-        "Replace specified string in a file. Use for updating specific content "
-        "in files or fixing errors in code."
-    )
-
-    class Args(BaseModel):
-        file: str = Field(description="Absolute path of the file to perform replacement on")
-        old_str: str = Field(description="Original string to be replaced")
-        new_str: str = Field(description="New string to replace with")
-        sudo: Optional[bool] = Field(
-            default=False, description="(Optional) Whether to use sudo privileges"
-        )
-
-    async def run(
-        self,
-        file: str,
-        old_str: str,
-        new_str: str,
-        sudo: Optional[bool] = False,
-    ) -> ToolResult:
-        return await self.toolkit.sandbox.file_replace(
-            file=file,
-            old_str=old_str,
-            new_str=new_str,
-            sudo=sudo,
-        )
-
-
-class FileFindInContentTool(Tool):
-    name = "file_find_in_content"
-    description = (
-        "Search for matching text within file content. Use for finding specific "
-        "content or patterns in files."
-    )
-
-    class Args(BaseModel):
-        file: str = Field(description="Absolute path of the file to search within")
-        regex: str = Field(description="Regular expression pattern to match")
-        sudo: Optional[bool] = Field(
-            default=False, description="(Optional) Whether to use sudo privileges"
-        )
-
-    async def run(self, file: str, regex: str, sudo: Optional[bool] = False) -> ToolResult:
-        return await self.toolkit.sandbox.file_search(
-            file=file,
-            regex=regex,
-            sudo=sudo,
-        )
-
-
-class FileFindByNameTool(Tool):
-    name = "file_find_by_name"
-    description = (
-        "Find files by name pattern in specified directory. Use for locating "
-        "files with specific naming patterns."
-    )
-
-    class Args(BaseModel):
-        path: str = Field(description="Absolute path of directory to search")
-        glob: str = Field(description="Filename pattern using glob syntax wildcards")
-
-    async def run(self, path: str, glob: str) -> ToolResult:
-        return await self.toolkit.sandbox.file_find(
-            path=path,
-            glob_pattern=glob,
-        )
-
 
 class FileToolkit(BaseToolkit):
     """File tool class, providing file operation functions"""
@@ -175,19 +16,136 @@ class FileToolkit(BaseToolkit):
 - Use line range limits appropriately; when uncertain, start by reading the first 20 lines
 - Be mindful of performance impact with large files
 """
-    tool_types = [
-        FileReadTool,
-        FileWriteTool,
-        FileStrReplaceTool,
-        FileFindInContentTool,
-        FileFindByNameTool,
-    ]
-
+    
     def __init__(self, sandbox: Sandbox):
         """Initialize file tool class
-
+        
         Args:
             sandbox: Sandbox service
         """
-        self.sandbox = sandbox
         super().__init__()
+        self.sandbox = sandbox
+        
+    @tool
+    async def file_read(
+        self,
+        file: str,
+        start_line: Optional[int] = None,
+        end_line: Optional[int] = None,
+        sudo: Optional[bool] = False
+    ) -> ToolResult:
+        """Read file content. Use for checking file contents, analyzing logs, or reading configuration files.
+        
+        Args:
+            file: Absolute path of the file to read
+            start_line: (Optional) Starting line to read from, 0-based. If not specified, starts from beginning
+            end_line: (Optional) Ending line number (exclusive). If not specified, reads entire file
+            sudo: (Optional) Whether to use sudo privileges, defaults to false
+        """
+        # Directly call sandbox's file_read method
+        return await self.sandbox.file_read(
+            file=file,
+            start_line=start_line,
+            end_line=end_line,
+            sudo=sudo
+        )
+    
+    @tool
+    async def file_write(
+        self,
+        file: str,
+        content: str,
+        append: Optional[bool] = False,
+        leading_newline: Optional[bool] = False,
+        trailing_newline: Optional[bool] = False,
+        sudo: Optional[bool] = False
+    ) -> ToolResult:
+        """Overwrite or append content to a file. Use for creating new files, appending content, or modifying existing files.
+        
+        Args:
+            file: Absolute path of the file to write to
+            content: Text content to write
+            append: (Optional) Whether to use append mode
+            leading_newline: (Optional) Whether to add a leading newline
+            trailing_newline: (Optional) Whether to add a trailing newline
+            sudo: (Optional) Whether to use sudo privileges
+        """
+        # Prepare content
+        final_content = content
+        if leading_newline:
+            final_content = "\n" + final_content
+        if trailing_newline:
+            final_content = final_content + "\n"
+            
+        # Directly call sandbox's file_write method, pass all parameters
+        return await self.sandbox.file_write(
+            file=file, 
+            content=final_content,
+            append=append,
+            leading_newline=False,  # Already handled in final_content
+            trailing_newline=False,  # Already handled in final_content
+            sudo=sudo
+        )
+    
+    @tool
+    async def file_str_replace(
+        self,
+        file: str,
+        old_str: str,
+        new_str: str,
+        sudo: Optional[bool] = False
+    ) -> ToolResult:
+        """Replace specified string in a file. Use for updating specific content in files or fixing errors in code.
+        
+        Args:
+            file: Absolute path of the file to perform replacement on
+            old_str: Original string to be replaced
+            new_str: New string to replace with
+            sudo: (Optional) Whether to use sudo privileges
+        """
+        # Directly call sandbox's file_replace method
+        return await self.sandbox.file_replace(
+            file=file,
+            old_str=old_str,
+            new_str=new_str,
+            sudo=sudo
+        )
+    
+    @tool
+    async def file_find_in_content(
+        self,
+        file: str,
+        regex: str,
+        sudo: Optional[bool] = False
+    ) -> ToolResult:
+        """Search for matching text within file content. Use for finding specific content or patterns in files.
+        
+        Args:
+            file: Absolute path of the file to search within
+            regex: Regular expression pattern to match
+            sudo: (Optional) Whether to use sudo privileges
+        """
+        # Directly call sandbox's file_search method
+        return await self.sandbox.file_search(
+            file=file,
+            regex=regex,
+            sudo=sudo
+        )
+    
+    @tool
+    async def file_find_by_name(
+        self,
+        path: str,
+        glob: str
+    ) -> ToolResult:
+        """Find files by name pattern in specified directory. Use for locating files with specific naming patterns.
+        
+        Args:
+            path: Absolute path of directory to search
+            glob: Filename pattern using glob syntax wildcards
+        """
+        # Directly call sandbox's file_find method
+        return await self.sandbox.file_find(
+            path=path,
+            glob_pattern=glob
+        ) 

--- a/backend/app/domain/services/tools/file.py
+++ b/backend/app/domain/services/tools/file.py
@@ -1,7 +1,166 @@
-from typing import Optional, Dict, Any
+from typing import Optional
+
+from pydantic import BaseModel, Field
+
 from app.domain.external.sandbox import Sandbox
-from app.domain.services.tools.base import BaseToolkit, tool
 from app.domain.models.tool_result import ToolResult
+from app.domain.services.tools.base import BaseToolkit, Tool
+
+
+class FileReadTool(Tool):
+    name = "file_read"
+    description = (
+        "Read file content. Use for checking file contents, analyzing logs, "
+        "or reading configuration files."
+    )
+
+    class Args(BaseModel):
+        file: str = Field(description="Absolute path of the file to read")
+        start_line: Optional[int] = Field(
+            default=None,
+            description="(Optional) Starting line to read from, 0-based. If not specified, starts from beginning",
+        )
+        end_line: Optional[int] = Field(
+            default=None,
+            description="(Optional) Ending line number (exclusive). If not specified, reads entire file",
+        )
+        sudo: Optional[bool] = Field(
+            default=False,
+            description="(Optional) Whether to use sudo privileges, defaults to false",
+        )
+
+    async def run(
+        self,
+        file: str,
+        start_line: Optional[int] = None,
+        end_line: Optional[int] = None,
+        sudo: Optional[bool] = False,
+    ) -> ToolResult:
+        return await self.toolkit.sandbox.file_read(
+            file=file,
+            start_line=start_line,
+            end_line=end_line,
+            sudo=sudo,
+        )
+
+
+class FileWriteTool(Tool):
+    name = "file_write"
+    description = (
+        "Overwrite or append content to a file. Use for creating new files, "
+        "appending content, or modifying existing files."
+    )
+
+    class Args(BaseModel):
+        file: str = Field(description="Absolute path of the file to write to")
+        content: str = Field(description="Text content to write")
+        append: Optional[bool] = Field(
+            default=False, description="(Optional) Whether to use append mode"
+        )
+        leading_newline: Optional[bool] = Field(
+            default=False, description="(Optional) Whether to add a leading newline"
+        )
+        trailing_newline: Optional[bool] = Field(
+            default=False, description="(Optional) Whether to add a trailing newline"
+        )
+        sudo: Optional[bool] = Field(
+            default=False, description="(Optional) Whether to use sudo privileges"
+        )
+
+    async def run(
+        self,
+        file: str,
+        content: str,
+        append: Optional[bool] = False,
+        leading_newline: Optional[bool] = False,
+        trailing_newline: Optional[bool] = False,
+        sudo: Optional[bool] = False,
+    ) -> ToolResult:
+        final_content = content
+        if leading_newline:
+            final_content = "\n" + final_content
+        if trailing_newline:
+            final_content = final_content + "\n"
+
+        return await self.toolkit.sandbox.file_write(
+            file=file,
+            content=final_content,
+            append=append,
+            leading_newline=False,
+            trailing_newline=False,
+            sudo=sudo,
+        )
+
+
+class FileStrReplaceTool(Tool):
+    name = "file_str_replace"
+    description = (
+        "Replace specified string in a file. Use for updating specific content "
+        "in files or fixing errors in code."
+    )
+
+    class Args(BaseModel):
+        file: str = Field(description="Absolute path of the file to perform replacement on")
+        old_str: str = Field(description="Original string to be replaced")
+        new_str: str = Field(description="New string to replace with")
+        sudo: Optional[bool] = Field(
+            default=False, description="(Optional) Whether to use sudo privileges"
+        )
+
+    async def run(
+        self,
+        file: str,
+        old_str: str,
+        new_str: str,
+        sudo: Optional[bool] = False,
+    ) -> ToolResult:
+        return await self.toolkit.sandbox.file_replace(
+            file=file,
+            old_str=old_str,
+            new_str=new_str,
+            sudo=sudo,
+        )
+
+
+class FileFindInContentTool(Tool):
+    name = "file_find_in_content"
+    description = (
+        "Search for matching text within file content. Use for finding specific "
+        "content or patterns in files."
+    )
+
+    class Args(BaseModel):
+        file: str = Field(description="Absolute path of the file to search within")
+        regex: str = Field(description="Regular expression pattern to match")
+        sudo: Optional[bool] = Field(
+            default=False, description="(Optional) Whether to use sudo privileges"
+        )
+
+    async def run(self, file: str, regex: str, sudo: Optional[bool] = False) -> ToolResult:
+        return await self.toolkit.sandbox.file_search(
+            file=file,
+            regex=regex,
+            sudo=sudo,
+        )
+
+
+class FileFindByNameTool(Tool):
+    name = "file_find_by_name"
+    description = (
+        "Find files by name pattern in specified directory. Use for locating "
+        "files with specific naming patterns."
+    )
+
+    class Args(BaseModel):
+        path: str = Field(description="Absolute path of directory to search")
+        glob: str = Field(description="Filename pattern using glob syntax wildcards")
+
+    async def run(self, path: str, glob: str) -> ToolResult:
+        return await self.toolkit.sandbox.file_find(
+            path=path,
+            glob_pattern=glob,
+        )
+
 
 class FileToolkit(BaseToolkit):
     """File tool class, providing file operation functions"""
@@ -16,136 +175,19 @@ class FileToolkit(BaseToolkit):
 - Use line range limits appropriately; when uncertain, start by reading the first 20 lines
 - Be mindful of performance impact with large files
 """
-    
+    tool_types = [
+        FileReadTool,
+        FileWriteTool,
+        FileStrReplaceTool,
+        FileFindInContentTool,
+        FileFindByNameTool,
+    ]
+
     def __init__(self, sandbox: Sandbox):
         """Initialize file tool class
-        
+
         Args:
             sandbox: Sandbox service
         """
-        super().__init__()
         self.sandbox = sandbox
-        
-    @tool(parse_docstring=True)
-    async def file_read(
-        self,
-        file: str,
-        start_line: Optional[int] = None,
-        end_line: Optional[int] = None,
-        sudo: Optional[bool] = False
-    ) -> ToolResult:
-        """Read file content. Use for checking file contents, analyzing logs, or reading configuration files.
-        
-        Args:
-            file: Absolute path of the file to read
-            start_line: (Optional) Starting line to read from, 0-based. If not specified, starts from beginning
-            end_line: (Optional) Ending line number (exclusive). If not specified, reads entire file
-            sudo: (Optional) Whether to use sudo privileges, defaults to false
-        """
-        # Directly call sandbox's file_read method
-        return await self.sandbox.file_read(
-            file=file,
-            start_line=start_line,
-            end_line=end_line,
-            sudo=sudo
-        )
-    
-    @tool(parse_docstring=True)
-    async def file_write(
-        self,
-        file: str,
-        content: str,
-        append: Optional[bool] = False,
-        leading_newline: Optional[bool] = False,
-        trailing_newline: Optional[bool] = False,
-        sudo: Optional[bool] = False
-    ) -> ToolResult:
-        """Overwrite or append content to a file. Use for creating new files, appending content, or modifying existing files.
-        
-        Args:
-            file: Absolute path of the file to write to
-            content: Text content to write
-            append: (Optional) Whether to use append mode
-            leading_newline: (Optional) Whether to add a leading newline
-            trailing_newline: (Optional) Whether to add a trailing newline
-            sudo: (Optional) Whether to use sudo privileges
-        """
-        # Prepare content
-        final_content = content
-        if leading_newline:
-            final_content = "\n" + final_content
-        if trailing_newline:
-            final_content = final_content + "\n"
-            
-        # Directly call sandbox's file_write method, pass all parameters
-        return await self.sandbox.file_write(
-            file=file, 
-            content=final_content,
-            append=append,
-            leading_newline=False,  # Already handled in final_content
-            trailing_newline=False,  # Already handled in final_content
-            sudo=sudo
-        )
-    
-    @tool(parse_docstring=True)
-    async def file_str_replace(
-        self,
-        file: str,
-        old_str: str,
-        new_str: str,
-        sudo: Optional[bool] = False
-    ) -> ToolResult:
-        """Replace specified string in a file. Use for updating specific content in files or fixing errors in code.
-        
-        Args:
-            file: Absolute path of the file to perform replacement on
-            old_str: Original string to be replaced
-            new_str: New string to replace with
-            sudo: (Optional) Whether to use sudo privileges
-        """
-        # Directly call sandbox's file_replace method
-        return await self.sandbox.file_replace(
-            file=file,
-            old_str=old_str,
-            new_str=new_str,
-            sudo=sudo
-        )
-    
-    @tool(parse_docstring=True)
-    async def file_find_in_content(
-        self,
-        file: str,
-        regex: str,
-        sudo: Optional[bool] = False
-    ) -> ToolResult:
-        """Search for matching text within file content. Use for finding specific content or patterns in files.
-        
-        Args:
-            file: Absolute path of the file to search within
-            regex: Regular expression pattern to match
-            sudo: (Optional) Whether to use sudo privileges
-        """
-        # Directly call sandbox's file_search method
-        return await self.sandbox.file_search(
-            file=file,
-            regex=regex,
-            sudo=sudo
-        )
-    
-    @tool(parse_docstring=True)
-    async def file_find_by_name(
-        self,
-        path: str,
-        glob: str
-    ) -> ToolResult:
-        """Find files by name pattern in specified directory. Use for locating files with specific naming patterns.
-        
-        Args:
-            path: Absolute path of directory to search
-            glob: Filename pattern using glob syntax wildcards
-        """
-        # Directly call sandbox's file_find method
-        return await self.sandbox.file_find(
-            path=path,
-            glob_pattern=glob
-        ) 
+        super().__init__()

--- a/backend/app/domain/services/tools/message.py
+++ b/backend/app/domain/services/tools/message.py
@@ -1,51 +1,6 @@
 from typing import List, Optional, Union
-
-from pydantic import BaseModel, Field
-
+from app.domain.services.tools.base import BaseToolkit, tool
 from app.domain.models.tool_result import ToolResult
-from app.domain.services.tools.base import BaseToolkit, Tool
-
-
-class MessageNotifyUserTool(Tool):
-    name = "message_notify_user"
-    description = (
-        "Send a message to user without requiring a response. Use for acknowledging "
-        "receipt of messages, providing progress updates, reporting task completion, "
-        "or explaining changes in approach."
-    )
-
-    class Args(BaseModel):
-        text: str = Field(description="Message text to display to user")
-
-    async def run(self, text: str) -> ToolResult:
-        return ToolResult(success=True, message="OK")
-
-
-class MessageAskUserTool(Tool):
-    name = "message_ask_user"
-    description = (
-        "Ask user a question and wait for response. Use for requesting "
-        "clarification, asking for confirmation, or gathering additional information."
-    )
-
-    class Args(BaseModel):
-        text: str = Field(description="Question text to present to user")
-        attachments: Optional[Union[str, List[str]]] = Field(
-            default=None,
-            description="(Optional) List of question-related files or reference materials",
-        )
-        suggest_user_takeover: Optional[str] = Field(
-            default=None,
-            description='(Optional) Suggested operation for user takeover (enum: "none" or "browser")',
-        )
-
-    async def run(
-        self,
-        text: str,
-        attachments: Optional[Union[str, List[str]]] = None,
-        suggest_user_takeover: Optional[str] = None,
-    ) -> ToolResult:
-        return ToolResult(success=True)
 
 
 class MessageToolkit(BaseToolkit):
@@ -61,8 +16,39 @@ class MessageToolkit(BaseToolkit):
 - When complete_step is available, end the current plan step with it (honest success/failure)
 - When deliver_result is available, use it for the overall final answer and output files
 """
-    tool_types = [MessageNotifyUserTool, MessageAskUserTool]
-
+    
     def __init__(self):
         """Initialize message tool class"""
         super().__init__()
+
+    @tool
+    async def message_notify_user(
+        self,
+        text: str
+    ) -> ToolResult:
+        """Send a message to user without requiring a response. Use for acknowledging receipt of messages, providing progress updates, reporting task completion, or explaining changes in approach.
+        
+        Args:
+            text: Message text to display to user
+        """
+            
+        # Return success result, actual UI display logic implemented by caller
+        return ToolResult(success=True, message="OK")
+    
+    @tool
+    async def message_ask_user(
+        self,
+        text: str,
+        attachments: Optional[Union[str, List[str]]] = None,
+        suggest_user_takeover: Optional[str] = None
+    ) -> ToolResult:
+        """Ask user a question and wait for response. Use for requesting clarification, asking for confirmation, or gathering additional information.
+        
+        Args:
+            text: Question text to present to user
+            attachments: (Optional) List of question-related files or reference materials
+            suggest_user_takeover: (Optional) Suggested operation for user takeover (enum: "none" or "browser")
+        """
+            
+        # Return success result, actual UI interaction logic implemented by caller
+        return ToolResult(success=True)

--- a/backend/app/domain/services/tools/message.py
+++ b/backend/app/domain/services/tools/message.py
@@ -1,6 +1,51 @@
 from typing import List, Optional, Union
-from app.domain.services.tools.base import BaseToolkit, tool
+
+from pydantic import BaseModel, Field
+
 from app.domain.models.tool_result import ToolResult
+from app.domain.services.tools.base import BaseToolkit, Tool
+
+
+class MessageNotifyUserTool(Tool):
+    name = "message_notify_user"
+    description = (
+        "Send a message to user without requiring a response. Use for acknowledging "
+        "receipt of messages, providing progress updates, reporting task completion, "
+        "or explaining changes in approach."
+    )
+
+    class Args(BaseModel):
+        text: str = Field(description="Message text to display to user")
+
+    async def run(self, text: str) -> ToolResult:
+        return ToolResult(success=True, message="OK")
+
+
+class MessageAskUserTool(Tool):
+    name = "message_ask_user"
+    description = (
+        "Ask user a question and wait for response. Use for requesting "
+        "clarification, asking for confirmation, or gathering additional information."
+    )
+
+    class Args(BaseModel):
+        text: str = Field(description="Question text to present to user")
+        attachments: Optional[Union[str, List[str]]] = Field(
+            default=None,
+            description="(Optional) List of question-related files or reference materials",
+        )
+        suggest_user_takeover: Optional[str] = Field(
+            default=None,
+            description='(Optional) Suggested operation for user takeover (enum: "none" or "browser")',
+        )
+
+    async def run(
+        self,
+        text: str,
+        attachments: Optional[Union[str, List[str]]] = None,
+        suggest_user_takeover: Optional[str] = None,
+    ) -> ToolResult:
+        return ToolResult(success=True)
 
 
 class MessageToolkit(BaseToolkit):
@@ -16,39 +61,8 @@ class MessageToolkit(BaseToolkit):
 - When complete_step is available, end the current plan step with it (honest success/failure)
 - When deliver_result is available, use it for the overall final answer and output files
 """
-    
+    tool_types = [MessageNotifyUserTool, MessageAskUserTool]
+
     def __init__(self):
         """Initialize message tool class"""
         super().__init__()
-
-    @tool(parse_docstring=True)
-    async def message_notify_user(
-        self,
-        text: str
-    ) -> ToolResult:
-        """Send a message to user without requiring a response. Use for acknowledging receipt of messages, providing progress updates, reporting task completion, or explaining changes in approach.
-        
-        Args:
-            text: Message text to display to user
-        """
-            
-        # Return success result, actual UI display logic implemented by caller
-        return ToolResult(success=True, message="OK")
-    
-    @tool(parse_docstring=True)
-    async def message_ask_user(
-        self,
-        text: str,
-        attachments: Optional[Union[str, List[str]]] = None,
-        suggest_user_takeover: Optional[str] = None
-    ) -> ToolResult:
-        """Ask user a question and wait for response. Use for requesting clarification, asking for confirmation, or gathering additional information.
-        
-        Args:
-            text: Question text to present to user
-            attachments: (Optional) List of question-related files or reference materials
-            suggest_user_takeover: (Optional) Suggested operation for user takeover (enum: "none" or "browser")
-        """
-            
-        # Return success result, actual UI interaction logic implemented by caller
-        return ToolResult(success=True)

--- a/backend/app/domain/services/tools/plan.py
+++ b/backend/app/domain/services/tools/plan.py
@@ -1,6 +1,8 @@
+from pydantic import BaseModel, Field
+
 from app.domain.models.agent_output import PlanReportOutput, ReplanOutput
 from app.domain.models.tool_result import ToolResult
-from app.domain.services.tools.base import BaseToolkit, tool
+from app.domain.services.tools.base import BaseToolkit, Tool
 
 
 def _normalize_step_statuses(steps: list[dict]) -> list[dict]:
@@ -14,26 +16,17 @@ def _normalize_step_statuses(steps: list[dict]) -> list[dict]:
     return normalized
 
 
-class PlanToolkit(BaseToolkit):
-    name = "plan"
-    instructions = """
-- The product Plan panel is authoritative and separate from todo.md.
-- After finishing or starting a planned step, call plan_report with a FULL
-  status snapshot for every known step id (pending|running|completed|failed).
-  Keep at most one step running.
-- Call replan with a clear reason when remaining steps no longer fit reality;
-  then rebuild /home/ubuntu/todo.md to match the new plan (attention only).
-- Do not invent Plan UI updates by only editing todo.md.
-"""
+class PlanReportTool(Tool):
+    name = "plan_report"
+    description = "Update authoritative plan step statuses for the Plan panel."
 
-    @tool(parse_docstring=True)
-    async def plan_report(self, steps: list[dict], reflection: str = "") -> ToolResult:
-        """Update authoritative plan step statuses for the Plan panel.
+    class Args(BaseModel):
+        steps: list[dict] = Field(
+            description="Full list of {id, status} (optional reflection per step)."
+        )
+        reflection: str = Field(default="", description="Optional short overall reflection.")
 
-        Args:
-            steps: Full list of {id, status} (optional reflection per step).
-            reflection: Optional short overall reflection.
-        """
+    async def run(self, steps: list[dict], reflection: str = "") -> ToolResult:
         parsed = PlanReportOutput.model_validate(
             {
                 "steps": _normalize_step_statuses(steps),
@@ -46,16 +39,32 @@ class PlanToolkit(BaseToolkit):
             data=parsed.model_dump(mode="json"),
         )
 
-    @tool(parse_docstring=True)
-    async def replan(self, reason: str) -> ToolResult:
-        """Request Planner to rewrite remaining steps.
 
-        Args:
-            reason: Why the current remaining plan is wrong or incomplete.
-        """
+class ReplanTool(Tool):
+    name = "replan"
+    description = "Request Planner to rewrite remaining steps."
+
+    class Args(BaseModel):
+        reason: str = Field(description="Why the current remaining plan is wrong or incomplete.")
+
+    async def run(self, reason: str) -> ToolResult:
         parsed = ReplanOutput.model_validate({"reason": reason})
         return ToolResult(
             success=True,
             message="Replan requested",
             data=parsed.model_dump(mode="json"),
         )
+
+
+class PlanToolkit(BaseToolkit):
+    name = "plan"
+    instructions = """
+- The product Plan panel is authoritative and separate from todo.md.
+- After finishing or starting a planned step, call plan_report with a FULL
+  status snapshot for every known step id (pending|running|completed|failed).
+  Keep at most one step running.
+- Call replan with a clear reason when remaining steps no longer fit reality;
+  then rebuild /home/ubuntu/todo.md to match the new plan (attention only).
+- Do not invent Plan UI updates by only editing todo.md.
+"""
+    tool_types = [PlanReportTool, ReplanTool]

--- a/backend/app/domain/services/tools/plan.py
+++ b/backend/app/domain/services/tools/plan.py
@@ -1,8 +1,6 @@
-from pydantic import BaseModel, Field
-
 from app.domain.models.agent_output import PlanReportOutput, ReplanOutput
 from app.domain.models.tool_result import ToolResult
-from app.domain.services.tools.base import BaseToolkit, Tool
+from app.domain.services.tools.base import BaseToolkit, tool
 
 
 def _normalize_step_statuses(steps: list[dict]) -> list[dict]:
@@ -16,17 +14,26 @@ def _normalize_step_statuses(steps: list[dict]) -> list[dict]:
     return normalized
 
 
-class PlanReportTool(Tool):
-    name = "plan_report"
-    description = "Update authoritative plan step statuses for the Plan panel."
+class PlanToolkit(BaseToolkit):
+    name = "plan"
+    instructions = """
+- The product Plan panel is authoritative and separate from todo.md.
+- After finishing or starting a planned step, call plan_report with a FULL
+  status snapshot for every known step id (pending|running|completed|failed).
+  Keep at most one step running.
+- Call replan with a clear reason when remaining steps no longer fit reality;
+  then rebuild /home/ubuntu/todo.md to match the new plan (attention only).
+- Do not invent Plan UI updates by only editing todo.md.
+"""
 
-    class Args(BaseModel):
-        steps: list[dict] = Field(
-            description="Full list of {id, status} (optional reflection per step)."
-        )
-        reflection: str = Field(default="", description="Optional short overall reflection.")
+    @tool
+    async def plan_report(self, steps: list[dict], reflection: str = "") -> ToolResult:
+        """Update authoritative plan step statuses for the Plan panel.
 
-    async def run(self, steps: list[dict], reflection: str = "") -> ToolResult:
+        Args:
+            steps: Full list of {id, status} (optional reflection per step).
+            reflection: Optional short overall reflection.
+        """
         parsed = PlanReportOutput.model_validate(
             {
                 "steps": _normalize_step_statuses(steps),
@@ -39,32 +46,16 @@ class PlanReportTool(Tool):
             data=parsed.model_dump(mode="json"),
         )
 
+    @tool
+    async def replan(self, reason: str) -> ToolResult:
+        """Request Planner to rewrite remaining steps.
 
-class ReplanTool(Tool):
-    name = "replan"
-    description = "Request Planner to rewrite remaining steps."
-
-    class Args(BaseModel):
-        reason: str = Field(description="Why the current remaining plan is wrong or incomplete.")
-
-    async def run(self, reason: str) -> ToolResult:
+        Args:
+            reason: Why the current remaining plan is wrong or incomplete.
+        """
         parsed = ReplanOutput.model_validate({"reason": reason})
         return ToolResult(
             success=True,
             message="Replan requested",
             data=parsed.model_dump(mode="json"),
         )
-
-
-class PlanToolkit(BaseToolkit):
-    name = "plan"
-    instructions = """
-- The product Plan panel is authoritative and separate from todo.md.
-- After finishing or starting a planned step, call plan_report with a FULL
-  status snapshot for every known step id (pending|running|completed|failed).
-  Keep at most one step running.
-- Call replan with a clear reason when remaining steps no longer fit reality;
-  then rebuild /home/ubuntu/todo.md to match the new plan (attention only).
-- Do not invent Plan UI updates by only editing todo.md.
-"""
-    tool_types = [PlanReportTool, ReplanTool]

--- a/backend/app/domain/services/tools/search.py
+++ b/backend/app/domain/services/tools/search.py
@@ -1,7 +1,29 @@
 from typing import Optional
+
+from pydantic import BaseModel, Field
+
 from app.domain.external.search import SearchEngine
-from app.domain.services.tools.base import BaseToolkit, tool
 from app.domain.models.tool_result import ToolResult
+from app.domain.services.tools.base import BaseToolkit, Tool
+
+
+class InfoSearchWebTool(Tool):
+    name = "info_search_web"
+    description = (
+        "Search web pages using search engine. Use for obtaining latest "
+        "information or finding references."
+    )
+
+    class Args(BaseModel):
+        query: str = Field(description="Search query in Google search style, using 3-5 keywords.")
+        date_range: Optional[str] = Field(
+            default=None,
+            description="(Optional) Time range filter for search results.",
+        )
+
+    async def run(self, query: str, date_range: Optional[str] = None) -> ToolResult:
+        return await self.toolkit.search_engine.search(query, date_range)
+
 
 class SearchToolkit(BaseToolkit):
     """Search tool class, providing search engine interaction functions"""
@@ -14,26 +36,13 @@ class SearchToolkit(BaseToolkit):
 - Search step by step: query attributes of a single entity separately, handle entities one by one
 - Authoritative web information takes priority over internal model knowledge
 """
-    
+    tool_types = [InfoSearchWebTool]
+
     def __init__(self, search_engine: SearchEngine):
         """Initialize search tool class
-        
+
         Args:
             search_engine: Search engine service
         """
-        super().__init__()
         self.search_engine = search_engine
-    
-    @tool(parse_docstring=True)
-    async def info_search_web(
-        self,
-        query: str,
-        date_range: Optional[str] = None
-    ) -> ToolResult:
-        """Search web pages using search engine. Use for obtaining latest information or finding references.
-        
-        Args:
-            query: Search query in Google search style, using 3-5 keywords.
-            date_range: (Optional) Time range filter for search results.
-        """
-        return await self.search_engine.search(query, date_range) 
+        super().__init__()

--- a/backend/app/domain/services/tools/search.py
+++ b/backend/app/domain/services/tools/search.py
@@ -1,29 +1,7 @@
 from typing import Optional
-
-from pydantic import BaseModel, Field
-
 from app.domain.external.search import SearchEngine
+from app.domain.services.tools.base import BaseToolkit, tool
 from app.domain.models.tool_result import ToolResult
-from app.domain.services.tools.base import BaseToolkit, Tool
-
-
-class InfoSearchWebTool(Tool):
-    name = "info_search_web"
-    description = (
-        "Search web pages using search engine. Use for obtaining latest "
-        "information or finding references."
-    )
-
-    class Args(BaseModel):
-        query: str = Field(description="Search query in Google search style, using 3-5 keywords.")
-        date_range: Optional[str] = Field(
-            default=None,
-            description="(Optional) Time range filter for search results.",
-        )
-
-    async def run(self, query: str, date_range: Optional[str] = None) -> ToolResult:
-        return await self.toolkit.search_engine.search(query, date_range)
-
 
 class SearchToolkit(BaseToolkit):
     """Search tool class, providing search engine interaction functions"""
@@ -36,13 +14,26 @@ class SearchToolkit(BaseToolkit):
 - Search step by step: query attributes of a single entity separately, handle entities one by one
 - Authoritative web information takes priority over internal model knowledge
 """
-    tool_types = [InfoSearchWebTool]
-
+    
     def __init__(self, search_engine: SearchEngine):
         """Initialize search tool class
-
+        
         Args:
             search_engine: Search engine service
         """
-        self.search_engine = search_engine
         super().__init__()
+        self.search_engine = search_engine
+    
+    @tool
+    async def info_search_web(
+        self,
+        query: str,
+        date_range: Optional[str] = None
+    ) -> ToolResult:
+        """Search web pages using search engine. Use for obtaining latest information or finding references.
+        
+        Args:
+            query: Search query in Google search style, using 3-5 keywords.
+            date_range: (Optional) Time range filter for search results.
+        """
+        return await self.search_engine.search(query, date_range) 

--- a/backend/app/domain/services/tools/shell.py
+++ b/backend/app/domain/services/tools/shell.py
@@ -24,66 +24,56 @@ class ShellToolkit(BaseToolkit):
         super().__init__()
         self.sandbox = sandbox
         
-    @tool
+    @tool(
+        description="Execute commands in a specified shell session. Use for running code, installing packages, or managing files.",
+        id="Unique identifier of the target shell session",
+        exec_dir="Working directory for command execution (must use absolute path)",
+        command="Shell command to execute",
+    )
     async def shell_exec(
         self,
         id: str,
         exec_dir: str,
         command: str
     ) -> ToolResult:
-        """Execute commands in a specified shell session. Use for running code, installing packages, or managing files.
-        
-        Args:
-            id: Unique identifier of the target shell session
-            exec_dir: Working directory for command execution (must use absolute path)
-            command: Shell command to execute
-        """
         return await self.sandbox.exec_command(id, exec_dir, command)
     
-    @tool
+    @tool(
+        description="View the content of a specified shell session. Use for checking command execution results or monitoring output.",
+        id="Unique identifier of the target shell session",
+    )
     async def shell_view(self, id: str) -> ToolResult:
-        """View the content of a specified shell session. Use for checking command execution results or monitoring output.
-        
-        Args:
-            id: Unique identifier of the target shell session
-        """
         return await self.sandbox.view_shell(id)
     
-    @tool
+    @tool(
+        description="Wait for the running process in a specified shell session to return. Use after running commands that require longer runtime.",
+        id="Unique identifier of the target shell session",
+        seconds="Wait duration in seconds",
+    )
     async def shell_wait(
         self,
         id: str,
         seconds: Optional[int] = None
     ) -> ToolResult:
-        """Wait for the running process in a specified shell session to return. Use after running commands that require longer runtime.
-        
-        Args:
-            id: Unique identifier of the target shell session
-            seconds: Wait duration in seconds
-        """
         return await self.sandbox.wait_for_process(id, seconds)
     
-    @tool
+    @tool(
+        description="Write input to a running process in a specified shell session. Use for responding to interactive command prompts.",
+        id="Unique identifier of the target shell session",
+        input="Input content to write to the process",
+        press_enter="Whether to press Enter key after input",
+    )
     async def shell_write_to_process(
         self,
         id: str,
         input: str,
         press_enter: bool
     ) -> ToolResult:
-        """Write input to a running process in a specified shell session. Use for responding to interactive command prompts.
-        
-        Args:
-            id: Unique identifier of the target shell session
-            input: Input content to write to the process
-            press_enter: Whether to press Enter key after input
-        """
         return await self.sandbox.write_to_process(id, input, press_enter)
     
-    @tool
+    @tool(
+        description="Terminate a running process in a specified shell session. Use for stopping long-running processes or handling frozen commands.",
+        id="Unique identifier of the target shell session",
+    )
     async def shell_kill_process(self, id: str) -> ToolResult:
-        """Terminate a running process in a specified shell session. Use for stopping long-running processes or handling frozen commands.
-        
-        Args:
-            id: Unique identifier of the target shell session
-        """
         return await self.sandbox.kill_process(id)

--- a/backend/app/domain/services/tools/shell.py
+++ b/backend/app/domain/services/tools/shell.py
@@ -26,9 +26,11 @@ class ShellToolkit(BaseToolkit):
         
     @tool(
         description="Execute commands in a specified shell session. Use for running code, installing packages, or managing files.",
-        id="Unique identifier of the target shell session",
-        exec_dir="Working directory for command execution (must use absolute path)",
-        command="Shell command to execute",
+        args={
+            "id": "Unique identifier of the target shell session",
+            "exec_dir": "Working directory for command execution (must use absolute path)",
+            "command": "Shell command to execute",
+        },
     )
     async def shell_exec(
         self,
@@ -40,15 +42,19 @@ class ShellToolkit(BaseToolkit):
     
     @tool(
         description="View the content of a specified shell session. Use for checking command execution results or monitoring output.",
-        id="Unique identifier of the target shell session",
+        args={
+            "id": "Unique identifier of the target shell session",
+        },
     )
     async def shell_view(self, id: str) -> ToolResult:
         return await self.sandbox.view_shell(id)
     
     @tool(
         description="Wait for the running process in a specified shell session to return. Use after running commands that require longer runtime.",
-        id="Unique identifier of the target shell session",
-        seconds="Wait duration in seconds",
+        args={
+            "id": "Unique identifier of the target shell session",
+            "seconds": "Wait duration in seconds",
+        },
     )
     async def shell_wait(
         self,
@@ -59,9 +65,11 @@ class ShellToolkit(BaseToolkit):
     
     @tool(
         description="Write input to a running process in a specified shell session. Use for responding to interactive command prompts.",
-        id="Unique identifier of the target shell session",
-        input="Input content to write to the process",
-        press_enter="Whether to press Enter key after input",
+        args={
+            "id": "Unique identifier of the target shell session",
+            "input": "Input content to write to the process",
+            "press_enter": "Whether to press Enter key after input",
+        },
     )
     async def shell_write_to_process(
         self,
@@ -73,7 +81,9 @@ class ShellToolkit(BaseToolkit):
     
     @tool(
         description="Terminate a running process in a specified shell session. Use for stopping long-running processes or handling frozen commands.",
-        id="Unique identifier of the target shell session",
+        args={
+            "id": "Unique identifier of the target shell session",
+        },
     )
     async def shell_kill_process(self, id: str) -> ToolResult:
         return await self.sandbox.kill_process(id)

--- a/backend/app/domain/services/tools/shell.py
+++ b/backend/app/domain/services/tools/shell.py
@@ -1,88 +1,7 @@
 from typing import Optional
-
-from pydantic import BaseModel, Field
-
 from app.domain.external.sandbox import Sandbox
+from app.domain.services.tools.base import BaseToolkit, tool
 from app.domain.models.tool_result import ToolResult
-from app.domain.services.tools.base import BaseToolkit, Tool
-
-
-class ShellExecTool(Tool):
-    name = "shell_exec"
-    description = (
-        "Execute commands in a specified shell session. "
-        "Use for running code, installing packages, or managing files."
-    )
-
-    class Args(BaseModel):
-        id: str = Field(description="Unique identifier of the target shell session")
-        exec_dir: str = Field(
-            description="Working directory for command execution (must use absolute path)"
-        )
-        command: str = Field(description="Shell command to execute")
-
-    async def run(self, id: str, exec_dir: str, command: str) -> ToolResult:
-        return await self.toolkit.sandbox.exec_command(id, exec_dir, command)
-
-
-class ShellViewTool(Tool):
-    name = "shell_view"
-    description = (
-        "View the content of a specified shell session. "
-        "Use for checking command execution results or monitoring output."
-    )
-
-    class Args(BaseModel):
-        id: str = Field(description="Unique identifier of the target shell session")
-
-    async def run(self, id: str) -> ToolResult:
-        return await self.toolkit.sandbox.view_shell(id)
-
-
-class ShellWaitTool(Tool):
-    name = "shell_wait"
-    description = (
-        "Wait for the running process in a specified shell session to return. "
-        "Use after running commands that require longer runtime."
-    )
-
-    class Args(BaseModel):
-        id: str = Field(description="Unique identifier of the target shell session")
-        seconds: Optional[int] = Field(default=None, description="Wait duration in seconds")
-
-    async def run(self, id: str, seconds: Optional[int] = None) -> ToolResult:
-        return await self.toolkit.sandbox.wait_for_process(id, seconds)
-
-
-class ShellWriteToProcessTool(Tool):
-    name = "shell_write_to_process"
-    description = (
-        "Write input to a running process in a specified shell session. "
-        "Use for responding to interactive command prompts."
-    )
-
-    class Args(BaseModel):
-        id: str = Field(description="Unique identifier of the target shell session")
-        input: str = Field(description="Input content to write to the process")
-        press_enter: bool = Field(description="Whether to press Enter key after input")
-
-    async def run(self, id: str, input: str, press_enter: bool) -> ToolResult:
-        return await self.toolkit.sandbox.write_to_process(id, input, press_enter)
-
-
-class ShellKillProcessTool(Tool):
-    name = "shell_kill_process"
-    description = (
-        "Terminate a running process in a specified shell session. "
-        "Use for stopping long-running processes or handling frozen commands."
-    )
-
-    class Args(BaseModel):
-        id: str = Field(description="Unique identifier of the target shell session")
-
-    async def run(self, id: str) -> ToolResult:
-        return await self.toolkit.sandbox.kill_process(id)
-
 
 class ShellToolkit(BaseToolkit):
     """Shell tool class, providing Shell interaction related functions"""
@@ -95,19 +14,76 @@ class ShellToolkit(BaseToolkit):
 - Use non-interactive `bc` for simple math, Python for anything complex; never compute mentally
 - Save code to files before execution; never pipe code inline into interpreters
 """
-    tool_types = [
-        ShellExecTool,
-        ShellViewTool,
-        ShellWaitTool,
-        ShellWriteToProcessTool,
-        ShellKillProcessTool,
-    ]
-
+    
     def __init__(self, sandbox: Sandbox):
         """Initialize Shell tool class
-
+        
         Args:
             sandbox: Sandbox service
         """
-        self.sandbox = sandbox
         super().__init__()
+        self.sandbox = sandbox
+        
+    @tool
+    async def shell_exec(
+        self,
+        id: str,
+        exec_dir: str,
+        command: str
+    ) -> ToolResult:
+        """Execute commands in a specified shell session. Use for running code, installing packages, or managing files.
+        
+        Args:
+            id: Unique identifier of the target shell session
+            exec_dir: Working directory for command execution (must use absolute path)
+            command: Shell command to execute
+        """
+        return await self.sandbox.exec_command(id, exec_dir, command)
+    
+    @tool
+    async def shell_view(self, id: str) -> ToolResult:
+        """View the content of a specified shell session. Use for checking command execution results or monitoring output.
+        
+        Args:
+            id: Unique identifier of the target shell session
+        """
+        return await self.sandbox.view_shell(id)
+    
+    @tool
+    async def shell_wait(
+        self,
+        id: str,
+        seconds: Optional[int] = None
+    ) -> ToolResult:
+        """Wait for the running process in a specified shell session to return. Use after running commands that require longer runtime.
+        
+        Args:
+            id: Unique identifier of the target shell session
+            seconds: Wait duration in seconds
+        """
+        return await self.sandbox.wait_for_process(id, seconds)
+    
+    @tool
+    async def shell_write_to_process(
+        self,
+        id: str,
+        input: str,
+        press_enter: bool
+    ) -> ToolResult:
+        """Write input to a running process in a specified shell session. Use for responding to interactive command prompts.
+        
+        Args:
+            id: Unique identifier of the target shell session
+            input: Input content to write to the process
+            press_enter: Whether to press Enter key after input
+        """
+        return await self.sandbox.write_to_process(id, input, press_enter)
+    
+    @tool
+    async def shell_kill_process(self, id: str) -> ToolResult:
+        """Terminate a running process in a specified shell session. Use for stopping long-running processes or handling frozen commands.
+        
+        Args:
+            id: Unique identifier of the target shell session
+        """
+        return await self.sandbox.kill_process(id)

--- a/backend/app/domain/services/tools/shell.py
+++ b/backend/app/domain/services/tools/shell.py
@@ -1,7 +1,88 @@
 from typing import Optional
+
+from pydantic import BaseModel, Field
+
 from app.domain.external.sandbox import Sandbox
-from app.domain.services.tools.base import BaseToolkit, tool
 from app.domain.models.tool_result import ToolResult
+from app.domain.services.tools.base import BaseToolkit, Tool
+
+
+class ShellExecTool(Tool):
+    name = "shell_exec"
+    description = (
+        "Execute commands in a specified shell session. "
+        "Use for running code, installing packages, or managing files."
+    )
+
+    class Args(BaseModel):
+        id: str = Field(description="Unique identifier of the target shell session")
+        exec_dir: str = Field(
+            description="Working directory for command execution (must use absolute path)"
+        )
+        command: str = Field(description="Shell command to execute")
+
+    async def run(self, id: str, exec_dir: str, command: str) -> ToolResult:
+        return await self.toolkit.sandbox.exec_command(id, exec_dir, command)
+
+
+class ShellViewTool(Tool):
+    name = "shell_view"
+    description = (
+        "View the content of a specified shell session. "
+        "Use for checking command execution results or monitoring output."
+    )
+
+    class Args(BaseModel):
+        id: str = Field(description="Unique identifier of the target shell session")
+
+    async def run(self, id: str) -> ToolResult:
+        return await self.toolkit.sandbox.view_shell(id)
+
+
+class ShellWaitTool(Tool):
+    name = "shell_wait"
+    description = (
+        "Wait for the running process in a specified shell session to return. "
+        "Use after running commands that require longer runtime."
+    )
+
+    class Args(BaseModel):
+        id: str = Field(description="Unique identifier of the target shell session")
+        seconds: Optional[int] = Field(default=None, description="Wait duration in seconds")
+
+    async def run(self, id: str, seconds: Optional[int] = None) -> ToolResult:
+        return await self.toolkit.sandbox.wait_for_process(id, seconds)
+
+
+class ShellWriteToProcessTool(Tool):
+    name = "shell_write_to_process"
+    description = (
+        "Write input to a running process in a specified shell session. "
+        "Use for responding to interactive command prompts."
+    )
+
+    class Args(BaseModel):
+        id: str = Field(description="Unique identifier of the target shell session")
+        input: str = Field(description="Input content to write to the process")
+        press_enter: bool = Field(description="Whether to press Enter key after input")
+
+    async def run(self, id: str, input: str, press_enter: bool) -> ToolResult:
+        return await self.toolkit.sandbox.write_to_process(id, input, press_enter)
+
+
+class ShellKillProcessTool(Tool):
+    name = "shell_kill_process"
+    description = (
+        "Terminate a running process in a specified shell session. "
+        "Use for stopping long-running processes or handling frozen commands."
+    )
+
+    class Args(BaseModel):
+        id: str = Field(description="Unique identifier of the target shell session")
+
+    async def run(self, id: str) -> ToolResult:
+        return await self.toolkit.sandbox.kill_process(id)
+
 
 class ShellToolkit(BaseToolkit):
     """Shell tool class, providing Shell interaction related functions"""
@@ -14,76 +95,19 @@ class ShellToolkit(BaseToolkit):
 - Use non-interactive `bc` for simple math, Python for anything complex; never compute mentally
 - Save code to files before execution; never pipe code inline into interpreters
 """
-    
+    tool_types = [
+        ShellExecTool,
+        ShellViewTool,
+        ShellWaitTool,
+        ShellWriteToProcessTool,
+        ShellKillProcessTool,
+    ]
+
     def __init__(self, sandbox: Sandbox):
         """Initialize Shell tool class
-        
+
         Args:
             sandbox: Sandbox service
         """
-        super().__init__()
         self.sandbox = sandbox
-        
-    @tool(parse_docstring=True)
-    async def shell_exec(
-        self,
-        id: str,
-        exec_dir: str,
-        command: str
-    ) -> ToolResult:
-        """Execute commands in a specified shell session. Use for running code, installing packages, or managing files.
-        
-        Args:
-            id: Unique identifier of the target shell session
-            exec_dir: Working directory for command execution (must use absolute path)
-            command: Shell command to execute
-        """
-        return await self.sandbox.exec_command(id, exec_dir, command)
-    
-    @tool(parse_docstring=True)
-    async def shell_view(self, id: str) -> ToolResult:
-        """View the content of a specified shell session. Use for checking command execution results or monitoring output.
-        
-        Args:
-            id: Unique identifier of the target shell session
-        """
-        return await self.sandbox.view_shell(id)
-    
-    @tool(parse_docstring=True)
-    async def shell_wait(
-        self,
-        id: str,
-        seconds: Optional[int] = None
-    ) -> ToolResult:
-        """Wait for the running process in a specified shell session to return. Use after running commands that require longer runtime.
-        
-        Args:
-            id: Unique identifier of the target shell session
-            seconds: Wait duration in seconds
-        """
-        return await self.sandbox.wait_for_process(id, seconds)
-    
-    @tool(parse_docstring=True)
-    async def shell_write_to_process(
-        self,
-        id: str,
-        input: str,
-        press_enter: bool
-    ) -> ToolResult:
-        """Write input to a running process in a specified shell session. Use for responding to interactive command prompts.
-        
-        Args:
-            id: Unique identifier of the target shell session
-            input: Input content to write to the process
-            press_enter: Whether to press Enter key after input
-        """
-        return await self.sandbox.write_to_process(id, input, press_enter)
-    
-    @tool(parse_docstring=True)
-    async def shell_kill_process(self, id: str) -> ToolResult:
-        """Terminate a running process in a specified shell session. Use for stopping long-running processes or handling frozen commands.
-        
-        Args:
-            id: Unique identifier of the target shell session
-        """
-        return await self.sandbox.kill_process(id)
+        super().__init__()

--- a/backend/tests/test_context_engineering.py
+++ b/backend/tests/test_context_engineering.py
@@ -21,39 +21,33 @@ from app.domain.services.tools.base import (
     OutputTool,
     Tool,
     describe_toolkits,
+    tool,
 )
-
-
-class EchoTool(Tool):
-    name = "echo"
-    description = "Echo the given text back."
-
-    class Args(BaseModel):
-        text: str
-
-    async def run(self, text: str) -> ToolResult:
-        return ToolResult(success=True, data=text)
 
 
 class EchoToolkit(BaseToolkit):
     name = "echo"
     instructions = "- Echo things back verbatim"
-    tool_types = [EchoTool]
 
+    @tool
+    async def echo(self, text: str) -> ToolResult:
+        """Echo the given text back.
 
-class NoopTool(Tool):
-    name = "noop"
-    description = "Do nothing."
-
-    async def run(self) -> ToolResult:
-        return ToolResult(success=True)
+        Args:
+            text: Text to echo
+        """
+        return ToolResult(success=True, data=text)
 
 
 class SilentToolkit(BaseToolkit):
     """Toolkit without instructions — must not add a prompt section."""
 
     name = "silent"
-    tool_types = [NoopTool]
+
+    @tool
+    async def noop(self) -> ToolResult:
+        """Do nothing."""
+        return ToolResult(success=True)
 
 
 class TestSystemPromptBuilder:
@@ -301,16 +295,13 @@ class TestAgentLoopStructuredOutput:
 
 class TestToolResultTruncation:
     async def test_oversized_tool_result_truncated(self):
-        class BigTool(Tool):
-            name = "big"
-            description = "Return something huge."
-
-            async def run(self) -> ToolResult:
-                return ToolResult(success=True, data="y" * 100000)
-
         class BigToolkit(BaseToolkit):
             name = "big"
-            tool_types = [BigTool]
+
+            @tool
+            async def big(self) -> ToolResult:
+                """Return something huge."""
+                return ToolResult(success=True, data="y" * 100000)
 
         llm = _ScriptedLLM([
             LLMMessage.assistant("", tool_calls=[ToolCall(id="c1", name="big", args={})]),

--- a/backend/tests/test_context_engineering.py
+++ b/backend/tests/test_context_engineering.py
@@ -21,33 +21,39 @@ from app.domain.services.tools.base import (
     OutputTool,
     Tool,
     describe_toolkits,
-    tool,
 )
+
+
+class EchoTool(Tool):
+    name = "echo"
+    description = "Echo the given text back."
+
+    class Args(BaseModel):
+        text: str
+
+    async def run(self, text: str) -> ToolResult:
+        return ToolResult(success=True, data=text)
 
 
 class EchoToolkit(BaseToolkit):
     name = "echo"
     instructions = "- Echo things back verbatim"
+    tool_types = [EchoTool]
 
-    @tool(parse_docstring=True)
-    async def echo(self, text: str) -> ToolResult:
-        """Echo the given text back.
 
-        Args:
-            text: Text to echo
-        """
-        return ToolResult(success=True, data=text)
+class NoopTool(Tool):
+    name = "noop"
+    description = "Do nothing."
+
+    async def run(self) -> ToolResult:
+        return ToolResult(success=True)
 
 
 class SilentToolkit(BaseToolkit):
     """Toolkit without instructions — must not add a prompt section."""
 
     name = "silent"
-
-    @tool(parse_docstring=True)
-    async def noop(self) -> ToolResult:
-        """Do nothing."""
-        return ToolResult(success=True)
+    tool_types = [NoopTool]
 
 
 class TestSystemPromptBuilder:
@@ -295,13 +301,16 @@ class TestAgentLoopStructuredOutput:
 
 class TestToolResultTruncation:
     async def test_oversized_tool_result_truncated(self):
+        class BigTool(Tool):
+            name = "big"
+            description = "Return something huge."
+
+            async def run(self) -> ToolResult:
+                return ToolResult(success=True, data="y" * 100000)
+
         class BigToolkit(BaseToolkit):
             name = "big"
-
-            @tool(parse_docstring=True)
-            async def big(self) -> ToolResult:
-                """Return something huge."""
-                return ToolResult(success=True, data="y" * 100000)
+            tool_types = [BigTool]
 
         llm = _ScriptedLLM([
             LLMMessage.assistant("", tool_calls=[ToolCall(id="c1", name="big", args={})]),

--- a/backend/tests/test_domain_tools.py
+++ b/backend/tests/test_domain_tools.py
@@ -121,8 +121,10 @@ class ExplicitToolkit(BaseToolkit):
 
     @tool(
         description="Do a thing with an id. Use for testing.",
-        id="The unique identifier",
-        count="(Optional) How many times",
+        args={
+            "id": "The unique identifier",
+            "count": "(Optional) How many times",
+        },
     )
     async def do_thing(self, id: str, count: Optional[int] = None) -> ToolResult:
         """This docstring must be ignored in decorator mode.
@@ -133,7 +135,7 @@ class ExplicitToolkit(BaseToolkit):
         """
         return ToolResult(success=True, data=f"{id}:{count}")
 
-    @tool("Rename a file.", path="Absolute path of the file")
+    @tool("Rename a file.", args={"path": "Absolute path of the file"})
     async def rename(self, path: str) -> ToolResult:
         return ToolResult(success=True, data=path)
 
@@ -177,6 +179,12 @@ class TestDecoratorDocs:
         params = tk.get_tool("lookup").to_openai_schema()["function"]["parameters"]
         assert params["properties"]["q"]["description"] == "Search query"
         assert "q" in params["required"]
+
+    def test_param_docs_must_use_args(self):
+        with pytest.raises(TypeError, match="args="):
+            @tool(description="oops", id="not nested")
+            async def bad(self, id: str) -> ToolResult:
+                return ToolResult(success=True)
 
     def test_shell_toolkit_uses_decorator_docs(self):
         from types import SimpleNamespace

--- a/backend/tests/test_domain_tools.py
+++ b/backend/tests/test_domain_tools.py
@@ -1,38 +1,33 @@
 """Unit tests for the framework-agnostic tool abstraction.
 
-Verifies that Tool classes derive OpenAI-compatible function schemas from
-Pydantic Args models, and that toolkits expose lookup / invocation without
-depending on LangChain.
+Verifies that the ``@tool`` decorator derives OpenAI-compatible function
+schemas from signatures + Google-style docstrings, and that toolkits expose
+lookup / invocation without depending on LangChain.
 """
 from typing import Optional
 
-from pydantic import BaseModel, Field
+import pytest
 
 from app.domain.models.tool_result import ToolResult
-from app.domain.services.tools.base import BaseToolkit, Tool
-from app.domain.services.tools.message import MessageToolkit
-from app.domain.services.tools.plan import PlanToolkit
-
-
-class DoThingTool(Tool):
-    name = "do_thing"
-    description = "Do a thing with an id. Use for testing."
-
-    class Args(BaseModel):
-        id: str = Field(description="The unique identifier")
-        count: Optional[int] = Field(default=None, description="(Optional) How many times")
-
-    async def run(self, id: str, count: Optional[int] = None) -> ToolResult:
-        return await self.toolkit.backend(id, count)
+from app.domain.services.tools.base import BaseToolkit, tool
 
 
 class SampleToolkit(BaseToolkit):
     name = "sample"
-    tool_types = [DoThingTool]
 
     def __init__(self, backend):
-        self.backend = backend
         super().__init__()
+        self.backend = backend
+
+    @tool
+    async def do_thing(self, id: str, count: Optional[int] = None) -> ToolResult:
+        """Do a thing with an id. Use for testing.
+
+        Args:
+            id: The unique identifier
+            count: (Optional) How many times
+        """
+        return await self.backend(id, count)
 
 
 class _FakeBackend:
@@ -57,6 +52,7 @@ class TestToolSchema:
         assert schema["type"] == "function"
         fn = schema["function"]
         assert fn["name"] == "do_thing"
+        # summary line becomes the description (Args section stripped out)
         assert "Do a thing with an id" in fn["description"]
         assert "Args:" not in fn["description"]
 
@@ -67,7 +63,7 @@ class TestToolSchema:
         # Official timeline needs brief — require it on every executable tool
         assert "brief" in params.get("required", [])
 
-    def test_parameter_descriptions_from_args_model(self):
+    def test_parameter_descriptions_from_docstring(self):
         params = self.tk.get_tool_schemas()[0]["function"]["parameters"]
         assert params["type"] == "object"
         assert params["properties"]["id"]["description"] == "The unique identifier"
@@ -114,6 +110,11 @@ class TestToolLookupAndInvoke:
     def test_tool_carries_toolkit_reference(self):
         assert self.tk.get_tool("do_thing").toolkit is self.tk
 
+    async def test_decorated_method_stays_callable(self):
+        result = await self.tk.do_thing(id="abc", count=2)
+        assert result.data == "abc:2"
+        assert self.backend.calls == [("abc", 2)]
+
 
 class TestTakeBrief:
     def test_take_brief_splits_ui_label(self):
@@ -132,21 +133,3 @@ class TestTakeBrief:
         brief, args = take_brief({"file": "a.py"})
         assert brief is None
         assert args == {"file": "a.py"}
-
-
-class TestBuiltinToolkits:
-    def test_message_toolkit_has_class_tools_without_brief(self):
-        tk = MessageToolkit()
-        assert [t.name for t in tk.get_tools()] == [
-            "message_notify_user",
-            "message_ask_user",
-        ]
-        schema = tk.get_tool("message_notify_user").to_openai_schema()
-        assert "brief" not in schema["function"]["parameters"]["properties"]
-
-    def test_plan_toolkit_has_class_tools(self):
-        tk = PlanToolkit()
-        assert [t.name for t in tk.get_tools()] == ["plan_report", "replan"]
-        params = tk.get_tool("replan").to_openai_schema()["function"]["parameters"]
-        assert "reason" in params["properties"]
-        assert "brief" in params["properties"]

--- a/backend/tests/test_domain_tools.py
+++ b/backend/tests/test_domain_tools.py
@@ -1,33 +1,38 @@
 """Unit tests for the framework-agnostic tool abstraction.
 
-Verifies that the ``@tool`` decorator derives OpenAI-compatible function
-schemas from signatures + Google-style docstrings, and that toolkits expose
-lookup / invocation without depending on LangChain.
+Verifies that Tool classes derive OpenAI-compatible function schemas from
+Pydantic Args models, and that toolkits expose lookup / invocation without
+depending on LangChain.
 """
 from typing import Optional
 
-import pytest
+from pydantic import BaseModel, Field
 
 from app.domain.models.tool_result import ToolResult
-from app.domain.services.tools.base import BaseToolkit, tool
+from app.domain.services.tools.base import BaseToolkit, Tool
+from app.domain.services.tools.message import MessageToolkit
+from app.domain.services.tools.plan import PlanToolkit
+
+
+class DoThingTool(Tool):
+    name = "do_thing"
+    description = "Do a thing with an id. Use for testing."
+
+    class Args(BaseModel):
+        id: str = Field(description="The unique identifier")
+        count: Optional[int] = Field(default=None, description="(Optional) How many times")
+
+    async def run(self, id: str, count: Optional[int] = None) -> ToolResult:
+        return await self.toolkit.backend(id, count)
 
 
 class SampleToolkit(BaseToolkit):
     name = "sample"
+    tool_types = [DoThingTool]
 
     def __init__(self, backend):
-        super().__init__()
         self.backend = backend
-
-    @tool(parse_docstring=True)
-    async def do_thing(self, id: str, count: Optional[int] = None) -> ToolResult:
-        """Do a thing with an id. Use for testing.
-
-        Args:
-            id: The unique identifier
-            count: (Optional) How many times
-        """
-        return await self.backend(id, count)
+        super().__init__()
 
 
 class _FakeBackend:
@@ -52,7 +57,6 @@ class TestToolSchema:
         assert schema["type"] == "function"
         fn = schema["function"]
         assert fn["name"] == "do_thing"
-        # summary line becomes the description (Args section stripped out)
         assert "Do a thing with an id" in fn["description"]
         assert "Args:" not in fn["description"]
 
@@ -63,7 +67,7 @@ class TestToolSchema:
         # Official timeline needs brief — require it on every executable tool
         assert "brief" in params.get("required", [])
 
-    def test_parameter_descriptions_from_docstring(self):
+    def test_parameter_descriptions_from_args_model(self):
         params = self.tk.get_tool_schemas()[0]["function"]["parameters"]
         assert params["type"] == "object"
         assert params["properties"]["id"]["description"] == "The unique identifier"
@@ -128,3 +132,21 @@ class TestTakeBrief:
         brief, args = take_brief({"file": "a.py"})
         assert brief is None
         assert args == {"file": "a.py"}
+
+
+class TestBuiltinToolkits:
+    def test_message_toolkit_has_class_tools_without_brief(self):
+        tk = MessageToolkit()
+        assert [t.name for t in tk.get_tools()] == [
+            "message_notify_user",
+            "message_ask_user",
+        ]
+        schema = tk.get_tool("message_notify_user").to_openai_schema()
+        assert "brief" not in schema["function"]["parameters"]["properties"]
+
+    def test_plan_toolkit_has_class_tools(self):
+        tk = PlanToolkit()
+        assert [t.name for t in tk.get_tools()] == ["plan_report", "replan"]
+        params = tk.get_tool("replan").to_openai_schema()["function"]["parameters"]
+        assert "reason" in params["properties"]
+        assert "brief" in params["properties"]

--- a/backend/tests/test_domain_tools.py
+++ b/backend/tests/test_domain_tools.py
@@ -1,8 +1,8 @@
 """Unit tests for the framework-agnostic tool abstraction.
 
-Verifies that the ``@tool`` decorator derives OpenAI-compatible function
-schemas from signatures + Google-style docstrings, and that toolkits expose
-lookup / invocation without depending on LangChain.
+Verifies that ``@tool`` takes descriptions from either decorator arguments
+or a Google-style docstring, and that toolkits expose lookup / invocation
+without depending on LangChain.
 """
 from typing import Optional
 
@@ -114,6 +114,81 @@ class TestToolLookupAndInvoke:
         result = await self.tk.do_thing(id="abc", count=2)
         assert result.data == "abc:2"
         assert self.backend.calls == [("abc", 2)]
+
+
+class ExplicitToolkit(BaseToolkit):
+    name = "explicit"
+
+    @tool(
+        description="Do a thing with an id. Use for testing.",
+        id="The unique identifier",
+        count="(Optional) How many times",
+    )
+    async def do_thing(self, id: str, count: Optional[int] = None) -> ToolResult:
+        """This docstring must be ignored in decorator mode.
+
+        Args:
+            id: WRONG id docs
+            count: WRONG count docs
+        """
+        return ToolResult(success=True, data=f"{id}:{count}")
+
+    @tool("Rename a file.", path="Absolute path of the file")
+    async def rename(self, path: str) -> ToolResult:
+        return ToolResult(success=True, data=path)
+
+
+class SchemaToolkit(BaseToolkit):
+    name = "schema"
+
+    @tool(
+        description="Look something up",
+        parameters={
+            "q": {"type": "string", "description": "Search query"},
+        },
+        required=["q"],
+    )
+    async def lookup(self, q: str) -> ToolResult:
+        return ToolResult(success=True, data=q)
+
+
+class TestDecoratorDocs:
+    def test_parameter_descriptions_from_decorator(self):
+        tk = ExplicitToolkit()
+        params = tk.get_tool("do_thing").to_openai_schema()["function"]["parameters"]
+        assert params["properties"]["id"]["description"] == "The unique identifier"
+        assert "How many times" in params["properties"]["count"]["description"]
+        assert "WRONG" not in params["properties"]["id"]["description"]
+
+    def test_decorator_description_ignores_docstring(self):
+        tk = ExplicitToolkit()
+        fn = tk.get_tool("do_thing").to_openai_schema()["function"]
+        assert fn["description"] == "Do a thing with an id. Use for testing."
+        assert "ignored" not in fn["description"]
+
+    def test_positional_description(self):
+        tk = ExplicitToolkit()
+        fn = tk.get_tool("rename").to_openai_schema()["function"]
+        assert fn["description"] == "Rename a file."
+        assert fn["parameters"]["properties"]["path"]["description"] == "Absolute path of the file"
+
+    def test_explicit_parameters_schema(self):
+        tk = SchemaToolkit()
+        params = tk.get_tool("lookup").to_openai_schema()["function"]["parameters"]
+        assert params["properties"]["q"]["description"] == "Search query"
+        assert "q" in params["required"]
+
+    def test_shell_toolkit_uses_decorator_docs(self):
+        from types import SimpleNamespace
+
+        from app.domain.services.tools.shell import ShellToolkit
+
+        tk = ShellToolkit(SimpleNamespace())
+        fn = tk.get_tool("shell_exec").to_openai_schema()["function"]
+        assert "Execute commands in a specified shell session" in fn["description"]
+        assert fn["parameters"]["properties"]["exec_dir"]["description"].startswith(
+            "Working directory"
+        )
 
 
 class TestTakeBrief:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 背景

工具仍写在 Toolkit 方法上。描述信息二选一：写在 `@tool(...)` 里，或写在 Google-style docstring 里，不混用。

装饰器模式下，参数说明必须放在 `args=` 里，不再和 `description` 平铺混写。

## 写法

**装饰器里写（shell 已改成这种）：**

```python
@tool(
    description="Execute commands in a specified shell session. ...",
    args={
        "id": "Unique identifier of the target shell session",
        "exec_dir": "Working directory for command execution (must use absolute path)",
        "command": "Shell command to execute",
    },
)
async def shell_exec(self, id: str, exec_dir: str, command: str) -> ToolResult:
    return await self.sandbox.exec_command(id, exec_dir, command)
```

**或只用 docstring：**

```python
@tool
async def info_search_web(self, query: str, date_range: Optional[str] = None) -> ToolResult:
    """Search web pages using search engine. ...

    Args:
        query: Search query in Google search style, using 3-5 keywords.
        date_range: (Optional) Time range filter for search results.
    """
    return await self.search_engine.search(query, date_range)
```

把参数写成 `@tool(description=..., id="...")` 会 `TypeError`，必须进 `args=`。类型仍从方法签名推断。

## 测试

`tests/test_domain_tools.py` 覆盖 docstring / `args=` / 误用平铺 kwargs。相关离线单测 **39 passed**。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c600441f-0490-4836-9629-464f0fc17ae9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c600441f-0490-4836-9629-464f0fc17ae9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

