### PR TITLE
docs: add Skills product guide (zh/en)

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ https://github.com/user-attachments/assets/89e0da0f-789f-464f-8648-49eb5035fe2f
  * Deployment: Minimal deployment requires only an LLM service, with no dependency on other external services.
  * Agent loop: Plan-and-execute flow with composable system prompts and native structured output tools (no fragile JSON-in-prompt protocol).
  * Tools: Supports Terminal, Browser, File, Web Search, and messaging tools with real-time viewing and takeover capabilities, supports external MCP tool integration.
+ * Skills: Reusable skill packages (official catalog / upload / GitHub), invoked with `/` in chat; Agent loads via `load_skill` and syncs into the sandbox. See [docs/en/skills.md](docs/en/skills.md).
  * Sandbox: Each task is allocated a separate sandbox that runs in a local Docker environment.
  * Task Sessions: Session history is managed through MongoDB/Redis, supporting background tasks.
  * Library: The sidebar Library aggregates attachments and artifacts across your sessions, with type filters, search, per-file favorites, preview, and jump-back to the source task.

--- a/README_zh.md
+++ b/README_zh.md
@@ -43,6 +43,7 @@ https://github.com/user-attachments/assets/fa45bcac-92c7-41ce-b8f6-7d9d99747f92
  * 部署：最小只需要一个 LLM 服务即可完成部署，不需要依赖其它外部服务。
  * Agent 循环：Plan-and-Execute，可组合 System Prompt，以及原生结构化输出工具（不再使用脆弱的 Prompt 内嵌 JSON 协议）。
  * 工具：支持 Terminal、Browser、File、Web Search、消息工具，并支持实时查看和接管，支持外部 MCP 工具集成。
+ * Skills：可复用技能包（官方目录 / 上传 / GitHub），对话中用 `/` 调用；Agent 经 `load_skill` 渐进加载并同步到沙盒。详见 [docs/skills.md](docs/skills.md)。
  * 沙盒：每个 Task 会分配单独的一个沙盒，沙盒在本地 Docker 环境里面运行。
  * 任务会话：通过 Mongo/Redis 对会话历史进行管理，支持后台任务。
  * 库：侧栏「库」聚合各会话产生的附件与产物，支持类型筛选、搜索、文件收藏与预览，并可定位回原任务。

--- a/docs/README.md
+++ b/docs/README.md
@@ -25,6 +25,7 @@ AI Manus 中每个服务与工具都包含一个 Built-in 版本，可以做到�
  * **部署：**最小只需要一个 LLM 服务即可完成部署，不需要依赖其它外部服务。
  * **Agent 循环：**Plan-and-Execute，可组合 System Prompt，原生结构化输出工具（`create_plan` / `complete_step` 等）。
  * **工具：**支持 Terminal、Browser、File、Web Search、消息工具，并支持实时查看和接管，支持外部 MCP 工具集成。
+ * **Skills：**可复用技能包（官方目录 / 上传 / GitHub 导入），对话中用 `/` 调用；Agent 经 `load_skill` 渐进加载并同步到沙盒。详见 [Skills 技能](skills.md)。
  * **沙盒：**每个 Task 会分配单独的一个沙盒，沙盒在本地 Docker 环境里面运行。
  * **任务会话：**通过 Mongo/Redis 对会话历史进行管理，支持后台任务。
  * **库：**侧栏「库」页面聚合用户各会话中的附件与产物，支持类型筛选、搜索、文件级收藏与预览，并可跳转回原任务。

--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -4,6 +4,7 @@
  * [📅 开发计划](roadmap.md)
  * 🛠️ 功能使用
    * [✨ 场景演示](demo.md)
+   * [🧩 Skills 技能](skills.md)
    * [🔧 MCP 配置](mcp.md)
  * [📋 配置说明](configuration.md)
  * 👨‍💻 开发指南

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -9,7 +9,7 @@
 1. Web 向 Server 发送创建 Agent 请求，Server 通过`/var/run/docker.sock`创建出 Sandbox，并返回会话 ID。
 2. Sandbox 是一个 Ubuntu Docker 环境，里面会启动 chrome 浏览器及 File/Shell 等工具的 API 服务。
 3. Web 往会话 ID 中发送用户消息，Server 收到用户消息后，将消息发送给 PlanAct Agent 处理。
