### PR TITLE
docs(skills): add manus-official-cdp for logged-in CDP mining

### DIFF
--- a/.cursor/skills/manus-official-cdp/SKILL.md
+++ b/.cursor/skills/manus-official-cdp/SKILL.md
@@ -1,0 +1,313 @@
+---
+name: manus-official-cdp
+description: >-
+  Use when opening logged-in manus.im via Chrome CDP without a fresh login —
+  auto-fetch session via fetch-session.cjs (CDP/Chrome DB), or read
+  MANUS_SESSION_TOKEN / MANUS_COOKIE, or instruct user how to export/give
+  `session_id`; triggers: CDP cookie, session_id, 免登录, 环境变量,
+  fetch-session, MANUS_SESSION_TOKEN, inject cookie, Default profile,
+  怎么获取 cookie, manus.im unavailable, connectOverCDP.
+---
+
+# Manus official CDP session
+
+Get a **logged-in** manus.im tab over Chrome DevTools Protocol using `session_id` from **env**, file, or Chrome Default profile — no interactive login when the JWT is still valid.
+
+Pairs with **replicate-manus-ui** (DOM / className mining). Respond in **中文** unless the user writes in English.
+
+## Hard rules
+
+1. **Only `session_id` is required** for auth (domain `.manus.im`). Skip analytics (`_gcl_au`, `__stripe_*`, Intercom, `_fbp`, `_ga`, theme, ad-consent).
+2. **Never commit** cookie values, JWT strings, profile copies, or env files that contain them. Never echo the full token in chat / logs / screenshots captions — print `valueLen` + prefix only.
+3. Prefer **reuse an already-open CDP Chrome** (`http://127.0.0.1:9222`) over launching a second profile that fights locks.
+4. Auth proof = API **200**, not “page isn’t `/login`”. Geo block can still show `/unavailable`.
+5. **Always resolve session before asking the user** — env → file → CDP cookies → only then instruct 获取/交给.
+6. If still missing, **do not invent workarounds** — tell the user how to export it and how to send it (incl. env vars), then wait.
+
+## Resolve order (agent MUST follow)
+
+```text
+0. fetch-session.cjs                 auto: CDP → Chrome DB → write file
+1. MANUS_SESSION_TOKEN               raw JWT
+2. MANUS_COOKIE                      Cookie header or session_id=...
+3. MANUS_SESSION_FILE                default /tmp/manus_session_id.value
+4. CDP context.cookies()             already on .manus.im
+5. Ask user (获取 + 交给 agent)
+```
+
+### Auto-fetch script（推荐）
+
+从本机 **已登录** 的 CDP Chrome 或 Chrome Default Cookies 自动取出 `session_id`，写入 `/tmp/manus_session_id.value`（`0600`），**默认不打印完整 JWT**：
+
+```bash
+node .cursor/skills/manus-official-cdp/scripts/fetch-session.cjs
+# {"ok":true,"source":"cdp:http://127.0.0.1:9222","valueLen":341,...}
+
+eval "$(node .cursor/skills/manus-official-cdp/scripts/fetch-session.cjs --export)"
+node .cursor/skills/manus-official-cdp/scripts/fetch-session.cjs --force-fetch
+TOKEN="$(node .cursor/skills/manus-official-cdp/scripts/fetch-session.cjs --token)"
+```
+
+依赖：CDP `:9222` + `playwright-core`（`/tmp/pw` 或 `PLAYWRIGHT_CORE`）；否则解密 Chrome Cookies（Keychain「Chrome Safe Storage」+ `sqlite3`，可能弹授权）。
+
+Agent 开干前先跑 `fetch-session.cjs`；`ok:false` 再教用户手动获取。
+
+只读已有 env/file（不抓取）：
+
+```bash
+node .cursor/skills/manus-official-cdp/scripts/resolve-session.cjs
+TOKEN="$(node .cursor/skills/manus-official-cdp/scripts/resolve-session.cjs --token)"
+```
+
+In Node/Playwright scripts, read the same sources yourself if the helper is unavailable:
+
+```js
+function resolveManusSession() {
+  const bare = (process.env.MANUS_SESSION_TOKEN || '').trim()
+  if (bare.includes('.')) return bare
+  const cookie = process.env.MANUS_COOKIE || ''
+  const m = cookie.match(/(?:^|;\s*)session_id=([^;]+)/i)
+  if (m) return m[1].trim()
+  const file = process.env.MANUS_SESSION_FILE || '/tmp/manus_session_id.value'
+  try {
+    const t = require('fs').readFileSync(file, 'utf8').trim()
+    const m2 = t.match(/(?:^|;\s*)session_id=([^;]+)/i)
+    return (m2 ? m2[1] : t).trim()
+  } catch { return '' }
+}
+```
+
+## Tell the user: how to get + how to give
+
+When the agent needs a cookie from the human, paste instructions in **中文** (unless they write in English). Keep it short; do not ask for analytics cookies.
+
+### How to get（获取）
+
+Ask them to use a browser where they are **already logged into** [manus.im](https://manus.im/app):
+
+**方式 A — DevTools（推荐）**
+
+1. 打开已登录的 `https://manus.im/app`
+2. `F12` / 右键检查 → **Application**（应用）→ **Cookies** → `https://manus.im`
+3. 找到名为 **`session_id`** 的那一行（domain 多为 `.manus.im`）
+4. 双击 **Value**，全选复制（一长串 `eyJ…` JWT）
+
+**方式 B — 任意请求的 Cookie 头**
+
+1. DevTools → **Network**
+2. 刷新页面，点开任意发往 `api.manus.im` 或 `manus.im` 的请求
+3. Request Headers 里找到 `Cookie:`，复制其中 `session_id=...` 那一段（到下一个 `;` 为止）
+
+**方式 C — 自动脚本（本机已登录时）**
+
+```bash
+node .cursor/skills/manus-official-cdp/scripts/fetch-session.cjs
+eval "$(node .cursor/skills/manus-official-cdp/scripts/fetch-session.cjs --export)"
+```
+
+从 CDP `:9222` 或 Chrome Default Cookies 拉取；成功后再开 agent。失败则用方式 A/B。
+
+**方式 D — 本机 Default Chrome 已登录（agent 侧）**
+
+若用户说「Default profile 里有」，agent 先跑 `fetch-session.cjs --force-fetch`；失败再退回方式 A/B。
+
+### How to give（交给 agent）
+
+任选一种，**优先自动脚本 / 环境变量**（不用把 JWT 贴进聊天）：
+
+| 方式 | 用户怎么做 | Agent 怎么用 |
+|------|------------|--------------|
+| **自动脚本（推荐）** | `node …/fetch-session.cjs` 然后 `eval "$(… --export)"` | 先跑 fetch；再注入 |
+| **环境变量** | `export MANUS_SESSION_TOKEN='eyJ…'` 或 `MANUS_COOKIE='session_id=eyJ…'` | `resolve-session.cjs` / `process.env` |
+| **shell 一次性** | 把变量写进当前 Cursor/终端会话环境 | 同上 |
+| **本地文件** | `printf '%s' 'eyJ…' > /tmp/manus_session_id.value && chmod 600 …` | 读文件 / helper |
+| **只贴 JWT** | 聊天里贴 Value | 写入 `/tmp/…` 再注入；**勿回显** |
+| **JSON** | 见下方模板 | `addCookies` |
+| **Cookie 头片段** | `session_id=eyJ…` | 解析后注入 |
+
+环境变量约定：
+
+| Var | Content |
+|-----|---------|
+| `MANUS_SESSION_TOKEN` | raw JWT only |
+| `MANUS_COOKIE` | `session_id=…` or full `Cookie:` header |
+| `MANUS_SESSION_FILE` | path to file with JWT or `session_id=…` (default `/tmp/manus_session_id.value`) |
+
+示例（用户本地终端，**不要**提交进 git / `.env` 入库）：
+
+```bash
+# 自动（本机已登录 + CDP 或 Chrome Cookies）：
+node .cursor/skills/manus-official-cdp/scripts/fetch-session.cjs
+eval "$(node .cursor/skills/manus-official-cdp/scripts/fetch-session.cjs --export)"
+
+# 或手动从 DevTools 复制 Value 后：
+export MANUS_SESSION_TOKEN='eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9…'
+export MANUS_COOKIE='session_id=eyJ…'
+
+# 自检（只看长度，不打印 token）：
+node .cursor/skills/manus-official-cdp/scripts/resolve-session.cjs
+```
+
+若 Cursor Agent 读不到你刚 `export` 的变量：在 **同一终端会话** 启动 agent，或把变量写进该会话的环境；必要时改用文件 `/tmp/manus_session_id.value`。
+
+推荐 JSON 模板（聊天粘贴用，可只填 `value`）：
+
+```json
+{
+  "name": "session_id",
+  "value": "PASTE_JWT_HERE",
+  "domain": ".manus.im",
+  "path": "/"
+}
+```
+
+Agent 解析到 token 后应立刻：
+
+1. 优先已有 env；否则写入 `/tmp/manus_session_id.value`（`0600`），**不要**把完整 JWT 再复述回聊天
+2. CDP `addCookies` → `GetAvailableCredits` Bearer 验 200 → 打开 `/app`
+3. 确认成功时只回报：`source` / `valueLen` / `api status` / 最终 URL
+
+提醒用户：这是登录凭证；用完可 `unset MANUS_SESSION_TOKEN MANUS_COOKIE`；**不要**发到公开渠道 / 不要提交 git。
+
+## Critical cookie
+
+| Field | Value |
+|-------|--------|
+| `name` | `session_id` |
+| `domain` | `.manus.im` |
+| `path` | `/` |
+| shape | JWT (`eyJ…`, ≥2 dots) |
+
+Optional: `login_success=1` on `manus.im` (not the real auth).
+
+API check (Bearer = raw JWT):
+
+```bash
+TOKEN="$(node .cursor/skills/manus-official-cdp/scripts/resolve-session.cjs --token)"
+curl -sS -X POST 'https://api.manus.im/user.v1.UserService/GetAvailableCredits' \
+  -H 'content-type: application/json' \
+  -H 'connect-protocol-version: 1' \
+  -H "authorization: Bearer ${TOKEN}" \
+  -H 'origin: https://manus.im' \
+  -d '{}'
+# expect HTTP 200 + totalCredits
+unset TOKEN
+```
+
+## Workflow
+
+```
+Manus CDP session:
+- [ ] 0. `fetch-session.cjs` (or resolve env/file) → else instruct user
+- [ ] 1. Ensure CDP Chrome on :9222 (or start sticky profile)
+- [ ] 2. Inject session_id if not already on context
+- [ ] 3. Verify GetAvailableCredits → 200
+- [ ] 4. Open https://manus.im/app ; handle /unavailable if geo-blocked
+- [ ] 5. Hand off to replicate-manus-ui mining
+```
+
+### 1. Start or attach CDP Chrome
+
+Sticky empty profile (cookie will be injected):
+
+```bash
+"/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" \
+  --remote-debugging-port=9222 \
+  --user-data-dir=/tmp/chrome-manus-cdp \
+  --profile-directory=Default \
+  --no-first-run --no-default-browser-check \
+  "https://manus.im/app"
+```
+
+If `:9222` already answers `json/version`, **attach** — do not start another Chrome on the same port.
+
+Drive with playwright-core (`/tmp/pw` or project `tmp/pw`):
+
+```js
+const { chromium } = require('/tmp/pw/node_modules/playwright-core')
+const browser = await chromium.connectOverCDP('http://127.0.0.1:9222')
+const context = browser.contexts()[0]
+```
+
+`browser.close()` on a CDP connection **disconnects only** — it does not quit Chrome.
+
+### 2. Get / inject `session_id`
+
+**First:** run the resolve helper (env / file). If `ok`, inject that JWT.
+
+**Else:** CDP profile that already has cookies — read via Playwright:
+
+```js
+const cookies = await context.cookies(['https://manus.im'])
+const session = cookies.find(c => c.name === 'session_id')
+```
+
+**Inject** (from env/file/user):
+
+```js
+const { execFileSync } = require('child_process')
+const value = execFileSync('node', [
+  '.cursor/skills/manus-official-cdp/scripts/resolve-session.cjs',
+  '--token',
+], { encoding: 'utf8' }).trim()
+
+await context.addCookies([{
+  name: 'session_id',
+  value,
+  domain: '.manus.im',
+  path: '/',
+  expires: Math.floor(Date.now() / 1000) + 60 * 60 * 24 * 30,
+  httpOnly: false,
+  secure: false,
+  sameSite: 'Lax',
+}])
+```
+
+macOS Default DB path (encrypted at rest):
+
+`~/Library/Application Support/Google/Chrome/Default/Cookies`
+
+Decrypt only if env/CDP cannot see the cookie; prefer env + Playwright `context.cookies()` over hand-decrypt.
+
+### 3. Verify auth before trusting the UI
+
+1. `session_id` present, JWT-shaped, `valueLen` ~300+
+2. `GetAvailableCredits` with `Authorization: Bearer <jwt>` → **200**
+3. Then navigate:
+
+```js
+const page = context.pages()[0] || await context.newPage()
+await page.goto('https://manus.im/app', { waitUntil: 'domcontentloaded', timeout: 45000 })
+await page.waitForTimeout(3000)
+```
+
+Success signals: URL stays on `/app` (or session deep link), title ~`Manus`, sidebar / `#manus-chat-box` / composer present, **not** `/login`.
+
+### 4. Geo / unavailable
+
+If URL or body shows **`/unavailable`** / 「Manus 在你所在的地区不可用」:
+
+- Cookie may still be valid (API 200) — **do not** treat as login failure
+- Need a network path that manus.im allows (VPN / different egress), then retry `/app` with the same cookie
+- Re-check after network change; do not rotate JWT unless API returns 401
+
+### 5. Hand off
+
+Once `/app` is logged-in and interactive → follow **replicate-manus-ui** for DOM dumps, screenshots under `tmp/screenshots/` (gitignored). 「截图发过来」→ personal **telegram-screenshots**.
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---------|--------------|-----|
+| API 401 `missing authorization header` | Sent Cookie only | Use `Bearer` JWT |
+| API 401 unauthenticated | Expired / revoked session | Fresh Default login; re-copy `session_id` |
+| `/login` after goto | Cookie missing / wrong domain | Inject `.manus.im` `session_id`; reload |
+| `/unavailable` + API 200 | Region block | Change egress; keep same cookie |
+| `:9222` empty / no pages | Tab closed; only extension SW | `context.newPage()` then goto `/app` |
+| Profile lock / Chrome won’t start | Default profile already open | Use `/tmp/chrome-manus-cdp` + inject, or attach existing CDP |
+
+## Security checklist
+
+- [ ] No JWT in git, PR, skill files, or agent transcripts if avoidable
+- [ ] Temp token files mode `0600`, path under `/tmp`, delete when done
+- [ ] Chat replies: `hasSession` / `valueLen` / `api status` only

--- a/.cursor/skills/manus-official-cdp/scripts/fetch-session.cjs
+++ b/.cursor/skills/manus-official-cdp/scripts/fetch-session.cjs
@@ -1,0 +1,359 @@
+#!/usr/bin/env node
+/**
+ * Auto-fetch manus.im session_id and write /tmp/manus_session_id.value (0600).
+ *
+ * Sources (first wins unless --force-fetch):
+ *   1. Existing env/file via resolve-session.cjs (skip with --force-fetch)
+ *   2. CDP Chrome on MANUS_CDP_URL (default http://127.0.0.1:9222)
+ *   3. Decrypt Chrome Cookies DB (Default + common /tmp CDP profiles)
+ *
+ * Output (default): JSON metadata only — never prints full JWT.
+ *   --token     print raw JWT to stdout
+ *   --export    print: export MANUS_SESSION_TOKEN='...'
+ *   --force-fetch  ignore existing env/file; re-read CDP/DB
+ *   --no-write  do not write the temp file
+ *
+ * Env:
+ *   MANUS_CDP_URL          CDP endpoint (default http://127.0.0.1:9222)
+ *   MANUS_SESSION_FILE     output path (default /tmp/manus_session_id.value)
+ *   MANUS_CHROME_COOKIES   override Cookies DB path
+ *   PLAYWRIGHT_CORE        path to playwright-core package root
+ */
+const fs = require('fs')
+const os = require('os')
+const path = require('path')
+const crypto = require('crypto')
+const { spawnSync } = require('child_process')
+
+const OUT =
+  process.env.MANUS_SESSION_FILE || '/tmp/manus_session_id.value'
+const CDP_URL = process.env.MANUS_CDP_URL || 'http://127.0.0.1:9222'
+const SCRIPT_DIR = __dirname
+
+function looksJwt(v) {
+  return typeof v === 'string' && v.length > 40 && (v.match(/\./g) || []).length >= 2
+}
+
+function metaOf(source, value) {
+  return {
+    ok: true,
+    source,
+    valueLen: value.length,
+    valuePrefix: value.slice(0, 12),
+    jwtish: looksJwt(value),
+    file: OUT,
+  }
+}
+
+function writeToken(value) {
+  fs.writeFileSync(OUT, value, { mode: 0o600 })
+  try {
+    fs.chmodSync(OUT, 0o600)
+  } catch {
+    /* ignore */
+  }
+}
+
+function tryResolveExisting() {
+  try {
+    const r = spawnSync(
+      process.execPath,
+      [path.join(SCRIPT_DIR, 'resolve-session.cjs'), '--token'],
+      { encoding: 'utf8' },
+    )
+    if (r.status === 0 && looksJwt(r.stdout.trim())) {
+      return { source: 'resolve-session', value: r.stdout.trim() }
+    }
+  } catch {
+    /* ignore */
+  }
+  return null
+}
+
+function findPlaywrightCore() {
+  const candidates = [
+    process.env.PLAYWRIGHT_CORE,
+    '/tmp/pw/node_modules/playwright-core',
+    path.join(process.cwd(), 'tmp/pw/node_modules/playwright-core'),
+    path.join(process.cwd(), 'node_modules/playwright-core'),
+  ].filter(Boolean)
+  for (const c of candidates) {
+    try {
+      if (fs.existsSync(path.join(c, 'package.json'))) return c
+    } catch {
+      /* ignore */
+    }
+  }
+  return null
+}
+
+async function tryCdp() {
+  let version
+  try {
+    const res = await fetch(`${CDP_URL.replace(/\/$/, '')}/json/version`, {
+      signal: AbortSignal.timeout(2000),
+    })
+    if (!res.ok) return null
+    version = await res.json()
+  } catch {
+    return null
+  }
+
+  const pwRoot = findPlaywrightCore()
+  if (!pwRoot) {
+    return {
+      error: 'cdp_up_but_no_playwright',
+      cdp: CDP_URL,
+      browser: version.Browser,
+    }
+  }
+
+  const { chromium } = require(pwRoot)
+  const browser = await chromium.connectOverCDP(CDP_URL)
+  try {
+    const context = browser.contexts()[0]
+    if (!context) return null
+    const cookies = await context.cookies(['https://manus.im', 'https://www.manus.im'])
+    const session = cookies.find((c) => c.name === 'session_id')
+    if (session && looksJwt(session.value)) {
+      return { source: `cdp:${CDP_URL}`, value: session.value }
+    }
+    return { error: 'cdp_no_session_id', cdp: CDP_URL }
+  } finally {
+    await browser.close().catch(() => {})
+  }
+}
+
+function chromeSafeStoragePassword() {
+  const r = spawnSync(
+    'security',
+    ['find-generic-password', '-w', '-s', 'Chrome Safe Storage', '-a', 'Chrome'],
+    { encoding: 'utf8' },
+  )
+  if (r.status !== 0) {
+    throw new Error(
+      (r.stderr || r.stdout || 'keychain read failed').trim() ||
+        'Chrome Safe Storage keychain denied',
+    )
+  }
+  return r.stdout.trim()
+}
+
+function decryptChromeValue(enc, password) {
+  if (!enc || enc.length < 4) return ''
+  const prefix = enc.subarray(0, 3).toString('utf8')
+  if (prefix !== 'v10' && prefix !== 'v11') {
+    // plaintext (rare) or unsupported scheme (e.g. v20 app-bound)
+    if (enc[0] === 0x76 /* v */) return ''
+    return enc.toString('utf8')
+  }
+  const key = crypto.pbkdf2Sync(password, 'saltysalt', 1003, 16, 'sha1')
+  const iv = Buffer.alloc(16, ' ')
+  const decipher = crypto.createDecipheriv('aes-128-cbc', key, iv)
+  let dec = Buffer.concat([decipher.update(enc.subarray(3)), decipher.final()])
+  const pad = dec[dec.length - 1]
+  if (pad >= 1 && pad <= 16) dec = dec.subarray(0, dec.length - pad)
+  let text = dec.toString('utf8')
+  if (!looksJwt(text) && dec.length > 32) {
+    const alt = dec.subarray(32).toString('utf8')
+    if (looksJwt(alt)) text = alt
+  }
+  return text
+}
+
+function cookieDbCandidates() {
+  const home = os.homedir()
+  const list = []
+  if (process.env.MANUS_CHROME_COOKIES) list.push(process.env.MANUS_CHROME_COOKIES)
+  list.push(
+    path.join(home, 'Library/Application Support/Google/Chrome/Default/Cookies'),
+    path.join(home, 'Library/Application Support/Google/Chrome/Default/Network/Cookies'),
+    path.join(home, 'Library/Application Support/Google/Chrome/Profile 1/Cookies'),
+    '/tmp/chrome-yaoyitao-local/Default/Cookies',
+    '/tmp/chrome-manus-cdp/Default/Cookies',
+    '/tmp/chrome-manus-debug/Default/Cookies',
+  )
+  return list.filter((p, i, a) => a.indexOf(p) === i && fs.existsSync(p))
+}
+
+function tryChromeDb() {
+  let password
+  try {
+    password = chromeSafeStoragePassword()
+  } catch (e) {
+    return { error: 'keychain', message: String(e.message || e) }
+  }
+
+  const dbs = cookieDbCandidates()
+  if (!dbs.length) return { error: 'no_cookie_db' }
+
+  let lastError
+  for (const dbPath of dbs) {
+    const tmp = path.join(
+      os.tmpdir(),
+      `manus-cookies-${process.pid}-${Date.now()}.db`,
+    )
+    try {
+      fs.copyFileSync(dbPath, tmp)
+      try {
+        fs.copyFileSync(dbPath + '-journal', tmp + '-journal')
+      } catch {
+        /* optional */
+      }
+
+      let row
+      try {
+        row = querySessionRow(tmp)
+      } finally {
+        try {
+          fs.unlinkSync(tmp)
+        } catch {
+          /* ignore */
+        }
+        try {
+          fs.unlinkSync(tmp + '-journal')
+        } catch {
+          /* ignore */
+        }
+      }
+      if (!row) continue
+
+      let value = row.value || ''
+      if ((!value || !looksJwt(value)) && row.encrypted_value) {
+        value = decryptChromeValue(row.encrypted_value, password)
+      }
+      if (looksJwt(value)) {
+        return { source: `chrome-db:${dbPath}`, value }
+      }
+    } catch (e) {
+      lastError = String(e.message || e)
+    }
+  }
+  return {
+    error: 'chrome_db_no_session',
+    dbsTried: dbs,
+    lastDbError: lastError,
+  }
+}
+
+function querySessionRow(dbPath) {
+  // Try better-sqlite3
+  try {
+    const Database = require('better-sqlite3')
+    const db = new Database(dbPath, { readonly: true, fileMustExist: true })
+    try {
+      const row = db
+        .prepare(
+          `SELECT host_key, value, encrypted_value FROM cookies
+           WHERE name = 'session_id' AND host_key LIKE '%manus%'
+           ORDER BY LENGTH(encrypted_value) + LENGTH(value) DESC LIMIT 1`,
+        )
+        .get()
+      if (!row) return null
+      return {
+        value: row.value || '',
+        encrypted_value: row.encrypted_value
+          ? Buffer.from(row.encrypted_value)
+          : null,
+      }
+    } finally {
+      db.close()
+    }
+  } catch {
+    /* fall through to sqlite3 CLI */
+  }
+
+  const sql =
+    `SELECT quote(value), hex(encrypted_value) FROM cookies ` +
+    `WHERE name='session_id' AND host_key LIKE '%manus%' ` +
+    `ORDER BY length(encrypted_value)+length(value) DESC LIMIT 1;`
+  const r = spawnSync('sqlite3', [dbPath, sql], { encoding: 'utf8' })
+  if (r.status !== 0) {
+    throw new Error((r.stderr || 'sqlite3 failed').trim())
+  }
+  const line = (r.stdout || '').trim()
+  if (!line) return null
+  // quote(value)|hex
+  const pipe = line.lastIndexOf('|')
+  let value = ''
+  let hex = line
+  if (pipe >= 0) {
+    value = line.slice(0, pipe)
+    hex = line.slice(pipe + 1)
+    // sqlite quote() wraps in single quotes and escapes ''
+    if (value.startsWith("'") && value.endsWith("'")) {
+      value = value.slice(1, -1).replace(/''/g, "'")
+    }
+  }
+  const encrypted_value = hex && /^[0-9A-Fa-f]+$/.test(hex) ? Buffer.from(hex, 'hex') : null
+  return { value, encrypted_value }
+}
+
+function finish(hit, opts) {
+  if (!opts.noWrite) writeToken(hit.value)
+  const m = metaOf(hit.source, hit.value)
+  m.wrote = !opts.noWrite
+
+  if (opts.mode === 'token') {
+    process.stdout.write(hit.value)
+    process.exit(0)
+  }
+  if (opts.mode === 'export') {
+    // Single-quoted shell export; escape embedded quotes
+    const q = hit.value.replace(/'/g, `'\"'\"'`)
+    process.stdout.write(`export MANUS_SESSION_TOKEN='${q}'\n`)
+    process.stdout.write(`export MANUS_SESSION_FILE='${OUT}'\n`)
+    process.exit(0)
+  }
+  process.stdout.write(JSON.stringify(m) + '\n')
+  process.exit(0)
+}
+
+async function main() {
+  const args = new Set(process.argv.slice(2))
+  const opts = {
+    mode: args.has('--token') ? 'token' : args.has('--export') ? 'export' : 'meta',
+    forceFetch: args.has('--force-fetch'),
+    noWrite: args.has('--no-write'),
+  }
+
+  const errors = []
+
+  if (!opts.forceFetch) {
+    const existing = tryResolveExisting()
+    if (existing) {
+      // Refresh file so MANUS_SESSION_FILE stays in sync
+      finish(existing, opts)
+    }
+  }
+
+  try {
+    const cdp = await tryCdp()
+    if (cdp && cdp.value) finish(cdp, opts)
+    if (cdp && cdp.error) errors.push(cdp)
+  } catch (e) {
+    errors.push({ error: 'cdp_exception', message: String(e.message || e) })
+  }
+
+  const db = tryChromeDb()
+  if (db && db.value) finish(db, opts)
+  if (db && db.error) errors.push(db)
+
+  process.stdout.write(
+    JSON.stringify({
+      ok: false,
+      file: OUT,
+      errors,
+      hint:
+        'Log into manus.im in Chrome, allow Keychain access if prompted, ' +
+        'or start CDP Chrome on :9222; or export MANUS_SESSION_TOKEN manually ' +
+        '(see manus-official-cdp skill).',
+    }) + '\n',
+  )
+  process.exit(1)
+}
+
+main().catch((e) => {
+  process.stderr.write(String(e.stack || e) + '\n')
+  process.exit(1)
+})

--- a/.cursor/skills/manus-official-cdp/scripts/resolve-session.cjs
+++ b/.cursor/skills/manus-official-cdp/scripts/resolve-session.cjs
@@ -1,0 +1,93 @@
+#!/usr/bin/env node
+/**
+ * Resolve manus.im session_id JWT from env / file.
+ * Default: print JSON metadata only (no token).
+ *   --token   print raw JWT to stdout (for piping into inject; never log)
+ *   --check   exit 0 if resolvable, 1 otherwise
+ *
+ * Sources (first wins):
+ *   1. MANUS_SESSION_TOKEN  — raw JWT
+ *   2. MANUS_COOKIE         — full Cookie header or "session_id=..."
+ *   3. MANUS_SESSION_FILE   — path to file (default /tmp/manus_session_id.value)
+ */
+const fs = require('fs')
+
+function extractFromCookieHeader(raw) {
+  const s = String(raw || '').trim()
+  if (!s) return ''
+  if (!s.includes('=') && !s.includes(';')) return s // bare JWT
+  for (const part of s.split(';')) {
+    const [k, ...rest] = part.trim().split('=')
+    if (k && k.trim().toLowerCase() === 'session_id') {
+      return rest.join('=').trim()
+    }
+  }
+  return ''
+}
+
+function looksJwt(v) {
+  return typeof v === 'string' && v.length > 40 && (v.match(/\./g) || []).length >= 2
+}
+
+function resolve() {
+  const fromToken = String(process.env.MANUS_SESSION_TOKEN || '').trim()
+  if (looksJwt(fromToken)) {
+    return { source: 'MANUS_SESSION_TOKEN', value: fromToken }
+  }
+
+  const fromCookie = extractFromCookieHeader(process.env.MANUS_COOKIE || '')
+  if (looksJwt(fromCookie)) {
+    return { source: 'MANUS_COOKIE', value: fromCookie }
+  }
+
+  const filePath =
+    process.env.MANUS_SESSION_FILE || '/tmp/manus_session_id.value'
+  if (fs.existsSync(filePath)) {
+    const fromFile = extractFromCookieHeader(fs.readFileSync(filePath, 'utf8'))
+    if (looksJwt(fromFile)) {
+      return { source: `file:${filePath}`, value: fromFile }
+    }
+  }
+
+  return null
+}
+
+const mode = process.argv.includes('--token')
+  ? 'token'
+  : process.argv.includes('--check')
+    ? 'check'
+    : 'meta'
+
+const hit = resolve()
+if (!hit) {
+  const meta = {
+    ok: false,
+    sourcesTried: [
+      'MANUS_SESSION_TOKEN',
+      'MANUS_COOKIE',
+      process.env.MANUS_SESSION_FILE || '/tmp/manus_session_id.value',
+    ],
+  }
+  if (mode === 'token') {
+    process.stderr.write('manus-official-cdp: no session_id in env/file\n')
+    process.exit(1)
+  }
+  process.stdout.write(JSON.stringify(meta) + '\n')
+  process.exit(mode === 'check' ? 1 : 0)
+}
+
+const meta = {
+  ok: true,
+  source: hit.source,
+  valueLen: hit.value.length,
+  valuePrefix: hit.value.slice(0, 12),
+  jwtish: looksJwt(hit.value),
+}
+
+if (mode === 'token') {
+  process.stdout.write(hit.value)
+  process.exit(0)
+}
+
+process.stdout.write(JSON.stringify(meta) + '\n')
+process.exit(0)

--- a/.cursor/skills/replicate-manus-ui/SKILL.md
+++ b/.cursor/skills/replicate-manus-ui/SKILL.md
@@ -53,11 +53,13 @@ Manus UI replicate:
 
 Prefer a **logged-in** session (guest marketing pages lack Computer / sidebar).
 
+**Login / CDP session:** follow project skill **manus-official-cdp** (Default-profile `session_id` → CDP inject → API verify → open `/app`). Do not re-learn cookie names ad hoc; geo `/unavailable` ≠ auth failure.
+
 ```bash
-# Chrome with sticky login profile
+# Chrome with sticky login profile (or attach existing :9222 — see manus-official-cdp)
 "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" \
   --remote-debugging-port=9222 \
-  --user-data-dir=/tmp/chrome-manus-debug \
+  --user-data-dir=/tmp/chrome-manus-cdp \
   --profile-directory=Default \
   --no-first-run --no-default-browser-check \
   "https://manus.im/app/…"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -249,6 +249,7 @@ The dev compose starts the backend with **debugpy** on port `5678`. Attach a rem
 | Skill File | When to Use |
 |---|---|
 | `.cursor/skills/starter.md` | Setting up, running, or testing any part of the codebase. Contains detailed API reference, env var tables, and testing workflows. |
+| `.cursor/skills/manus-official-cdp/SKILL.md` | Logged-in manus.im over Chrome CDP via Default-profile `session_id` (inject / verify / geo `/unavailable`); use before replicate-manus-ui capture. |
 | `.cursor/skills/replicate-manus-ui/SKILL.md` | Align frontend UI with manus.im (mine official JS/DOM; Computer / sidebar / Library / Project / Search / chat chrome parity). |
 | `.cursor/skills/update-docs/SKILL.md` | Sync compose/env embeds + README demos via `.cursor/skills/update-docs/update_doc.sh` (not docs/demo.md scenarios). |
 | `.cursor/skills/demo-videos/SKILL.md` | Recording/uploading README demo MP4s (`tmp/videos` + `gh image` + `docs/demos.yml`; never commit binaries; publish only after user confirmation). |


### PR DESCRIPTION
## Summary
- Add `.cursor/skills/manus-official-cdp` for getting a logged-in manus.im session over Chrome CDP (`session_id` via env / auto-fetch / manual paste).
- Ship `fetch-session.cjs` + `resolve-session.cjs` helpers (CDP cookies → Chrome DB → `/tmp` file / env).
- Cross-link from `replicate-manus-ui` capture steps and register the skill in `AGENTS.md`.

## Test plan
- [ ] `node .cursor/skills/manus-official-cdp/scripts/fetch-session.cjs` with CDP Chrome on `:9222` (or logged-in Default Chrome) returns `ok: true` metadata only
- [ ] `eval "$(node …/fetch-session.cjs --export)"` then `resolve-session.cjs` finds `MANUS_SESSION_TOKEN`
- [ ] Confirm no JWT / cookie values are committed in the PR diff


Made with [Cursor](https://cursor.com)