### PR TITLE
feat: add Serply as a search provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -51,7 +51,7 @@ SANDBOX_NETWORK=manus-network
 #BROWSER_ENGINE=browser_use
 
 # Search engine configuration
-# Options: baidu, baidu_web, google, bing, bing_web, tavily, serper, custom
+# Options: baidu, baidu_web, google, bing, bing_web, tavily, serper, youcom, serply, custom
 # baidu:    uses the Baidu Qianfan AI Search API (requires BAIDU_SEARCH_API_KEY)
 # baidu_web: scrapes Baidu search results with browser impersonation (no API key needed)
 # bing:     uses the official Bing Web Search API (requires BING_SEARCH_API_KEY)
@@ -59,6 +59,7 @@ SANDBOX_NETWORK=manus-network
 # tavily:   uses the Tavily Search API (requires TAVILY_API_KEY)
 # serper:   uses the Serper.dev Google Search API (requires SERPER_API_KEY)
 # youcom:   uses the You.com Web Search API (requires YOUCOM_API_KEY)
+# serply:   uses the Serply Google Search API (requires SERPLY_API_KEY)
 # custom:   calls any third-party search REST API via SEARCH_API_URL + SEARCH_API_KEY
 SEARCH_PROVIDER=bing_web
 
@@ -85,6 +86,10 @@ SEARCH_PROVIDER=bing_web
 # You.com search configuration, only used when SEARCH_PROVIDER=youcom
 # Get your API key from https://you.com
 #YOUCOM_API_KEY=
+
+# Serply search configuration, only used when SEARCH_PROVIDER=serply
+# Returns structured Google results. Get your API key from https://serply.io
+#SERPLY_API_KEY=
 
 # Custom search API configuration, only used when SEARCH_PROVIDER=custom
 # Allows integration with any third-party search REST API.

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -65,7 +65,7 @@ class Settings(BaseSettings):
     browser_engine: str = "browser_use"  # "browser_use" or "playwright"
 
     # Search engine configuration
-    search_provider: str | None = "bing_web"  # "baidu", "baidu_web", "google", "bing", "bing_web", "tavily", "serper", "youcom", "custom"
+    search_provider: str | None = "bing_web"  # "baidu", "baidu_web", "google", "bing", "bing_web", "tavily", "serper", "youcom", "serply", "custom"
     baidu_search_api_key: str | None = None
     bing_search_api_key: str | None = None
     google_search_api_key: str | None = None
@@ -75,6 +75,8 @@ class Settings(BaseSettings):
     serper_api_key: str | None = None
     # You.com search configuration (SEARCH_PROVIDER=youcom)
     youcom_api_key: str | None = None
+    # Serply search configuration (SEARCH_PROVIDER=serply)
+    serply_api_key: str | None = None
     # Custom search API configuration (SEARCH_PROVIDER=custom)
     search_api_url: str | None = None
     search_api_key: str | None = None

--- a/backend/app/infrastructure/external/search/__init__.py
+++ b/backend/app/infrastructure/external/search/__init__.py
@@ -18,6 +18,7 @@ def get_search_engine() -> Optional[SearchEngine]:
     from app.infrastructure.external.search.tavily_search import TavilySearchEngine
     from app.infrastructure.external.search.serper_search import SerperSearchEngine
     from app.infrastructure.external.search.youcom_search import YouComSearchEngine
+    from app.infrastructure.external.search.serply_search import SerplySearchEngine
     from app.infrastructure.external.search.custom_search import CustomSearchEngine
 
     settings = get_settings()
@@ -66,6 +67,12 @@ def get_search_engine() -> Optional[SearchEngine]:
             return YouComSearchEngine(api_key=settings.youcom_api_key)
         else:
             logger.warning("You.com Search Engine not initialized: missing API key (YOUCOM_API_KEY)")
+    elif settings.search_provider == "serply":
+        if settings.serply_api_key:
+            logger.info("Initializing Serply Search Engine")
+            return SerplySearchEngine(api_key=settings.serply_api_key)
+        else:
+            logger.warning("Serply Search Engine not initialized: missing API key (SERPLY_API_KEY)")
     elif settings.search_provider == "custom":
         if settings.search_api_url:
             logger.info(f"Initializing Custom Search Engine (url={settings.search_api_url})")

