### PR TITLE
feat: add optional you.com search integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -58,6 +58,7 @@ SANDBOX_NETWORK=manus-network
 # bing_web: scrapes Bing search results directly (no API key needed)
 # tavily:   uses the Tavily Search API (requires TAVILY_API_KEY)
 # serper:   uses the Serper.dev Google Search API (requires SERPER_API_KEY)
+# youcom:   uses the You.com Web Search API (requires YOUCOM_API_KEY)
 # custom:   calls any third-party search REST API via SEARCH_API_URL + SEARCH_API_KEY
 SEARCH_PROVIDER=bing_web
 
@@ -80,6 +81,10 @@ SEARCH_PROVIDER=bing_web
 # Serper.dev search configuration, only used when SEARCH_PROVIDER=serper
 # Returns reliable Google results. Get your API key from https://serper.dev
 #SERPER_API_KEY=
+
+# You.com search configuration, only used when SEARCH_PROVIDER=youcom
+# Get your API key from https://you.com
+#YOUCOM_API_KEY=
 
 # Custom search API configuration, only used when SEARCH_PROVIDER=custom
 # Allows integration with any third-party search REST API.

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -65,7 +65,7 @@ class Settings(BaseSettings):
     browser_engine: str = "browser_use"  # "browser_use" or "playwright"
 
     # Search engine configuration
-    search_provider: str | None = "bing_web"  # "baidu", "baidu_web", "google", "bing", "bing_web", "tavily", "serper", "custom"
+    search_provider: str | None = "bing_web"  # "baidu", "baidu_web", "google", "bing", "bing_web", "tavily", "serper", "youcom", "custom"
     baidu_search_api_key: str | None = None
     bing_search_api_key: str | None = None
     google_search_api_key: str | None = None
@@ -73,6 +73,8 @@ class Settings(BaseSettings):
     tavily_api_key: str | None = None
     # Serper.dev search configuration (SEARCH_PROVIDER=serper)
     serper_api_key: str | None = None
+    # You.com search configuration (SEARCH_PROVIDER=youcom)
+    youcom_api_key: str | None = None
     # Custom search API configuration (SEARCH_PROVIDER=custom)
     search_api_url: str | None = None
     search_api_key: str | None = None

--- a/backend/app/infrastructure/external/search/__init__.py
+++ b/backend/app/infrastructure/external/search/__init__.py
@@ -17,6 +17,7 @@ def get_search_engine() -> Optional[SearchEngine]:
     from app.infrastructure.external.search.bing_web_search import BingWebSearchEngine
     from app.infrastructure.external.search.tavily_search import TavilySearchEngine
     from app.infrastructure.external.search.serper_search import SerperSearchEngine
+    from app.infrastructure.external.search.youcom_search import YouComSearchEngine
     from app.infrastructure.external.search.custom_search import CustomSearchEngine
 
     settings = get_settings()
@@ -59,6 +60,12 @@ def get_search_engine() -> Optional[SearchEngine]:
             return SerperSearchEngine(api_key=settings.serper_api_key)
         else:
             logger.warning("Serper Search Engine not initialized: missing API key (SERPER_API_KEY)")
+    elif settings.search_provider == "youcom":
+        if settings.youcom_api_key:
+            logger.info("Initializing You.com Search Engine")
+            return YouComSearchEngine(api_key=settings.youcom_api_key)
+        else:
+            logger.warning("You.com Search Engine not initialized: missing API key (YOUCOM_API_KEY)")
     elif settings.search_provider == "custom":
         if settings.search_api_url:
             logger.info(f"Initializing Custom Search Engine (url={settings.search_api_url})")