-4. PlanAct Agent 进行规划与执行：规划器/执行器通过原生工具调用提交结构化结果（如 `create_plan` / `complete_step`），并按需调用沙盒工具（Shell / Browser / File / Search / MCP）。
+4. PlanAct Agent 进行规划与执行：规划器/执行器通过原生工具调用提交结构化结果（如 `create_plan` / `complete_step`），并按需调用沙盒工具（Shell / Browser / File / Search / MCP）与技能工具（`load_skill`）。
 5. Agent 处理过程中产生的所有事件经 Redis 队列，通过 WebSocket（`/api/v1/ws/chat`，`join_session` / `leave_session`）推回 Web；会话列表增量通过 `/api/v1/ws/sessions` 推送。
 
 **当用户浏览工具时：**
@@ -18,6 +18,18 @@
     1. Sandbox 的无头浏览器通过 xvfb 与 x11vnc 启动了 vnc 服务，并且通过 websockify 将 vnc 转化成 websocket。
     2. Web 的 NoVNC 组件通过 Server 的 `/api/v1/ws/vnc/{session_id}`（Cookie / Bearer）转发到 Sandbox，实现浏览器查看。
 - 其它工具：其它工具原理也是差不多。
+
+## Skills（技能）
+
+Skills 是可复用的工作流说明包（`SKILL.md` + 可选资源），用户在设置中添加/启用，在对话里用 `/` 或 chip 调用。
+
+**运行时分层（Agent 模式）：**
+
+1. **L1：**启用技能的 name/description 写入系统提示（及 `load_skill` 工具说明）。
+2. **L2：**用户显式调用后，模型应先调用 `load_skill` 获取完整 `SKILL.md`。
+3. **L3：**启用中的技能包同步到沙盒 `/home/ubuntu/skills/{name}/`。
+
+用户操作、导入格式与 HTTP API 见 [Skills 技能](skills.md)。
 
 ## 库（Library）
 

--- a/docs/en/README.md
+++ b/docs/en/README.md
@@ -25,6 +25,7 @@ Each service and tool in AI Manus includes a Built-in version that can be fully 
  * **Deployment:** Only requires one LLM service for deployment, no dependency on other external services.
  * **Agent loop:** Plan-and-execute with composable system prompts and native structured output tools (`create_plan` / `complete_step`, etc.).
  * **Tools:** Supports Terminal, Browser, File, Web Search, message tools, with real-time viewing and takeover capabilities, and supports external MCP tool integration.
+ * **Skills:** Reusable skill packages (official catalog / upload / GitHub import), invoked with `/` in chat; Agent loads via `load_skill` and syncs files into the sandbox. See [Skills](skills.md).
  * **Sandbox:** Each Task is allocated a separate sandbox that runs in a local Docker environment.
  * **Task Sessions:** Manages session history through Mongo/Redis, supports background tasks.
  * **Library:** The sidebar Library page aggregates attachments and artifacts across the user's sessions, with type filters, search, per-file favorites, preview, and navigation back to the source task.

--- a/docs/en/_sidebar.md
+++ b/docs/en/_sidebar.md
@@ -3,6 +3,7 @@
  * [📅 Development Roadmap](/en/roadmap.md)
  * 🛠️ Features
    * [✨ Demo Scenarios](/en/demo.md)
+   * [🧩 Skills](/en/skills.md)
    * [🔧 MCP Configuration](/en/mcp.md)
  * [📋 Configuration Guide](/en/configuration.md)
  * 👨‍💻 Development Guide

--- a/docs/en/architecture.md
+++ b/docs/en/architecture.md
@@ -9,7 +9,7 @@
 1. Web sends a create Agent request to Server, Server creates Sandbox through `/var/run/docker.sock` and returns session ID.
 2. Sandbox is an Ubuntu Docker environment that starts Chrome browser and API services for File/Shell and other tools.
 3. Web sends user messages to the session ID, Server receives user messages and forwards them to PlanAct Agent for processing.