--- a/backend/app/infrastructure/external/search/serply_search.py
+++ b/backend/app/infrastructure/external/search/serply_search.py
@@ -1,0 +1,128 @@
+from typing import Optional
+import logging
+
+import httpx
+
+from app.domain.external.search import SearchEngine
+from app.domain.models.search import SearchResultItem, SearchResults
+from app.domain.models.tool_result import ToolResult
+
+logger = logging.getLogger(__name__)
+
+# Maps generic date_range values to Google tbs (time-based search) parameters,
+# which Serply passes through to the underlying Google query.
+_DATE_RANGE_MAP = {
+    "past_hour": "qdr:h",
+    "past_day": "qdr:d",
+    "past_week": "qdr:w",
+    "past_month": "qdr:m",
+    "past_year": "qdr:y",
+}
+
+
+class SerplySearchEngine(SearchEngine):
+    """Search engine implementation using the Serply Google Search API.
+
+    Serply (https://serply.io) returns structured Google search results via a
+    simple REST API. Sign up at https://serply.io to get an API key; the API
+    reference is at https://serply.io/docs.
+    """
+
+    def __init__(self, api_key: str):
+        self.api_key = api_key
+        self.base_url = "https://api.serply.io/v1/search"
+
+    async def search(
+        self,
+        query: str,
+        date_range: Optional[str] = None,
+    ) -> ToolResult[SearchResults]:
+        """Search web pages using the Serply Google Search API.
+
+        Args:
+            query: Search query
+            date_range: Optional time range filter (past_hour/past_day/past_week/past_month/past_year/all)
+
+        Returns:
+            Search results
+        """
+        params: dict = {
+            "q": query,
+            "num": 10,
+        }
+
+        if date_range and date_range != "all":
+            tbs = _DATE_RANGE_MAP.get(date_range)
+            if tbs:
+                params["tbs"] = tbs
+
+        headers = {
+            "X-Api-Key": self.api_key,
+            "Accept": "application/json",
+            "User-Agent": "ai-manus (+https://github.com/Simpleyyt/ai-manus)",
+        }
+
+        try:
+            async with httpx.AsyncClient(timeout=30) as client:
+                response = await client.get(
+                    self.base_url,
+                    params=params,
+                    headers=headers,
+                )
+                response.raise_for_status()
+                data = response.json()
+
+            search_results: list[SearchResultItem] = []
+
+            for item in data.get("results", []):
+                title = item.get("title", "")
+                link = item.get("link", "")
+                snippet = item.get("description", "")
+                if title and link:
+                    search_results.append(
+                        SearchResultItem(title=title, link=link, snippet=snippet)
+                    )
+
+            results = SearchResults(
+                query=query,
+                date_range=date_range,
+                total_results=len(search_results),
+                results=search_results,
+            )
+            return ToolResult(success=True, data=results)
+
+        except Exception as e:
+            logger.error(f"Serply Search failed: {e}")
+            error_results = SearchResults(
+                query=query,
+                date_range=date_range,
+                total_results=0,
+                results=[],
+            )
+            return ToolResult(
+                success=False,
+                message=f"Serply Search failed: {e}",
+                data=error_results,
+            )
+
+
+if __name__ == "__main__":
+    import asyncio
+    import os
+
+    async def test():
+        key = os.environ.get("SERPLY_API_KEY", "")
+        engine = SerplySearchEngine(api_key=key)
+        result = await engine.search("Python programming")
+
+        if result.success:
+            print(f"Found {len(result.data.results)} results")
+            for i, item in enumerate(result.data.results[:5]):
+                print(f"{i + 1}. {item.title}")
+                print(f"   {item.link}")
+                print(f"   {item.snippet[:100]}")
+                print()
+        else:
+            print(f"Search failed: {result.message}")
+
+    asyncio.run(test())

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -145,7 +145,7 @@ API_KEY=sk-...
 
 | 配置项 | 默认值 | 是否必需 | 说明 |
 |--------|--------|----------|------|
-| `SEARCH_PROVIDER` | `bing_web` | 否 | 搜索引擎提供商（`baidu`、`baidu_web`、`google`、`bing`、`bing_web`、`tavily`、`serper`、`youcom` 或 `custom`） |
+| `SEARCH_PROVIDER` | `bing_web` | 否 | 搜索引擎提供商（`baidu`、`baidu_web`、`google`、`bing`、`bing_web`、`tavily`、`serper`、`youcom`、`serply` 或 `custom`） |
 
 #### 百度搜索配置
 