--- a/backend/app/infrastructure/external/search/youcom_search.py
+++ b/backend/app/infrastructure/external/search/youcom_search.py
@@ -1,0 +1,124 @@
+from typing import Optional
+import logging
+
+import httpx
+
+from app.domain.external.search import SearchEngine
+from app.domain.models.search import SearchResultItem, SearchResults
+from app.domain.models.tool_result import ToolResult
+
+logger = logging.getLogger(__name__)
+
+# Maps generic date_range values to You.com fileFilters (time-based search parameters)
+_DATE_RANGE_MAP = {
+    "past_hour": "h",
+    "past_day": "d",
+    "past_week": "w",
+    "past_month": "m",
+    "past_year": "y",
+}
+
+
+class YouComSearchEngine(SearchEngine):
+    """Search engine implementation using the You.com Web Search API.
+
+    You.com's Web Search API (https://api.you.com) returns ranked web results
+    with snippets, backed by the You.com search index.
+    Sign up at https://you.com to get an API key (free tier available).
+    """
+
+    def __init__(self, api_key: str):
+        self.api_key = api_key
+        self.base_url = "https://api.you.com/v1/research"
+
+    async def search(
+        self,
+        query: str,
+        date_range: Optional[str] = None,
+    ) -> ToolResult[SearchResults]:
+        """Search web pages using the You.com Web Search API.
+
+        Args:
+            query: Search query
+            date_range: Optional time range filter (past_hour/past_day/past_week/past_month/past_year/all)
+
+        Returns:
+            Search results
+        """
+        params: dict = {
+            "query": query,
+        }
+
+        if date_range and date_range != "all":
+            f = _DATE_RANGE_MAP.get(date_range)
+            if f:
+                params["fileFilters"] = f
+
+        headers = {
+            "X-API-Key": self.api_key,
+        }
+
+        try:
+            async with httpx.AsyncClient(timeout=30) as client:
+                response = await client.get(
+                    self.base_url,
+                    params=params,
+                    headers=headers,
+                )
+                response.raise_for_status()
+                data = response.json()
+
+            search_results: list[SearchResultItem] = []
+
+            for item in data.get("hits", []):
+                title = item.get("title", "")
+                link = item.get("url", "")
+                snippet = item.get("snippet", "")
+                if title and link:
+                    search_results.append(
+                        SearchResultItem(title=title, link=link, snippet=snippet)
+                    )
+
+            results = SearchResults(
+                query=query,
+                date_range=date_range,
+                total_results=len(search_results),
+                results=search_results,
+            )
+            return ToolResult(success=True, data=results)
+
+        except Exception as e:
+            logger.error(f"You.com Search failed: {e}")
+            error_results = SearchResults(
+                query=query,
+                date_range=date_range,
+                total_results=0,
+                results=[],
+            )
+            return ToolResult(
+                success=False,
+                message=f"You.com Search failed: {e}",
+                data=error_results,
+            )
+
+
+if __name__ == "__main__":
+    import asyncio
+    import os
+
+    async def test():
+        key = os.environ.get("YOUCOM_API_KEY", "")
+        engine = YouComSearchEngine(api_key=key)
+        result = await engine.search("Python programming")
+
+        if result.success:
+            print(f"Found {len(result.data.results)} results")
+            for i, item in enumerate(result.data.results[:5]):
+                print(f"{i + 1}. {item.title}")
+                print(f"   {item.link}")
+                print(f"   {item.snippet[:100]}")
+                print()
+        else:
+            print(f"Search failed: {result.message}")
+
+    asyncio.run(test())

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -145,7 +145,7 @@ API_KEY=sk-...
 
 | 配置项 | 默认值 | 是否必需 | 说明 |
 |--------|--------|----------|------|
-| `SEARCH_PROVIDER` | `bing_web` | 否 | 搜索引擎提供商（`baidu`、`baidu_web`、`google`、`bing`、`bing_web`、`tavily`、`serper` 或 `custom`） |
+| `SEARCH_PROVIDER` | `bing_web` | 否 | 搜索引擎提供商（`baidu`、`baidu_web`、`google`、`bing`、`bing_web`、`tavily`、`serper`、`youcom` 或 `custom`） |
 
 #### 百度搜索配置
 