-4. PlanAct Agent plans and executes steps: the planner/executor submit structured results through native tool calls (e.g. `create_plan` / `complete_step`), and invoke sandbox tools (Shell / Browser / File / Search / MCP) as needed.
+4. PlanAct Agent plans and executes steps: the planner/executor submit structured results through native tool calls (e.g. `create_plan` / `complete_step`), and invoke sandbox tools (Shell / Browser / File / Search / MCP) and skill tools (`load_skill`) as needed.
 5. All events generated during Agent processing flow through Redis queues and are pushed back to the Web over WebSocket (`/api/v1/ws/chat` with `join_session` / `leave_session`); session-list updates use `/api/v1/ws/sessions`.
 
 **When users browse tools:**
@@ -18,6 +18,18 @@
     1. The headless browser in Sandbox starts VNC service through xvfb and x11vnc, and converts VNC to WebSocket through websockify.
     2. Web's NoVNC component connects via Server `/api/v1/ws/vnc/{session_id}` (Cookie / Bearer) and forwards to the Sandbox, enabling browser viewing.
 - Other tools: Other tools work on similar principles.
+
+## Skills
+
+Skills are reusable workflow packages (`SKILL.md` plus optional assets). Users add/enable them in Settings and invoke them in chat with `/` or skill chips.
+
+**Runtime layers (Agent mode):**
+
+1. **L1:** Enabled skill names/descriptions go into the system prompt (and the `load_skill` tool description).
+2. **L2:** After an explicit invocation, the model should call `load_skill` for the full `SKILL.md`.
+3. **L3:** Enabled packages sync into the sandbox at `/home/ubuntu/skills/{name}/`.
+
+User flows, package format, and HTTP APIs: [Skills](skills.md).
 
 ## Library
 

