### PR TITLE
docs: cross-link manus-official-cdp in agent guides

### DIFF
--- a/.cursor/skills/manus-official-cdp/SKILL.md
+++ b/.cursor/skills/manus-official-cdp/SKILL.md
@@ -15,6 +15,28 @@ Get a **logged-in** manus.im tab over Chrome DevTools Protocol using `session_id
 
 Pairs with **replicate-manus-ui** (DOM / className mining). Respond in **中文** unless the user writes in English.
 
+## Quick start (humans)
+
+本机已登录 manus.im 时，优先自动拉取（**不要**把 JWT 提交进 git）：
+
+```bash
+# 1) 可选：起带调试口的 Chrome，或复用已有 :9222
+# 2) 拉取 session_id → /tmp/manus_session_id.value（只打印元数据）
+node .cursor/skills/manus-official-cdp/scripts/fetch-session.cjs
+
+# 3) 写入当前 shell 环境变量
+eval "$(node .cursor/skills/manus-official-cdp/scripts/fetch-session.cjs --export)"
+
+# 4) 告诉 agent「已 export MANUS_SESSION_TOKEN」或直接让 agent 跑上面的脚本
+```
+
+手动交付：DevTools → Application → Cookies → `session_id`，然后任选：
+
+- `export MANUS_SESSION_TOKEN='eyJ…'`
+- 或聊天里只贴 JWT / JSON（见下方「How to give」）
+
+索引与环境变量表也写在 [AGENTS.md § Skills](../../../AGENTS.md#skills) / [CLAUDE.md](../../../CLAUDE.md) Frontend notes。
+
 ## Hard rules
 
 1. **Only `session_id` is required** for auth (domain `.manus.im`). Skip analytics (`_gcl_au`, `__stripe_*`, Intercom, `_fbp`, `_ga`, theme, ad-consent).

--- a/.cursor/skills/starter.md
+++ b/.cursor/skills/starter.md
@@ -213,7 +213,27 @@ Upload and download files.
 
 ---
 
-## 6 · Updating This Skill
+## 6 · Related project skills
+
+Full index: [AGENTS.md](../../AGENTS.md#skills).
+
+| Skill | When |
+|---|---|
+| `.cursor/skills/manus-official-cdp/SKILL.md` | Need a **logged-in** manus.im tab over CDP before mining official UI (`fetch-session.cjs` / `MANUS_SESSION_TOKEN`). Agent-local — never commit JWTs; not a product `.env` knob. |
+| `.cursor/skills/replicate-manus-ui/SKILL.md` | Align local Vue with manus.im by mining JS/DOM and pasting classNames (直接抄). |
+| `.cursor/skills/debug-claw/SKILL.md` | Claw / OpenClaw chat, history, uploads, containers. |
+| `.cursor/skills/update-docs/SKILL.md` | Sync compose/env embeds + README demos. |
+| `.cursor/skills/demo-videos/SKILL.md` | Record / upload README demo MP4s. |
+| `.cursor/skills/release/SKILL.md` | Cut `vX.Y.Z` GitHub releases. |
+
+Quick CDP session check:
+
+```bash
+node .cursor/skills/manus-official-cdp/scripts/fetch-session.cjs
+# expect {"ok":true,"source":"cdp:…"|…,"valueLen":…} — no full JWT in output
+```
+
+## 7 · Updating This Skill
 
 When you discover a new testing trick, environment workaround, or operational runbook step:
 
@@ -227,3 +247,5 @@ Examples of things worth adding:
 - A new pytest marker was introduced → add it to the backend testing section.
 - A new env var controls behavior → add it to the `.env` knobs table.
 - A workaround for a flaky test or Docker issue → add a troubleshooting subsection.
+
+<!-- Added 2026-09-09: related skills + manus-official-cdp pointer -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -249,10 +249,32 @@ The dev compose starts the backend with **debugpy** on port `5678`. Attach a rem
 | Skill File | When to Use |
 |---|---|
 | `.cursor/skills/starter.md` | Setting up, running, or testing any part of the codebase. Contains detailed API reference, env var tables, and testing workflows. |
-| `.cursor/skills/manus-official-cdp/SKILL.md` | Logged-in manus.im over Chrome CDP via Default-profile `session_id` (inject / verify / geo `/unavailable`); use before replicate-manus-ui capture. |
+| `.cursor/skills/manus-official-cdp/SKILL.md` | Logged-in manus.im over Chrome CDP: auto `fetch-session.cjs` / `MANUS_SESSION_TOKEN` / `MANUS_COOKIE`, inject `session_id`, API verify; geo `/unavailable` ≠ auth failure. Use **before** replicate-manus-ui capture. Never commit JWTs. |
 | `.cursor/skills/replicate-manus-ui/SKILL.md` | Align frontend UI with manus.im (mine official JS/DOM; Computer / sidebar / Library / Project / Search / chat chrome parity). |
 | `.cursor/skills/update-docs/SKILL.md` | Sync compose/env embeds + README demos via `.cursor/skills/update-docs/update_doc.sh` (not docs/demo.md scenarios). |
 | `.cursor/skills/demo-videos/SKILL.md` | Recording/uploading README demo MP4s (`tmp/videos` + `gh image` + `docs/demos.yml`; never commit binaries; publish only after user confirmation). |
 | `.cursor/skills/release/SKILL.md` | Cutting `vX.Y.Z` GitHub releases (bilingual notes like v2.4.0/v2.5.0; no demo-videos-* releases). |
+| `.cursor/skills/debug-claw/SKILL.md` | Debugging OpenClaw / Claw chat, history, uploads, WebSocket, containers. |
 
-Personal (not in repo): `~/.cursor/skills/telegram-screenshots/SKILL.md` — UI screenshots → Telegram Bot MCP.
+Personal (not in repo): `~/.cursor/skills/telegram-screenshots/SKILL.md` — UI screenshots → Telegram Bot MCP, not OpenClaw.
+
+### Official manus.im capture (agents)
+
+Agent-local only — **not** product `.env` / `.env.example`:
+
+| Var / file | Purpose |
+|---|---|
+| `MANUS_SESSION_TOKEN` | Raw `session_id` JWT |
+| `MANUS_COOKIE` | `session_id=…` or full Cookie header |
+| `MANUS_SESSION_FILE` | Path to JWT file (default `/tmp/manus_session_id.value`) |
+| `MANUS_CDP_URL` | CDP endpoint (default `http://127.0.0.1:9222`) |
+
+```bash
+# Auto-fetch from CDP Chrome or Default profile Cookies (prints metadata only)
+node .cursor/skills/manus-official-cdp/scripts/fetch-session.cjs
+eval "$(node .cursor/skills/manus-official-cdp/scripts/fetch-session.cjs --export)"
+
+# Then mine UI with replicate-manus-ui (logged-in /app required)
+```
+
+Details (how humans export a cookie for the agent, geo `/unavailable`, security): `.cursor/skills/manus-official-cdp/SKILL.md`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,6 +90,7 @@ Each toolkit in `domain/services/tools/` (shell, browser, file, search, message,
 - Vue 3 Composition API, `<script setup lang="ts">` throughout; path alias `@/` → `src/`.
 - API layer in `src/api/` (axios + WebSocket clients for session list / chat); pages in `src/pages/`; reusable logic in `src/composables/`; rich tool renderers in `src/components/toolViews/`.
 - i18n via vue-i18n (Chinese + English) in `src/locales/`. Add keys to both locales.
+- **Official manus.im UI parity:** get a logged-in CDP session via `.cursor/skills/manus-official-cdp/SKILL.md` (`fetch-session.cjs` / `MANUS_SESSION_TOKEN`), then mine and paste with `.cursor/skills/replicate-manus-ui/SKILL.md`. Do not approximate from screenshots alone.
 
 ## Conventions & gotchas
 
@@ -99,3 +100,4 @@ Each toolkit in `domain/services/tools/` (shell, browser, file, search, message,
 - Config is centralized in `backend/app/core/config.py` (Pydantic `Settings`, `@lru_cache`d `get_settings()`); env vars come from `.env`. For dev, point `API_BASE` at `http://mockserver:8090/v1` and set `AUTH_PROVIDER=none` to skip both real LLM and login.
 - CI (`.github/workflows/docker-build-and-push.yml`) only builds/pushes multi-arch Docker images — it runs **no tests or lint**. Verify changes locally.
 - Docs site is Docsify under `docs/`; `.cursor/skills/update-docs/update_doc.sh` syncs compose/env embeds and README demos (not `docs/demo.md` scenario pages). See `.cursor/skills/update-docs/SKILL.md`. Version releases: `.cursor/skills/release/SKILL.md`.
+- **Cursor agent skills** live under `.cursor/skills/` — full index in [AGENTS.md](AGENTS.md#skills). `MANUS_SESSION_TOKEN` / `MANUS_COOKIE` are **agent-local** for official-site CDP mining; they are **not** product `.env` knobs and must never be committed.


### PR DESCRIPTION
## Summary
- Document **manus-official-cdp** in `CLAUDE.md` (frontend parity) and enrich `AGENTS.md` Skills (env table + `fetch-session.cjs` quick commands; restore `debug-claw` row).
- Add related-skills section to `.cursor/skills/starter.md`.
- Add human **Quick start** to `.cursor/skills/manus-official-cdp/SKILL.md`.

Clarifies that `MANUS_SESSION_TOKEN` / `MANUS_COOKIE` are **agent-local**, not product `.env`.

## Test plan
- [ ] Skim `AGENTS.md` § Skills + Official manus.im capture
- [ ] Confirm `CLAUDE.md` Frontend notes link the two skills
- [ ] `node .cursor/skills/manus-official-cdp/scripts/fetch-session.cjs` still runs (unchanged scripts)


Made with [Cursor](https://cursor.com)