@@ -191,6 +191,14 @@ API_KEY=sk-...
 | 配置项 | 默认值 | 是否必需 | 说明 |
 |--------|--------|----------|------|
 | `SERPER_API_KEY` | - | 是 | Serper.dev API 密钥，从 [serper.dev](https://serper.dev) 获取（提供免费额度） |
+
+#### You.com 搜索配置
+
+仅当 `SEARCH_PROVIDER=youcom` 时使用。You.com 提供 AI 优先的网络搜索 API，返回排序后的结果和摘要：
+
+| 配置项 | 默认值 | 是否必需 | 说明 |
+|--------|--------|----------|------|
+| `YOUCOM_API_KEY` | - | 是 | You.com API 密钥，从 [you.com](https://you.com) 获取 |
 
 #### 自定义搜索 API 配置
 

--- a/docs/en/configuration.md
+++ b/docs/en/configuration.md
@@ -145,7 +145,7 @@ API_KEY=sk-...
 
 | Configuration | Default Value | Required | Description |
 |---------------|---------------|----------|-------------|
-| `SEARCH_PROVIDER` | `bing_web` | No | Search engine provider (`baidu`, `baidu_web`, `google`, `bing`, `bing_web`, `tavily`, `serper`, or `custom`) |
+| `SEARCH_PROVIDER` | `bing_web` | No | Search engine provider (`baidu`, `baidu_web`, `google`, `bing`, `bing_web`, `tavily`, `serper`, `youcom`, or `custom`) |
 
 #### Baidu Search Configuration
 
@@ -191,6 +191,14 @@ Used only when `SEARCH_PROVIDER=serper`. Serper.dev delivers reliable Google sea
 | Configuration | Default Value | Required | Description |
 |---------------|---------------|----------|-------------|
 | `SERPER_API_KEY` | - | Yes | Serper.dev API key, get from [serper.dev](https://serper.dev) (free tier available) |
+
+#### You.com Search Configuration
+
+Used only when `SEARCH_PROVIDER=youcom`. You.com provides an AI-first web search API with ranked results and snippets:
+
+| Configuration | Default Value | Required | Description |
+|---------------|---------------|----------|-------------|
+| `YOUCOM_API_KEY` | - | Yes | You.com API key, get from [you.com](https://you.com) |
 
 #### Custom Search API Configuration
 

--- a/docs/en/quick_start.md
+++ b/docs/en/quick_start.md
@@ -161,13 +161,14 @@ SANDBOX_NETWORK=manus-network
 #BROWSER_ENGINE=browser_use
 
 # Search engine configuration
-# Options: baidu, baidu_web, google, bing, bing_web, tavily, serper, custom
+# Options: baidu, baidu_web, google, bing, bing_web, tavily, serper, youcom, custom
 # baidu:    uses the Baidu Qianfan AI Search API (requires BAIDU_SEARCH_API_KEY)
 # baidu_web: scrapes Baidu search results with browser impersonation (no API key needed)
 # bing:     uses the official Bing Web Search API (requires BING_SEARCH_API_KEY)
 # bing_web: scrapes Bing search results directly (no API key needed)
 # tavily:   uses the Tavily Search API (requires TAVILY_API_KEY)
 # serper:   uses the Serper.dev Google Search API (requires SERPER_API_KEY)
+# youcom:   uses the You.com Web Search API (requires YOUCOM_API_KEY)
 # custom:   calls any third-party search REST API via SEARCH_API_URL + SEARCH_API_KEY
 SEARCH_PROVIDER=bing_web
 
@@ -190,6 +191,10 @@ SEARCH_PROVIDER=bing_web
 # Serper.dev search configuration, only used when SEARCH_PROVIDER=serper
 # Returns reliable Google results. Get your API key from https://serper.dev
 #SERPER_API_KEY=
+
+# You.com search configuration, only used when SEARCH_PROVIDER=youcom
+# Get your API key from https://you.com
+#YOUCOM_API_KEY=
 
 # Custom search API configuration, only used when SEARCH_PROVIDER=custom
 # Allows integration with any third-party search REST API.

--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -162,13 +162,14 @@ SANDBOX_NETWORK=manus-network
 #BROWSER_ENGINE=browser_use
 
 # Search engine configuration
-# Options: baidu, baidu_web, google, bing, bing_web, tavily, serper, custom
+# Options: baidu, baidu_web, google, bing, bing_web, tavily, serper, youcom, custom
 # baidu:    uses the Baidu Qianfan AI Search API (requires BAIDU_SEARCH_API_KEY)
 # baidu_web: scrapes Baidu search results with browser impersonation (no API key needed)
 # bing:     uses the official Bing Web Search API (requires BING_SEARCH_API_KEY)
 # bing_web: scrapes Bing search results directly (no API key needed)
 # tavily:   uses the Tavily Search API (requires TAVILY_API_KEY)
 # serper:   uses the Serper.dev Google Search API (requires SERPER_API_KEY)
+# youcom:   uses the You.com Web Search API (requires YOUCOM_API_KEY)
 # custom:   calls any third-party search REST API via SEARCH_API_URL + SEARCH_API_KEY
 SEARCH_PROVIDER=bing_web
 
@@ -191,6 +192,10 @@ SEARCH_PROVIDER=bing_web
 # Serper.dev search configuration, only used when SEARCH_PROVIDER=serper
 # Returns reliable Google results. Get your API key from https://serper.dev
 #SERPER_API_KEY=
+
+# You.com search configuration, only used when SEARCH_PROVIDER=youcom
+# Get your API key from https://you.com
+#YOUCOM_API_KEY=
 
 # Custom search API configuration, only used when SEARCH_PROVIDER=custom
 # Allows integration with any third-party search REST API.


### PR DESCRIPTION
## Summary

Adds [you.com](https://you.com) as an opt-in search provider, alongside the existing Google/Bing/Baidu/Tavily/Serper/custom providers.

- New `YouComSearchEngine` (`backend/app/infrastructure/external/search/youcom_search.py`) implementing the existing `SearchEngine` protocol: GET `https://api.you.com/v1/research` with `X-API-Key` auth, maps the generic `date_range` values to the API's `fileFilters` parameter, and parses `hits` into `SearchResultItem`.
- Wired into `get_search_engine()` factory and `Settings` as `SEARCH_PROVIDER=youcom` + `YOUCOM_API_KEY`.
- Docs updated: `configuration.md` and `quick_start.md` (both en/zh) plus `.env.example`.

Opt-in only — default `SEARCH_PROVIDER` (`bing_web`) is unchanged, and nothing changes for existing configurations.

## Testing

- Smoke-tested the engine end-to-end with a stubbed HTTP layer: request shape (URL, query/`fileFilters` params, `X-API-Key` header), hit parsing into `SearchResultItem`, empty-result filtering, and the no-`date_range` path all verified.
- No existing behavior modified outside the new provider branch of the factory.