--- a/docs/en/skills.md
+++ b/docs/en/skills.md
@@ -1,0 +1,112 @@
+# Skills
+
+## Introduction
+
+Skills are reusable workflow packages: each skill has a name, a description, and a full `SKILL.md` instruction body (optionally with scripts and asset files). The format follows [Agent Skills](https://agentskills.io/what-are-skills).
+
+In AI Manus you can:
+
+- Add skills from the **official catalog**, upload a ZIP, or import a **public GitHub** repo
+- Insert a skill chip with **`/`** in the composer, or send text starting with `/{name}`
+- Let the Agent call **`load_skill`** for the full instructions and sync skill files into the sandbox
+
+> Skills are not the same as [MCP](mcp.md): MCP connects external tool servers; Skills are specialized workflow instructions for the model (and optional sandbox files).
+
+## How to use
+
+### 1. Manage skills in Settings
+
+Open **Settings → Skills**:
+
+| Action | Description |
+|--------|-------------|
+| **Added list** | Search and browse; toggle **enable / disable** (disable ≠ unsubscribe) |
+| **Browse Skills** | Add unsubscribed skills from Official / Personal catalogs |
+| **Create ▾** | Add from official library, upload a package, import from GitHub, or “Create with Manus” (jump to chat) |
+
+On first load, a default set is auto-subscribed and enabled (e.g. `skill-creator`, `web-research`, `summarize`, `slides`). Official entries such as `market-research` must be added manually.
+
+### 2. Add custom skills
+
+**Upload**
+
+- Supports `.zip` / `.skill` packages (the backend can also wrap a parseable bare `SKILL.md`)
+- Package must include a parseable `SKILL.md` (YAML frontmatter: `name`, `description` + Markdown body)
+- `name` must match lowercase alphanumerics with `-` segments (e.g. `my-skill`)
+- Max package size: **20MB**
+
+**Import from GitHub**
+
+- Public repos only: `https://github.com/{owner}/{repo}`
+- Fetches the default-branch zipball (`main`, then `master`)
+- `SKILL.md` must live at the repo root or under a single top-level folder
+
+Successful upload/import auto-adds the skill as enabled.
+
+### 3. Invoke in chat
+
+1. Type **`/`** in the composer and pick an **enabled** skill (inserts a skill chip)
+2. Or send: `/skill-name` followed by your task text
+3. On send, the client may attach `required_skills`; the backend also parses leading `/{name}` in the message text
+
+References to missing or disabled skills are **silently ignored** (treated as normal text).
+
+**Agent mode (full capability)**
+
+- System prompt lists skill names/descriptions only (L1)
+- On explicit invocation, the model should call the **`load_skill`** tool for the full `SKILL.md` (L2)
+- Enabled packages sync into the sandbox at `/home/ubuntu/skills/{name}/` (L3)
+
+**Chat / Lite mode**
+
+- No sandbox sync and no `load_skill`; skill support is weaker than Agent mode
+
+## Bundled official skills
+
+Shipped under `backend/app/application/data/official_skills/`:
+
+| name | Summary |
+|------|---------|
+| `skill-creator` | Help create reusable skills |
+| `web-research` | Web research workflows |
+| `summarize` | Long-document summarization |
+| `slides` | Presentation / slides |
+| `market-research` | Market research (not auto-added; browse to add) |
+
+## HTTP API
+
+Prefix: `/api/v1` (authenticated).
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/skills` | Catalog + added list (with `enabled`) |
+| `POST` | `/skills/added` | body `{ "skill_ids": [...] }` add / re-enable |
+| `PATCH` | `/skills/added/{skill_id}` | body `{ "enabled": true/false }` |
+| `POST` | `/skills/import/github` | body `{ "url": "https://github.com/owner/repo" }` |
+| `POST` | `/skills/import/upload` | multipart field `file` |
+
+Invocation goes through WebSocket `/api/v1/ws/chat` (optional `required_skills`). There is no dedicated “run skill” REST endpoint.
+
+There is currently **no** API to fully remove a subscription—only disable.
+
+## Configuration
+
+Skills have **no** dedicated environment variables; nothing to toggle in `.env`. Package size limits and sandbox paths are code constants.
+
+Developer entry points:
+
+- Backend: `backend/app/application/services/skill_service.py`, `skill_runtime_service.py`
+- Official packages: `backend/app/application/data/official_skills/`
+- Frontend: Settings Skills tab, composer `/` slash menu and skill chips
+
+## Notes
+
+- The **Team** skills tab is an empty placeholder for now.
+- GitHub import is public `owner/repo` only; private repos, non-`main`/`master` defaults, or nested package layouts may fail.
+- Do not expect sandbox scripts or full `load_skill` behavior in Chat mode.
+- Non-UTF-8 files inside a package may be skipped during sandbox sync.
+
+## Further reading
+
+- [Agent Skills specification](https://agentskills.io/what-are-skills)
+- [MCP configuration](mcp.md) (external tools)

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -1,0 +1,112 @@
+# Skills 技能
+
+## 简介
+
+Skills（技能）是可复用的工作流说明包：每个技能包含名称、描述，以及一份完整的 `SKILL.md` 指令（可附带脚本与资源文件）。格式对齐 [Agent Skills](https://agentskills.io/what-are-skills)。
+
+在 AI Manus 中，你可以：
+
+- 从**官方目录**添加技能，或上传 ZIP / 从 **GitHub 公库**导入
+- 在对话输入框用 **`/`** 插入技能 chip，或发送以 `/{name}` 开头的文本
+- 让 Agent 按需 **`load_skill`** 加载完整说明，并把技能文件同步进沙盒
+
+> Skills 与 [MCP](mcp.md) 不同：MCP 接入外部工具服务；Skills 是给模型看的专项工作流说明（并可附带沙盒内文件）。
+
+## 使用方式
+
+### 1. 在设置中管理技能
+
+打开 **设置 → 技能**：
+
+| 操作 | 说明 |
+|------|------|
+| **已添加列表** | 搜索、查看；用开关 **启用 / 停用**（停用不等于删除订阅） |
+| **浏览技能** | 从官方 / 个人目录添加未订阅的技能 |
+| **创建 ▾** | 从官方库添加、上传包、GitHub 导入，或「与 Manus 一起创建」跳转聊天 |
+
+首次进入时会自动订阅并启用一批默认技能（如 `skill-creator`、`web-research`、`summarize`、`slides` 等）。官方目录中的 `market-research` 等需手动添加。
+
+### 2. 添加自定义技能
+
+**上传**
+
+- 支持 `.zip` / `.skill` 包（后端也可接受可解析的 `SKILL.md` 并打包）
+- 包内需含可解析的 `SKILL.md`（YAML frontmatter：`name`、`description` + Markdown 正文）
+- `name` 需匹配：`小写字母/数字`，段之间用 `-`（如 `my-skill`）
+- 包大小上限：**20MB**
+
+**从 GitHub 导入**
+
+- 仅支持公开仓库：`https://github.com/{owner}/{repo}`
+- 拉取默认分支 zipball（先 `main`，再试 `master`）
+- 仓库根目录（或单一顶层文件夹）需包含 `SKILL.md`
+
+导入或上传成功后会自动加入「已添加」并启用。
+
+### 3. 在对话中调用
+
+1. 在输入框输入 **`/`**，从菜单选择已**启用**的技能（插入技能 chip）
+2. 或直接发送：`/skill-name 后面跟你的任务说明`
+3. 发送后，前端会带上 `required_skills`；后端也会解析文本里的 `/{name}`
+
+未添加或已停用的技能引用会被**静默忽略**（当作普通消息处理）。
+
+**Agent 模式（完整能力）**
+
+- 系统提示中只放技能名与描述（L1）
+- 用户显式调用时，要求模型先调用工具 **`load_skill`** 拉取完整 `SKILL.md`（L2）
+- 启用中的技能包会同步到沙盒：`/home/ubuntu/skills/{name}/`（L3）
+
+**Chat / Lite 模式**
+
+- 不会同步沙盒文件，也没有 `load_skill`；技能能力弱于 Agent 模式
+
+## 官方捆绑技能
+
+仓库内置官方包（目录 `backend/app/application/data/official_skills/`）：
+
+| name | 说明（概要） |
+|------|----------------|
+| `skill-creator` | 协助创建可复用技能 |
+| `web-research` | 网络调研类任务 |
+| `summarize` | 长文摘要 |
+| `slides` | 演示文稿 / 幻灯片 |
+| `market-research` | 市场调研（默认未自动添加，需在浏览中添加） |
+
+## HTTP API
+
+前缀：`/api/v1`（需登录）。
+
+| 方法 | 路径 | 说明 |
+|------|------|------|
+| `GET` | `/skills` | 返回目录 catalog + 已添加列表（含 enabled） |
+| `POST` | `/skills/added` | body `{ "skill_ids": [...] }` 添加 / 重新启用 |
+| `PATCH` | `/skills/added/{skill_id}` | body `{ "enabled": true/false }` |
+| `POST` | `/skills/import/github` | body `{ "url": "https://github.com/owner/repo" }` |
+| `POST` | `/skills/import/upload` | multipart 字段 `file` |
+
+聊天调用走 WebSocket `/api/v1/ws/chat`（可带 `required_skills`），没有单独的「执行技能」REST 接口。
+
+当前**没有**从已添加列表中彻底删除订阅的 API；只能停用。
+
+## 配置说明
+
+Skills **没有**专用环境变量；不依赖 `.env` 开关。包大小、沙盒路径等为代码内约定。
+
+相关实现入口（开发者）：
+
+- 后端服务：`backend/app/application/services/skill_service.py`、`skill_runtime_service.py`
+- 官方包：`backend/app/application/data/official_skills/`
+- 前端：设置页 Skills、输入框 `/` slash 与 skill chip
+
+## 注意事项
+
+- **Team** 技能页签目前为空占位，无团队技能。
+- GitHub 仅公库、简单 `owner/repo` URL；私库、非 `main`/`master` 默认分支、子目录包可能失败。
+- Chat 模式不要期望沙盒脚本与完整 `load_skill` 行为。
+- 技能包内非 UTF-8 文件同步到沙盒时可能被跳过。
+
+## 更多资源
+
+- [Agent Skills 规范](https://agentskills.io/what-are-skills)
+- [MCP 配置](mcp.md)（外部工具接入）


### PR DESCRIPTION
## Summary
- Add user-facing **Skills** docs: `docs/skills.md` + `docs/en/skills.md` (settings, `/` invoke, upload/GitHub, L1–L3 runtime, HTTP API, caveats).
- Wire Docsify sidebars and mention Skills in architecture + README feature lists (zh/en).

This documents the **product Skills feature**, not the Cursor `manus-official-cdp` agent skill.

## Test plan
- [ ] Open docs site sidebar → Skills / 技能 pages render
- [ ] Spot-check API paths against `/api/v1/skills*`
- [ ] Confirm README bullets link to the new pages


Made with [Cursor](https://cursor.com)