### PR TITLE
feat(backend): add OrcaRouter as a named LLM provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,8 +4,9 @@ API_BASE=http://mockserver:8090/v1
 
 # Model configuration
 # MODEL_PROVIDER selects the LLM integration (via LangChain init_chat_model).
-# Built-in providers: openai, deepseek, anthropic, ollama. OpenAI-compatible
-# endpoints (DeepSeek / OneAPI / vLLM / ...) work with openai + API_BASE.
+# Built-in providers: openai, deepseek, anthropic, ollama, orcarouter.
+# OpenAI-compatible endpoints (DeepSeek / OneAPI / vLLM / ...) work with
+# openai + API_BASE. orcarouter points at the OrcaRouter gateway by default.
 # See docs/configuration.md for per-provider examples.
 MODEL_PROVIDER=openai
 MODEL_NAME=deepseek-chat

--- a/backend/app/infrastructure/external/llm/langchain_llm.py
+++ b/backend/app/infrastructure/external/llm/langchain_llm.py
@@ -29,6 +29,11 @@ from app.infrastructure.external.llm.robust_json_parser import (
 
 logger = logging.getLogger(__name__)
 
+# Default base URL for the OrcaRouter gateway. Like OpenRouter, OrcaRouter
+# exposes a provider/model namespace (e.g. ``anthropic/claude-sonnet-4.5``)
+# over an OpenAI-compatible API, so it plugs into LangChain's OpenAI chat model.
+ORCAROUTER_API_BASE = "https://api.orcarouter.ai/v1"
+
 
 class LangchainLLM:
     """Concrete :class:`LLM` gateway backed by LangChain chat models."""
@@ -50,6 +55,12 @@ class LangchainLLM:
         )
         if settings.extra_headers:
             kwargs["default_headers"] = settings.extra_headers