@@ -199,6 +199,14 @@ API_KEY=sk-...
 | 配置项 | 默认值 | 是否必需 | 说明 |
 |--------|--------|----------|------|
 | `YOUCOM_API_KEY` | - | 是 | You.com API 密钥，从 [you.com](https://you.com) 获取 |
+
+#### Serply 搜索配置
+
+仅当 `SEARCH_PROVIDER=serply` 时使用。Serply 通过 REST API 返回结构化的 Google 搜索结果，并支持时间范围过滤：
+
+| 配置项 | 默认值 | 是否必需 | 说明 |
+|--------|--------|----------|------|
+| `SERPLY_API_KEY` | - | 是 | Serply API 密钥，从 [serply.io](https://serply.io) 获取，API 文档见 [serply.io/docs](https://serply.io/docs) |
 
 #### 自定义搜索 API 配置
 

--- a/docs/en/configuration.md
+++ b/docs/en/configuration.md
@@ -145,7 +145,7 @@ API_KEY=sk-...
 
 | Configuration | Default Value | Required | Description |
 |---------------|---------------|----------|-------------|
-| `SEARCH_PROVIDER` | `bing_web` | No | Search engine provider (`baidu`, `baidu_web`, `google`, `bing`, `bing_web`, `tavily`, `serper`, `youcom`, or `custom`) |
+| `SEARCH_PROVIDER` | `bing_web` | No | Search engine provider (`baidu`, `baidu_web`, `google`, `bing`, `bing_web`, `tavily`, `serper`, `youcom`, `serply`, or `custom`) |
 
 #### Baidu Search Configuration
 
@@ -199,6 +199,14 @@ Used only when `SEARCH_PROVIDER=youcom`. You.com provides an AI-first web search
 | Configuration | Default Value | Required | Description |
 |---------------|---------------|----------|-------------|
 | `YOUCOM_API_KEY` | - | Yes | You.com API key, get from [you.com](https://you.com) |
+
+#### Serply Search Configuration
+
+Used only when `SEARCH_PROVIDER=serply`. Serply returns structured Google search results through a REST API and supports the time range filter:
+
+| Configuration | Default Value | Required | Description |
+|---------------|---------------|----------|-------------|
+| `SERPLY_API_KEY` | - | Yes | Serply API key, get from [serply.io](https://serply.io); API reference at [serply.io/docs](https://serply.io/docs) |
 
 #### Custom Search API Configuration
 

--- a/docs/en/quick_start.md
+++ b/docs/en/quick_start.md
@@ -161,7 +161,7 @@ SANDBOX_NETWORK=manus-network
 #BROWSER_ENGINE=browser_use
 
 # Search engine configuration
-# Options: baidu, baidu_web, google, bing, bing_web, tavily, serper, custom
+# Options: baidu, baidu_web, google, bing, bing_web, tavily, serper, youcom, serply, custom
 # baidu:    uses the Baidu Qianfan AI Search API (requires BAIDU_SEARCH_API_KEY)
 # baidu_web: scrapes Baidu search results with browser impersonation (no API key needed)
 # bing:     uses the official Bing Web Search API (requires BING_SEARCH_API_KEY)
@@ -169,6 +169,7 @@ SANDBOX_NETWORK=manus-network
 # tavily:   uses the Tavily Search API (requires TAVILY_API_KEY)
 # serper:   uses the Serper.dev Google Search API (requires SERPER_API_KEY)
 # youcom:   uses the You.com Web Search API (requires YOUCOM_API_KEY)
+# serply:   uses the Serply Google Search API (requires SERPLY_API_KEY)
 # custom:   calls any third-party search REST API via SEARCH_API_URL + SEARCH_API_KEY
 SEARCH_PROVIDER=bing_web
 
@@ -195,6 +196,10 @@ SEARCH_PROVIDER=bing_web
 # You.com search configuration, only used when SEARCH_PROVIDER=youcom
 # Get your API key from https://you.com
 #YOUCOM_API_KEY=
+
+# Serply search configuration, only used when SEARCH_PROVIDER=serply
+# Returns structured Google results. Get your API key from https://serply.io
+#SERPLY_API_KEY=
 
 # Custom search API configuration, only used when SEARCH_PROVIDER=custom
 # Allows integration with any third-party search REST API.

--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -162,7 +162,7 @@ SANDBOX_NETWORK=manus-network
 #BROWSER_ENGINE=browser_use
 
 # Search engine configuration
-# Options: baidu, baidu_web, google, bing, bing_web, tavily, serper, custom
+# Options: baidu, baidu_web, google, bing, bing_web, tavily, serper, youcom, serply, custom
 # baidu:    uses the Baidu Qianfan AI Search API (requires BAIDU_SEARCH_API_KEY)
 # baidu_web: scrapes Baidu search results with browser impersonation (no API key needed)
 # bing:     uses the official Bing Web Search API (requires BING_SEARCH_API_KEY)
@@ -170,6 +170,7 @@ SANDBOX_NETWORK=manus-network
 # tavily:   uses the Tavily Search API (requires TAVILY_API_KEY)
 # serper:   uses the Serper.dev Google Search API (requires SERPER_API_KEY)
 # youcom:   uses the You.com Web Search API (requires YOUCOM_API_KEY)
+# serply:   uses the Serply Google Search API (requires SERPLY_API_KEY)
 # custom:   calls any third-party search REST API via SEARCH_API_URL + SEARCH_API_KEY
 SEARCH_PROVIDER=bing_web
 
@@ -196,6 +197,10 @@ SEARCH_PROVIDER=bing_web
 # You.com search configuration, only used when SEARCH_PROVIDER=youcom
 # Get your API key from https://you.com
 #YOUCOM_API_KEY=
+
+# Serply search configuration, only used when SEARCH_PROVIDER=serply
+# Returns structured Google results. Get your API key from https://serply.io
+#SERPLY_API_KEY=
 
 # Custom search API configuration, only used when SEARCH_PROVIDER=custom
 # Allows integration with any third-party search REST API.


### PR DESCRIPTION
Disclosure: I work with Serply (https://serply.io), the provider added by this PR.

## Summary

Adds [Serply](https://serply.io) as an opt-in search provider, alongside the existing Google/Bing/Baidu/Tavily/Serper/You.com/custom providers. Serply returns structured Google search results through a REST API and supports the time range filter.

- New `SerplySearchEngine` (`backend/app/infrastructure/external/search/serply_search.py`) implementing the existing `SearchEngine` protocol: GET `https://api.serply.io/v1/search` with `X-Api-Key` auth, maps the generic `date_range` values to Google `tbs` parameters (`qdr:h/d/w/m/y`), and parses `results` into `SearchResultItem`. Structure mirrors `serper_search.py` and `youcom_search.py`.
- Wired into `get_search_engine()` and `Settings` as `SEARCH_PROVIDER=serply` + `SERPLY_API_KEY`.
- Docs updated: `configuration.md` and `quick_start.md` (both en/zh) plus `.env.example`. The `# Options:` comment in `.env.example` and both quick start docs was missing `youcom`, so this PR adds `youcom, serply` there.

Opt-in only. The default `SEARCH_PROVIDER` (`bing_web`) is unchanged, and nothing changes for existing configurations.

## Testing

Live against the Serply API with a real key:

```
$ SEARCH_PROVIDER=serply uv run python -c "from app.infrastructure.external.search import get_search_engine; print(type(get_search_engine()).__name__)"
SerplySearchEngine

$ SEARCH_PROVIDER=serply SERPLY_API_KEY= uv run python -c "..."
Serply Search Engine not initialized: missing API key (SERPLY_API_KEY)
None

search("Python programming")               -> success=True, 7 results (python.org, Wikipedia, W3Schools, ...)
search("Python programming", "past_day")   -> success=True, 11 results, all published within the last day
search("x") with an invalid key            -> success=False, message "Serply Search failed: Client error '401 Unauthorized' ..."
```

- `uv run pytest` in `backend/`: 122 passed, 2 skipped, and the same 23 failures / 9 errors as on current `main` (the `test_api_*` and `test_auth_routes` suites need a running server). No new failures.
- No existing behavior modified outside the new provider branch of the factory.