+        # OrcaRouter is an OpenAI-compatible gateway. Expose it as a named
+        # provider with a built-in default endpoint so users don't have to
+        # point API_BASE at it manually; an explicit API_BASE still wins.
+        if (settings.model_provider or "openai").lower() == "orcarouter":
+            kwargs["model_provider"] = "openai"
+            kwargs["base_url"] = settings.api_base or ORCAROUTER_API_BASE
         self._model = init_chat_model(**kwargs)
 
         self._json_output_parser = RetryWithErrorOutputParser.from_llm(

--- a/backend/tests/test_llm_gateway.py
+++ b/backend/tests/test_llm_gateway.py
@@ -6,8 +6,12 @@ which is the boundary that keeps LangChain out of the domain.
 """
 from langchain.messages import AIMessage, HumanMessage, SystemMessage, ToolMessage
 
+from app.core.config import Settings
 from app.domain.models.message import LLMMessage, Role, ToolCall
-from app.infrastructure.external.llm.langchain_llm import LangchainLLM
+from app.infrastructure.external.llm.langchain_llm import (
+    ORCAROUTER_API_BASE,
+    LangchainLLM,
+)
 
 
 def _gateway() -> LangchainLLM:
@@ -65,3 +69,29 @@ class TestRoundTrip:
         assert back.tool_calls[0].name == "info_search_web"
         assert back.tool_calls[0].args == {"query": "x"}
         assert back.tool_calls[0].id == "c3"
+
+
+class TestOrcaRouterProvider:
+    """OrcaRouter is wired as a named provider backed by ChatOpenAI."""
+
+    def test_orcarouter_defaults_to_orca_base_url(self):
+        gw = LangchainLLM(
+            settings=Settings(
+                api_key="test",
+                model_provider="orcarouter",
+                model_name="anthropic/claude-sonnet-4.5",
+            )
+        )
+        assert gw._model.openai_api_base == ORCAROUTER_API_BASE
+        assert gw._model.model_name == "anthropic/claude-sonnet-4.5"
+
+    def test_orcarouter_respects_explicit_api_base(self):
+        gw = LangchainLLM(
+            settings=Settings(
+                api_key="test",
+                model_provider="orcarouter",
+                model_name="anthropic/claude-sonnet-4.5",
+                api_base="https://selfhost.example.com/v1",
+            )
+        )
+        assert gw._model.openai_api_base == "https://selfhost.example.com/v1"

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -13,7 +13,7 @@
 
 | 配置项 | 默认值 | 是否必需 | 说明 |
 |--------|--------|----------|------|
-| `MODEL_PROVIDER` | `openai` | 否 | 模型提供商，决定底层使用哪个 LLM 集成（如 `openai`、`deepseek`、`anthropic`、`ollama`），仅在 `LLM_PROVIDER=langchain` 时生效 |
+| `MODEL_PROVIDER` | `openai` | 否 | 模型提供商，决定底层使用哪个 LLM 集成（如 `openai`、`deepseek`、`anthropic`、`ollama`、`orcarouter`），仅在 `LLM_PROVIDER=langchain` 时生效 |
 | `MODEL_NAME` | `deepseek-chat` | 是 | 要使用的模型名称 |
 | `TEMPERATURE` | `0.7` | 否 | 模型响应的随机性程度，范围 0-1 |
 | `MAX_TOKENS` | `2000` | 否 | 模型响应的最大 token 数量 |
@@ -32,6 +32,7 @@
 | `deepseek` | DeepSeek 原生集成 | `langchain-deepseek` |
 | `anthropic` | Anthropic Claude | `langchain-anthropic` |
 | `ollama` | 本地 Ollama 运行的开源模型 | `langchain-ollama` |
+| `orcarouter` | OrcaRouter 网关（OpenAI 兼容，暴露 `provider/model` 模型命名空间），默认端点 `https://api.orcarouter.ai/v1`，可用 `API_BASE` 覆盖 | `langchain-openai` |
 
 **配置示例：**
 
@@ -71,6 +72,14 @@
   MODEL_NAME=llama3.1
   API_BASE=http://host.docker.internal:11434
   API_KEY=ollama   # Ollama 无需真实密钥，但 API_KEY 必须非空以通过校验
+  ```
+
+- **OrcaRouter**
+  ```env
+  MODEL_PROVIDER=orcarouter
+  MODEL_NAME=anthropic/claude-sonnet-4.5
+  API_KEY=sk-orcarouter-...
+  # API_BASE 可省略，默认指向 https://api.orcarouter.ai/v1；自建网关时可覆盖
   ```
 
 > **接入更多提供商**：`init_chat_model` 还支持 Google Gemini、AWS Bedrock、Azure OpenAI、Mistral 等更多提供商。只需在 `backend/pyproject.toml` 增加对应的 `langchain-xxx` 集成包（如 `langchain-google-genai`）并重新构建镜像（`./build.sh` 或 `./dev.sh build`），再将 `MODEL_PROVIDER` 设为对应值即可。完整的提供商列表与命名参见 [LangChain `init_chat_model` 文档](https://python.langchain.com/api_reference/langchain/chat_models/langchain.chat_models.base.init_chat_model.html)。

--- a/docs/en/configuration.md
+++ b/docs/en/configuration.md
@@ -13,7 +13,7 @@
 
 | Configuration | Default Value | Required | Description |
 |---------------|---------------|----------|-------------|
-| `MODEL_PROVIDER` | `openai` | No | Model provider that selects the underlying LLM integration (e.g. `openai`, `deepseek`, `anthropic`, `ollama`); only used when `LLM_PROVIDER=langchain` |
+| `MODEL_PROVIDER` | `openai` | No | Model provider that selects the underlying LLM integration (e.g. `openai`, `deepseek`, `anthropic`, `ollama`, `orcarouter`); only used when `LLM_PROVIDER=langchain` |
 | `MODEL_NAME` | `deepseek-chat` | Yes | Name of the model to use |
 | `TEMPERATURE` | `0.7` | No | Randomness level of model responses, range 0-1 |
 | `MAX_TOKENS` | `2000` | No | Maximum number of tokens in model response |
@@ -32,6 +32,7 @@ The following providers are built in (their LangChain integration packages are p
 | `deepseek` | Native DeepSeek integration | `langchain-deepseek` |
 | `anthropic` | Anthropic Claude | `langchain-anthropic` |
 | `ollama` | Open-source models served locally by Ollama | `langchain-ollama` |
+| `orcarouter` | OrcaRouter gateway (OpenAI-compatible, exposes a `provider/model` model namespace); defaults to `https://api.orcarouter.ai/v1`, overridable via `API_BASE` | `langchain-openai` |
 
 **Examples:**
 
@@ -71,6 +72,14 @@ The following providers are built in (their LangChain integration packages are p
   MODEL_NAME=llama3.1
   API_BASE=http://host.docker.internal:11434
   API_KEY=ollama   # Ollama needs no real key, but API_KEY must be non-empty to pass validation
+  ```
+
+- **OrcaRouter**
+  ```env
+  MODEL_PROVIDER=orcarouter
+  MODEL_NAME=anthropic/claude-sonnet-4.5
+  API_KEY=sk-orcarouter-...
+  # API_BASE can be omitted to use the default https://api.orcarouter.ai/v1; set it to override for a self-hosted gateway
   ```
 
 > **Adding more providers**: `init_chat_model` also supports Google Gemini, AWS Bedrock, Azure OpenAI, Mistral and many more. Just add the matching `langchain-xxx` integration package (e.g. `langchain-google-genai`) to `backend/pyproject.toml`, rebuild the images (`./build.sh` or `./dev.sh build`), and set `MODEL_PROVIDER` accordingly. See the [LangChain `init_chat_model` docs](https://python.langchain.com/api_reference/langchain/chat_models/langchain.chat_models.base.init_chat_model.html) for the full list of providers and names.

--- a/docs/en/quick_start.md
+++ b/docs/en/quick_start.md
@@ -114,8 +114,9 @@ API_BASE=http://mockserver:8090/v1
 
 # Model configuration
 # MODEL_PROVIDER selects the LLM integration (via LangChain init_chat_model).
-# Built-in providers: openai, deepseek, anthropic, ollama. OpenAI-compatible
-# endpoints (DeepSeek / OneAPI / vLLM / ...) work with openai + API_BASE.
+# Built-in providers: openai, deepseek, anthropic, ollama, orcarouter.
+# OpenAI-compatible endpoints (DeepSeek / OneAPI / vLLM / ...) work with
+# openai + API_BASE. orcarouter points at the OrcaRouter gateway by default.
 # See docs/configuration.md for per-provider examples.
 MODEL_PROVIDER=openai
 MODEL_NAME=deepseek-chat

--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -115,8 +115,9 @@ API_BASE=http://mockserver:8090/v1
 
 # Model configuration
 # MODEL_PROVIDER selects the LLM integration (via LangChain init_chat_model).
-# Built-in providers: openai, deepseek, anthropic, ollama. OpenAI-compatible
-# endpoints (DeepSeek / OneAPI / vLLM / ...) work with openai + API_BASE.
+# Built-in providers: openai, deepseek, anthropic, ollama, orcarouter.
+# OpenAI-compatible endpoints (DeepSeek / OneAPI / vLLM / ...) work with
+# openai + API_BASE. orcarouter points at the OrcaRouter gateway by default.
 # See docs/configuration.md for per-provider examples.
 MODEL_PROVIDER=openai
 MODEL_NAME=deepseek-chat


### PR DESCRIPTION
# feat(backend): add OrcaRouter as a named LLM provider

This PR makes [OrcaRouter](https://www.orcarouter.ai) a first-class `MODEL_PROVIDER` in AI Manus, wired exactly parallel to the existing named providers (`deepseek`, `anthropic`, `ollama`) that LangChain's `init_chat_model` already serves.

OrcaRouter is an OpenAI-compatible AI gateway built for both models and agents. Like OpenRouter, it exposes a provider/model namespace across many models — but it also combines adaptive routing, automatic failover, zero-markup inference, observability, guardrails, and agent-tool governance behind the same endpoint. Adding `orcarouter` as a first-class provider means AI Manus users can use that stack directly, without treating OrcaRouter as an anonymous custom base URL.

It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

## How it mirrors the existing wiring

AI Manus switches LLM integrations purely through environment variables: `MODEL_PROVIDER` selects the LangChain integration, `MODEL_NAME` picks the model, `API_KEY`/`API_BASE` supply credentials and endpoint. Native providers like `deepseek` ship a built-in default endpoint so `API_BASE` can be omitted. OrcaRouter is the same shape — an OpenAI-compatible endpoint that resolves `provider/model` model IDs — so it fits naturally as a sibling provider.

- **`backend/app/infrastructure/external/llm/langchain_llm.py`** — introduces `ORCAROUTER_API_BASE = "https://api.orcarouter.ai/v1"` and, when `MODEL_PROVIDER=orcarouter`, rewrites the provider to LangChain's OpenAI-compatible `ChatOpenAI` with that default base URL. This reuses the `langchain-openai` package already listed in `backend/pyproject.toml` — no new dependency. An explicit `API_BASE` still wins, exactly as the other providers behave.
- **`backend/tests/test_llm_gateway.py`** — new `TestOrcaRouterProvider` covering the default base URL (model `anthropic/claude-sonnet-4.5` stays untouched) and the explicit-`API_BASE` override.
- **`docs/configuration.md` / `docs/en/configuration.md`** — `orcarouter` added to the `MODEL_PROVIDER` table (built-in providers) and a config example alongside the DeepSeek/Anthropic/Ollama ones.
- **`.env.example` / `docs/quick_start.md` / `docs/en/quick_start.md`** — the embedded "Built-in providers" comment now lists `orcarouter`.

## Usage

```env
MODEL_PROVIDER=orcarouter
MODEL_NAME=anthropic/claude-sonnet-4.5
API_KEY=sk-orcarouter-...
# API_BASE can be omitted to use the default https://api.orcarouter.ai/v1
```

## Verification

- Unit tests: `tests/test_llm_gateway.py` + `tests/test_openai_gateway.py` + the pure unit-level backend suites — 82 passed.
- Live check: ran a real completion through the new `orcarouter` code path (`LangchainLLM` with `MODEL_PROVIDER=orcarouter`) against `https://api.orcarouter.ai/v1` with a valid key and received a successful response (`RESPONSE: 'OK'`).

Discord: discord.gg/YEubt8enRA · X: https://x.com/OrcaRouter

I'm an engineer on the OrcaRouter team.
